### PR TITLE
Rename SafeConfig* to Config*

### DIFF
--- a/src/chains/chains.controller.spec.ts
+++ b/src/chains/chains.controller.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { SafeConfigModule } from '../services/safe-config/safe-config.module';
+import { ConfigServiceModule } from '../services/config-service/config-service.module';
 import { ChainsController } from './chains.controller';
 import { ChainsService } from './chains.service';
 
@@ -8,7 +8,7 @@ describe('ChainsController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [SafeConfigModule],
+      imports: [ConfigServiceModule],
       controllers: [ChainsController],
       providers: [ChainsService],
     }).compile();

--- a/src/chains/chains.module.ts
+++ b/src/chains/chains.module.ts
@@ -1,10 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ChainsService } from './chains.service';
 import { ChainsController } from './chains.controller';
-import { SafeConfigModule } from '../services/safe-config/safe-config.module';
+import { ConfigServiceModule } from '../services/config-service/config-service.module';
 
 @Module({
-  imports: [SafeConfigModule],
+  imports: [ConfigServiceModule],
   controllers: [ChainsController],
   providers: [ChainsService],
 })

--- a/src/chains/chains.service.spec.ts
+++ b/src/chains/chains.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { SafeConfigModule } from '../services/safe-config/safe-config.module';
+import { ConfigServiceModule } from '../services/config-service/config-service.module';
 import { ChainsService } from './chains.service';
 
 describe('ChainsService', () => {
@@ -7,7 +7,7 @@ describe('ChainsService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [SafeConfigModule],
+      imports: [ConfigServiceModule],
       providers: [ChainsService],
     }).compile();
 

--- a/src/chains/chains.service.ts
+++ b/src/chains/chains.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@nestjs/common';
-import { SafeConfigService } from '../services/safe-config/safe-config.service';
+import { ConfigService } from '../services/config-service/config-service.service';
 import { Chain } from './entities/chain.entity';
 import { Page } from './entities/page.entity';
 
 @Injectable()
 export class ChainsService {
-  constructor(private readonly safeConfigService: SafeConfigService) {}
+  constructor(private readonly safeConfigService: ConfigService) {}
 
   async getChains(): Promise<Page<Chain>> {
     const result = await this.safeConfigService.getChains();

--- a/src/services/config-service/config-service.module.ts
+++ b/src/services/config-service/config-service.module.ts
@@ -1,7 +1,7 @@
 import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { HttpErrorHandler } from '../errors/http-error-handler';
-import { SafeConfigService } from './safe-config.service';
+import { ConfigService } from './config-service.service';
 
 const BASE_URL_PROVIDER = {
   provide: 'SAFE_CONFIG_BASE_URL',
@@ -10,7 +10,7 @@ const BASE_URL_PROVIDER = {
 
 @Module({
   imports: [HttpModule],
-  providers: [SafeConfigService, BASE_URL_PROVIDER, HttpErrorHandler],
-  exports: [SafeConfigService, BASE_URL_PROVIDER],
+  providers: [ConfigService, BASE_URL_PROVIDER, HttpErrorHandler],
+  exports: [ConfigService, BASE_URL_PROVIDER],
 })
-export class SafeConfigModule {}
+export class ConfigServiceModule {}

--- a/src/services/config-service/config-service.service.ts
+++ b/src/services/config-service/config-service.service.ts
@@ -1,18 +1,18 @@
 import { HttpService } from '@nestjs/axios';
 import { Inject, Injectable } from '@nestjs/common';
-import { SafeConfigPage } from './entities/page.entity';
-import { SafeConfigChain } from './entities/chain.entity';
+import { Page } from './entities/page.entity';
+import { Chain } from './entities/chain.entity';
 import { HttpErrorHandler } from '../errors/http-error-handler';
 
 @Injectable()
-export class SafeConfigService {
+export class ConfigService {
   constructor(
     @Inject('SAFE_CONFIG_BASE_URL') private readonly baseUrl,
     private readonly httpService: HttpService,
     private readonly httpErrorHandler: HttpErrorHandler,
   ) {}
 
-  async getChains(): Promise<SafeConfigPage<SafeConfigChain>> {
+  async getChains(): Promise<Page<Chain>> {
     try {
       const url = this.baseUrl + '/api/v1/chains';
       const response = await this.httpService.axiosRef.get(url);
@@ -22,7 +22,7 @@ export class SafeConfigService {
     }
   }
 
-  async getChain(chainId: string): Promise<SafeConfigChain> {
+  async getChain(chainId: string): Promise<Chain> {
     try {
       const url = this.baseUrl + `/api/v1/chains/${chainId}`;
       const response = await this.httpService.axiosRef.get(url);

--- a/src/services/config-service/entities/chain.entity.ts
+++ b/src/services/config-service/entities/chain.entity.ts
@@ -1,4 +1,4 @@
-export interface SafeConfigChain {
+export interface Chain {
   chainId: string;
   chainName: string;
   transactionService: string;

--- a/src/services/config-service/entities/page.entity.ts
+++ b/src/services/config-service/entities/page.entity.ts
@@ -1,4 +1,4 @@
-export interface SafeConfigPage<T> {
+export interface Page<T> {
   count: number;
   next?: string;
   previous?: string;

--- a/src/services/transaction-service/transaction-service.manager.ts
+++ b/src/services/transaction-service/transaction-service.manager.ts
@@ -1,8 +1,8 @@
 import { HttpService } from '@nestjs/axios';
 import { Injectable, Logger } from '@nestjs/common';
 import { HttpErrorHandler } from '../errors/http-error-handler';
-import { SafeConfigChain } from '../safe-config/entities/chain.entity';
-import { SafeConfigService } from '../safe-config/safe-config.service';
+import { Chain } from '../config-service/entities/chain.entity';
+import { ConfigService } from '../config-service/config-service.service';
 import { TransactionService } from './transaction-service.service';
 
 @Injectable()
@@ -11,7 +11,7 @@ export class TransactionServiceManager {
   private transactionServiceMap: Record<string, TransactionService> = {};
 
   constructor(
-    private readonly safeConfigService: SafeConfigService,
+    private readonly configService: ConfigService,
     private readonly httpService: HttpService,
     private readonly httpErrorHandler: HttpErrorHandler,
   ) {}
@@ -22,11 +22,9 @@ export class TransactionServiceManager {
     if (transactionService !== undefined) return transactionService;
 
     this.logger.log(
-      `Transaction Service for chain ${chainId} not available. Getting from the SafeConfigService`,
+      `Transaction Service for chain ${chainId} not available. Fetching from the Config Service`,
     );
-    const chain: SafeConfigChain = await this.safeConfigService.getChain(
-      chainId,
-    );
+    const chain: Chain = await this.configService.getChain(chainId);
     this.transactionServiceMap[chainId] = new TransactionService(
       chain.transactionService,
       this.httpService,

--- a/src/services/transaction-service/transaction-service.module.ts
+++ b/src/services/transaction-service/transaction-service.module.ts
@@ -1,11 +1,11 @@
 import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
-import { SafeConfigModule } from '../safe-config/safe-config.module';
+import { ConfigServiceModule } from '../config-service/config-service.module';
 import { HttpErrorHandler } from '../errors/http-error-handler';
 import { TransactionServiceManager } from './transaction-service.manager';
 
 @Module({
-  imports: [SafeConfigModule, HttpModule],
+  imports: [ConfigServiceModule, HttpModule],
   providers: [TransactionServiceManager, HttpErrorHandler],
   exports: [TransactionServiceManager],
 })


### PR DESCRIPTION
- Renames `safe-config` folder to `config-service`
- Renames `SafeConfigModule` to `ConfigServiceModule`
- Renames `SafeConfigService` to `ConfigService`
- Renames `SafeConfigChain` to `Chain` (if the name conflicts in a feature, import aliases should be used)
- Renames `SafeConfigPage` to `Page` (if the name conflicts in a feature, import aliases should be used)