### PR TITLE
Add managed API versioning

### DIFF
--- a/src/balances/balances.controller.ts
+++ b/src/balances/balances.controller.ts
@@ -4,11 +4,12 @@ import { BalancesService } from './balances.service';
 
 @Controller({
   path: '',
+  version: '1',
 })
 export class BalancesController {
   constructor(private readonly balancesService: BalancesService) {}
 
-  @Get('v1/chains/:chainId/safes/:safeAddress/balances')
+  @Get('chains/:chainId/safes/:safeAddress/balances')
   async getBalances(
     @Param('chainId') chainId: string,
     @Param('safeAddress') safeAddress: string,

--- a/src/chains/chains.controller.ts
+++ b/src/chains/chains.controller.ts
@@ -1,9 +1,12 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, VERSION_NEUTRAL } from '@nestjs/common';
 import { ChainsService } from './chains.service';
 import { Chain } from './entities/chain.entity';
 import { Page } from './entities/page.entity';
 
-@Controller('chains')
+@Controller({
+  path: 'chains',
+  version: VERSION_NEUTRAL,
+})
 export class ChainsController {
   constructor(private readonly chainsService: ChainsService) {}
 

--- a/src/chains/chains.controller.ts
+++ b/src/chains/chains.controller.ts
@@ -1,11 +1,11 @@
-import { Controller, Get, VERSION_NEUTRAL } from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
 import { ChainsService } from './chains.service';
 import { Chain } from './entities/chain.entity';
 import { Page } from './entities/page.entity';
 
 @Controller({
   path: 'chains',
-  version: VERSION_NEUTRAL,
+  version: '1',
 })
 export class ChainsController {
   constructor(private readonly chainsService: ChainsService) {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,12 @@
+import { VersioningType } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.enableVersioning({
+    type: VersioningType.URI,
+  });
   await app.listen(3000);
 }
 bootstrap();


### PR DESCRIPTION
Closes #4 

This PR implements managed API versioning feature from Nest. Using this feature we could have an explicit and clear route mapping. I used `@Controller` versioning only, but route-level versioning is available as well.