### PR TITLE
Add logger

### DIFF
--- a/src/services/errors/http-error-handler.ts
+++ b/src/services/errors/http-error-handler.ts
@@ -1,4 +1,4 @@
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';
 import axios, { AxiosError } from 'axios';
 import { HttpExceptionPayload } from './interfaces/http-exception-payload.interface';
 
@@ -9,6 +9,8 @@ import { HttpExceptionPayload } from './interfaces/http-exception-payload.interf
  */
 @Injectable()
 export class HttpErrorHandler {
+  private readonly logger = new Logger(HttpErrorHandler.name);
+
   private mapError(err: AxiosError | Error): HttpExceptionPayload {
     if (axios.isAxiosError(err) && err.response) {
       const axiosError = err as AxiosError;
@@ -27,7 +29,8 @@ export class HttpErrorHandler {
   }
 
   handle(err: AxiosError | Error) {
-    const error = this.mapError(err);
-    throw new HttpException(error, error.code);
+    const errPayload = this.mapError(err);
+    this.logger.error(errPayload);
+    throw new HttpException(errPayload, errPayload.code);
   }
 }

--- a/src/services/safe-config/safe-config.module.ts
+++ b/src/services/safe-config/safe-config.module.ts
@@ -1,5 +1,6 @@
 import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
+import { HttpErrorHandler } from '../errors/http-error-handler';
 import { SafeConfigService } from './safe-config.service';
 
 const BASE_URL_PROVIDER = {
@@ -9,7 +10,7 @@ const BASE_URL_PROVIDER = {
 
 @Module({
   imports: [HttpModule],
-  providers: [SafeConfigService, BASE_URL_PROVIDER],
+  providers: [SafeConfigService, BASE_URL_PROVIDER, HttpErrorHandler],
   exports: [SafeConfigService, BASE_URL_PROVIDER],
 })
 export class SafeConfigModule {}

--- a/src/services/safe-config/safe-config.service.ts
+++ b/src/services/safe-config/safe-config.service.ts
@@ -2,12 +2,14 @@ import { HttpService } from '@nestjs/axios';
 import { Inject, Injectable } from '@nestjs/common';
 import { SafeConfigPage } from './entities/page.entity';
 import { SafeConfigChain } from './entities/chain.entity';
+import { HttpErrorHandler } from '../errors/http-error-handler';
 
 @Injectable()
 export class SafeConfigService {
   constructor(
     @Inject('SAFE_CONFIG_BASE_URL') private readonly baseUrl,
     private readonly httpService: HttpService,
+    private readonly httpErrorHandler: HttpErrorHandler,
   ) {}
 
   async getChains(): Promise<SafeConfigPage<SafeConfigChain>> {
@@ -15,9 +17,8 @@ export class SafeConfigService {
       const url = this.baseUrl + '/api/v1/chains';
       const response = await this.httpService.axiosRef.get(url);
       return response.data;
-    } catch (error) {
-      console.log(error);
-      throw error;
+    } catch (err) {
+      this.httpErrorHandler.handle(err);
     }
   }
 
@@ -26,9 +27,8 @@ export class SafeConfigService {
       const url = this.baseUrl + `/api/v1/chains/${chainId}`;
       const response = await this.httpService.axiosRef.get(url);
       return response.data;
-    } catch (error) {
-      console.log(error);
-      throw error;
+    } catch (err) {
+      this.httpErrorHandler.handle(err);
     }
   }
 }

--- a/src/services/safe-transaction/safe-transaction.manager.ts
+++ b/src/services/safe-transaction/safe-transaction.manager.ts
@@ -1,5 +1,5 @@
 import { HttpService } from '@nestjs/axios';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { HttpErrorHandler } from '../errors/http-error-handler';
 import { SafeConfigChain } from '../safe-config/entities/chain.entity';
 import { SafeConfigService } from '../safe-config/safe-config.service';
@@ -7,6 +7,7 @@ import { SafeTransactionService } from './safe-transaction.service';
 
 @Injectable()
 export class SafeTransactionManager {
+  private readonly logger = new Logger(SafeTransactionService.name);
   private transactionServiceMap: Record<string, SafeTransactionService> = {};
 
   constructor(
@@ -18,11 +19,11 @@ export class SafeTransactionManager {
   async getTransactionService(
     chainId: string,
   ): Promise<SafeTransactionService> {
-    console.log(`Getting TransactionService instance for chain ${chainId}`);
+    this.logger.log(`Getting TransactionService instance for chain ${chainId}`);
     const transactionService = this.transactionServiceMap[chainId];
     if (transactionService !== undefined) return transactionService;
 
-    console.log(
+    this.logger.log(
       `Transaction Service for chain ${chainId} not available. Getting from the SafeConfigService`,
     );
     const chain: SafeConfigChain = await this.safeConfigService.getChain(


### PR DESCRIPTION
This PR changes the usage on `console.log` to the Nest.js default logging feature.

I did a brief research of the options we have, and both [Winston](https://github.com/gremo/nest-winston) and [Pino](https://www.npmjs.com/package/nestjs-pino) Nest integrations seems great, but not sure the features they offer are valuable for us right now, maybe Pino could be used in the future since it's very performant, but in my opinion it would be a premature optimisation at this point.

@fmrsabino What do you think about logging incoming http requests? I think it's pretty useful sometimes and, if I'm not wrong, old client gateway implementation uses that. We could achieve this easily by applying a [middleware](https://docs.nestjs.com/middleware) to the modules we want. If you find it useful I could include it in this PR (or create a new issue).