### PR TITLE
Inject BASE_URL for SafeConfigService

### DIFF
--- a/src/services/safe-config/safe-config.module.ts
+++ b/src/services/safe-config/safe-config.module.ts
@@ -3,7 +3,7 @@ import { Module } from '@nestjs/common';
 import { SafeConfigService } from './safe-config.service';
 
 const BASE_URL_PROVIDER = {
-  provide: 'BASE_URL',
+  provide: 'SAFE_CONFIG_BASE_URL',
   useValue: 'https://safe-config.gnosis.io', // TODO extract to a config file
 };
 

--- a/src/services/safe-config/safe-config.module.ts
+++ b/src/services/safe-config/safe-config.module.ts
@@ -2,9 +2,14 @@ import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { SafeConfigService } from './safe-config.service';
 
+const BASE_URL_PROVIDER = {
+  provide: 'BASE_URL',
+  useValue: 'https://safe-config.gnosis.io', // TODO extract to a config file
+};
+
 @Module({
   imports: [HttpModule],
-  providers: [SafeConfigService],
-  exports: [SafeConfigService],
+  providers: [SafeConfigService, BASE_URL_PROVIDER],
+  exports: [SafeConfigService, BASE_URL_PROVIDER],
 })
 export class SafeConfigModule {}

--- a/src/services/safe-config/safe-config.service.ts
+++ b/src/services/safe-config/safe-config.service.ts
@@ -6,7 +6,7 @@ import { SafeConfigChain } from './entities/chain.entity';
 @Injectable()
 export class SafeConfigService {
   constructor(
-    @Inject('BASE_URL') private readonly baseUrl,
+    @Inject('SAFE_CONFIG_BASE_URL') private readonly baseUrl,
     private readonly httpService: HttpService,
   ) {}
 

--- a/src/services/safe-config/safe-config.service.ts
+++ b/src/services/safe-config/safe-config.service.ts
@@ -1,18 +1,19 @@
 import { HttpService } from '@nestjs/axios';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { SafeConfigPage } from './entities/page.entity';
 import { SafeConfigChain } from './entities/chain.entity';
 
 @Injectable()
 export class SafeConfigService {
-  // TODO: extract base URL to constructor
-  constructor(private readonly httpService: HttpService) {}
+  constructor(
+    @Inject('BASE_URL') private readonly baseUrl,
+    private readonly httpService: HttpService,
+  ) {}
 
   async getChains(): Promise<SafeConfigPage<SafeConfigChain>> {
     try {
-      const response = await this.httpService.axiosRef.get(
-        `https://safe-config.gnosis.io/api/v1/chains`,
-      );
+      const url = this.baseUrl + '/api/v1/chains';
+      const response = await this.httpService.axiosRef.get(url);
       return response.data;
     } catch (error) {
       console.log(error);
@@ -22,9 +23,8 @@ export class SafeConfigService {
 
   async getChain(chainId: string): Promise<SafeConfigChain> {
     try {
-      const response = await this.httpService.axiosRef.get(
-        `https://safe-config.gnosis.io/api/v1/chains/${chainId}`,
-      );
+      const url = this.baseUrl + `/api/v1/chains/${chainId}`;
+      const response = await this.httpService.axiosRef.get(url);
       return response.data;
     } catch (error) {
       console.log(error);


### PR DESCRIPTION
Closes #2 

- Add `BASE_URL_PROVIDER`, a provider that can be injected with `@Inject('SAFE_CONFIG_BASE_URL')` and has the value of the Safe Config service url