### PR TITLE
Run pipeline on any branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
- Runs CI pipeline on any branch
- Previously a Pull Request targeting the `main` branch had to be open for it to run (besides always running on the `main` branch)
- This allows validating the status of the pipeline before opening a Pull Request