### PR TITLE
Add tests to Balances Controller. Add factory functions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "rxjs": "^7.2.0"
   },
   "devDependencies": {
+    "@faker-js/faker": "^7.4.0",
     "@nestjs/cli": "^9.0.0",
     "@nestjs/schematics": "^9.0.0",
     "@nestjs/testing": "^9.0.0",

--- a/src/balances/balances.controller.spec.ts
+++ b/src/balances/balances.controller.spec.ts
@@ -31,7 +31,7 @@ describe('Balances Controller (Unit)', () => {
     it(`Success`, async () => {
       const chainId = '1';
       const safeAddress = '0x0000000000000000000000000000000000000001';
-      const safeTransactionServiceBalancesResponse = safeBalanceFactory(1);
+      const transactionServiceBalancesResponse = safeBalanceFactory(1);
       const exchangeResponse = exchangeResultFactory({ USD: 2.0 });
       const chainResponse = chainFactory(chainId);
       axiosMock.get.mockImplementation((url) => {
@@ -42,7 +42,7 @@ describe('Balances Controller (Unit)', () => {
           `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/balances/usd/`
         ) {
           return Promise.resolve({
-            data: safeTransactionServiceBalancesResponse,
+            data: transactionServiceBalancesResponse,
           });
         } else if (url == configuration().exchange.baseUri) {
           return Promise.resolve({ data: exchangeResponse });
@@ -51,29 +51,25 @@ describe('Balances Controller (Unit)', () => {
         }
       });
 
+      const expectedBalance = transactionServiceBalancesResponse[0];
       await request(app.getHttpServer())
         .get(`/chains/${chainId}/safes/${safeAddress}/balances/usd`)
         .expect(200)
         .expect({
-          fiatTotal: safeTransactionServiceBalancesResponse[0].fiatBalance,
+          fiatTotal: expectedBalance.fiatBalance,
           items: [
             {
               tokenInfo: {
                 tokenType: 'ERC20',
-                address: safeTransactionServiceBalancesResponse[0].tokenAddress,
-                decimals:
-                  safeTransactionServiceBalancesResponse[0].token.decimals,
-                symbol: safeTransactionServiceBalancesResponse[0].token.symbol,
-                name: safeTransactionServiceBalancesResponse[0].token.name,
-                logoUri:
-                  safeTransactionServiceBalancesResponse[0].token.logo_uri,
+                address: expectedBalance.tokenAddress,
+                decimals: expectedBalance.token.decimals,
+                symbol: expectedBalance.token.symbol,
+                name: expectedBalance.token.name,
+                logoUri: expectedBalance.token.logo_uri,
               },
-              balance:
-                safeTransactionServiceBalancesResponse[0].balance.toString(),
-              fiatBalance:
-                safeTransactionServiceBalancesResponse[0].fiatBalance,
-              fiatConversion:
-                safeTransactionServiceBalancesResponse[0].fiatConversion,
+              balance: expectedBalance.balance.toString(),
+              fiatBalance: expectedBalance.fiatBalance,
+              fiatConversion: expectedBalance.fiatConversion,
             },
           ],
         });
@@ -99,7 +95,7 @@ describe('Balances Controller (Unit)', () => {
       it(`500 error response`, async () => {
         const chainId = '1';
         const safeAddress = '0x0000000000000000000000000000000000000001';
-        const safeTransactionServiceBalancesResponse = safeBalanceFactory(1);
+        const transactionServiceBalancesResponse = safeBalanceFactory(1);
         const chainResponse = chainFactory(chainId);
         axiosMock.get.mockImplementation((url) => {
           if (url == `https://safe-config.gnosis.io/api/v1/chains/${chainId}`) {
@@ -109,7 +105,7 @@ describe('Balances Controller (Unit)', () => {
             `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/balances/usd/`
           ) {
             return Promise.resolve({
-              data: safeTransactionServiceBalancesResponse,
+              data: transactionServiceBalancesResponse,
             });
           } else if (url == configuration().exchange.baseUri) {
             return Promise.reject({ status: 500 });
@@ -132,7 +128,7 @@ describe('Balances Controller (Unit)', () => {
       it(`No rates returned`, async () => {
         const chainId = '1';
         const safeAddress = '0x0000000000000000000000000000000000000001';
-        const safeTransactionServiceBalancesResponse = safeBalanceFactory(1);
+        const transactionServiceBalancesResponse = safeBalanceFactory(1);
         const exchangeResponse = {}; // no rates
         const chainResponse = chainFactory(chainId);
         axiosMock.get.mockImplementation((url) => {
@@ -143,7 +139,7 @@ describe('Balances Controller (Unit)', () => {
             `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/balances/usd/`
           ) {
             return Promise.resolve({
-              data: safeTransactionServiceBalancesResponse,
+              data: transactionServiceBalancesResponse,
             });
           } else if (url == configuration().exchange.baseUri) {
             return Promise.resolve({ data: exchangeResponse });
@@ -167,7 +163,7 @@ describe('Balances Controller (Unit)', () => {
       it(`from-rate missing`, async () => {
         const chainId = '1';
         const safeAddress = '0x0000000000000000000000000000000000000001';
-        const safeTransactionServiceBalancesResponse = safeBalanceFactory(1);
+        const transactionServiceBalancesResponse = safeBalanceFactory(1);
         const exchangeResponse = exchangeResultFactory({ XYZ: 2 }); // Returns different rate than USD
         const chainResponse = chainFactory(chainId);
         axiosMock.get.mockImplementation((url) => {
@@ -178,7 +174,7 @@ describe('Balances Controller (Unit)', () => {
             `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/balances/usd/`
           ) {
             return Promise.resolve({
-              data: safeTransactionServiceBalancesResponse,
+              data: transactionServiceBalancesResponse,
             });
           } else if (url == configuration().exchange.baseUri) {
             return Promise.resolve({ data: exchangeResponse });
@@ -202,7 +198,7 @@ describe('Balances Controller (Unit)', () => {
       it(`from-rate is 0`, async () => {
         const chainId = '1';
         const safeAddress = '0x0000000000000000000000000000000000000001';
-        const safeTransactionServiceBalancesResponse = safeBalanceFactory(1);
+        const transactionServiceBalancesResponse = safeBalanceFactory(1);
         const exchangeResponse = exchangeResultFactory({ USD: 0 }); // rate is zero
         const chainResponse = chainFactory(chainId);
         axiosMock.get.mockImplementation((url) => {
@@ -213,7 +209,7 @@ describe('Balances Controller (Unit)', () => {
             `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/balances/usd/`
           ) {
             return Promise.resolve({
-              data: safeTransactionServiceBalancesResponse,
+              data: transactionServiceBalancesResponse,
             });
           } else if (url == configuration().exchange.baseUri) {
             return Promise.resolve({ data: exchangeResponse });
@@ -238,7 +234,7 @@ describe('Balances Controller (Unit)', () => {
         const chainId = '1';
         const toRate = 'XYZ';
         const safeAddress = '0x0000000000000000000000000000000000000001';
-        const safeTransactionServiceBalancesResponse = safeBalanceFactory(1);
+        const transactionServiceBalancesResponse = safeBalanceFactory(1);
         const exchangeResponse = exchangeResultFactory({ USD: 2 }); // Returns different rate than XYZ
         const chainResponse = chainFactory(chainId);
         axiosMock.get.mockImplementation((url) => {
@@ -249,7 +245,7 @@ describe('Balances Controller (Unit)', () => {
             `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/balances/usd/`
           ) {
             return Promise.resolve({
-              data: safeTransactionServiceBalancesResponse,
+              data: transactionServiceBalancesResponse,
             });
           } else if (url == configuration().exchange.baseUri) {
             return Promise.resolve({ data: exchangeResponse });

--- a/src/balances/balances.controller.spec.ts
+++ b/src/balances/balances.controller.spec.ts
@@ -3,6 +3,10 @@ import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import axios from 'axios';
 import { BalancesModule } from './balances.module';
+import safeBalanceFactory from '../services/transaction-service/entities/__tests__/balance.factory';
+import exchangeResultFactory from '../services/exchange/entities/__tests__/exchange.factory';
+import chainFactory from '../services/config-service/entities/__tests__/chain.factory';
+import configuration from '../config/configuration';
 
 jest.mock('axios');
 const axiosMock = axios as jest.Mocked<typeof axios>;
@@ -19,95 +23,282 @@ describe('Balances Controller (Unit)', () => {
     await app.init();
   });
 
-  it(`GET /balances`, async () => {
-    const chainId = 1;
-    const safeAddress = '0x0000000000000000000000000000000000000001';
-    const safeTransactionServiceBalancesResponse = {
-      data: [
-        {
-          tokenAddress: `0x6810e776880C02933D47DB1b9fc05908e5386b96`,
-          token: {
-            name: 'Gnosis',
-            symbol: 'GNO',
-            decimals: 16,
-            logo_uri: null,
-          },
-          balance: 1,
-          fiatBalance: 100,
-          fiatConversion: 2,
-        },
-      ],
-    };
-
-    const exchangeResponse = {
-      data: {
-        success: true,
-        timestamp: 1660567445,
-        base: 'EUR',
-        date: '2022-08-15',
-        rates: {
-          USD: 2,
-        },
-      },
-    };
-
-    const safeConfigServiceResponse = {
-      data: {
-        chainId: '1',
-        chainName: 'mainnet',
-        transactionService: 'https://test.safe.transaction.service',
-        vpcTransactionService: 'https://test.safe.transaction.service',
-      },
-    };
-    axiosMock.get.mockImplementation((url) => {
-      if (url == 'https://safe-config.gnosis.io/api/v1/chains/1') {
-        return Promise.resolve(safeConfigServiceResponse);
-      } else if (
-        url ==
-        `https://test.safe.transaction.service/api/v1/safes/0x0000000000000000000000000000000000000001/balances/usd/`
-      ) {
-        return Promise.resolve(safeTransactionServiceBalancesResponse);
-      } else if (url == 'http://api.exchangeratesapi.io/latest') {
-        return Promise.resolve(exchangeResponse);
-      } else {
-        return Promise.reject(new Error(`Could not match ${url}`));
-      }
-    });
-
-    await request(app.getHttpServer())
-      .get(`/chains/${chainId}/safes/${safeAddress}/balances/USD`)
-      .expect(200)
-      .expect({
-        fiatTotal: 100,
-        items: [
-          {
-            tokenInfo: {
-              tokenType: 'ERC20',
-              address: '0x6810e776880C02933D47DB1b9fc05908e5386b96',
-              decimals: 16,
-              symbol: 'GNO',
-              name: 'Gnosis',
-              logoUri: null,
-            },
-            balance: 1,
-            fiatBalance: 100,
-            fiatConversion: 2,
-          },
-        ],
-      });
-
-    expect(axiosMock.get.mock.calls[0][0]).toBe(
-      'https://safe-config.gnosis.io/api/v1/chains/1',
-    );
-    expect(axiosMock.get.mock.calls[1][0]).toBe(
-      `https://test.safe.transaction.service/api/v1/safes/${safeAddress}/balances/usd/`,
-    );
-    expect(axiosMock.get.mock.calls[1][1]).toStrictEqual({
-      params: { trusted: undefined, excludeSpam: undefined },
-    });
-  });
-
   afterAll(async () => {
     await app.close();
+  });
+
+  describe('GET /balances', () => {
+    it(`Success`, async () => {
+      const chainId = '1';
+      const safeAddress = '0x0000000000000000000000000000000000000001';
+      const safeTransactionServiceBalancesResponse = safeBalanceFactory(1);
+      const exchangeResponse = exchangeResultFactory({ USD: 2.0 });
+      const chainResponse = chainFactory(chainId);
+      axiosMock.get.mockImplementation((url) => {
+        if (url == `https://safe-config.gnosis.io/api/v1/chains/${chainId}`) {
+          return Promise.resolve({ data: chainResponse });
+        } else if (
+          url ==
+          `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/balances/usd/`
+        ) {
+          return Promise.resolve({
+            data: safeTransactionServiceBalancesResponse,
+          });
+        } else if (url == configuration().exchange.baseUri) {
+          return Promise.resolve({ data: exchangeResponse });
+        } else {
+          return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/chains/${chainId}/safes/${safeAddress}/balances/usd`)
+        .expect(200)
+        .expect({
+          fiatTotal: safeTransactionServiceBalancesResponse[0].fiatBalance,
+          items: [
+            {
+              tokenInfo: {
+                tokenType: 'ERC20',
+                address: safeTransactionServiceBalancesResponse[0].tokenAddress,
+                decimals:
+                  safeTransactionServiceBalancesResponse[0].token.decimals,
+                symbol: safeTransactionServiceBalancesResponse[0].token.symbol,
+                name: safeTransactionServiceBalancesResponse[0].token.name,
+                logoUri:
+                  safeTransactionServiceBalancesResponse[0].token.logo_uri,
+              },
+              balance:
+                safeTransactionServiceBalancesResponse[0].balance.toString(),
+              fiatBalance:
+                safeTransactionServiceBalancesResponse[0].fiatBalance,
+              fiatConversion:
+                safeTransactionServiceBalancesResponse[0].fiatConversion,
+            },
+          ],
+        });
+
+      // 4 Network calls are expected (1. Chain data, 2. Balances, 3. Exchange API, 4. Chain data (Native Currency)
+      // Once caching is in place we don't need to retrieve the Chain Data again
+      expect(axiosMock.get.mock.calls.length).toBe(4);
+      expect(axiosMock.get.mock.calls[0][0]).toBe(
+        'https://safe-config.gnosis.io/api/v1/chains/1',
+      );
+      expect(axiosMock.get.mock.calls[1][0]).toBe(
+        `${chainResponse.transactionService}/api/v1/safes/0x0000000000000000000000000000000000000001/balances/usd/`,
+      );
+      expect(axiosMock.get.mock.calls[1][1]).toStrictEqual({
+        params: { trusted: undefined, excludeSpam: undefined },
+      });
+      expect(axiosMock.get.mock.calls[2][0]).toBe(
+        configuration().exchange.baseUri,
+      );
+    });
+
+    describe('Exchange API Error', () => {
+      it(`500 error response`, async () => {
+        const chainId = '1';
+        const safeAddress = '0x0000000000000000000000000000000000000001';
+        const safeTransactionServiceBalancesResponse = safeBalanceFactory(1);
+        const chainResponse = chainFactory(chainId);
+        axiosMock.get.mockImplementation((url) => {
+          if (url == `https://safe-config.gnosis.io/api/v1/chains/${chainId}`) {
+            return Promise.resolve({ data: chainResponse });
+          } else if (
+            url ==
+            `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/balances/usd/`
+          ) {
+            return Promise.resolve({
+              data: safeTransactionServiceBalancesResponse,
+            });
+          } else if (url == configuration().exchange.baseUri) {
+            return Promise.reject({ status: 500 });
+          } else {
+            return Promise.reject(new Error(`Could not match ${url}`));
+          }
+        });
+
+        await request(app.getHttpServer())
+          .get(`/chains/${chainId}/safes/${safeAddress}/balances/usd`)
+          .expect(503)
+          .expect({
+            message: 'Service unavailable',
+            code: 503,
+          });
+
+        expect(axiosMock.get.mock.calls.length).toBe(3);
+      });
+
+      it(`No rates returned`, async () => {
+        const chainId = '1';
+        const safeAddress = '0x0000000000000000000000000000000000000001';
+        const safeTransactionServiceBalancesResponse = safeBalanceFactory(1);
+        const exchangeResponse = {}; // no rates
+        const chainResponse = chainFactory(chainId);
+        axiosMock.get.mockImplementation((url) => {
+          if (url == `https://safe-config.gnosis.io/api/v1/chains/${chainId}`) {
+            return Promise.resolve({ data: chainResponse });
+          } else if (
+            url ==
+            `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/balances/usd/`
+          ) {
+            return Promise.resolve({
+              data: safeTransactionServiceBalancesResponse,
+            });
+          } else if (url == configuration().exchange.baseUri) {
+            return Promise.resolve({ data: exchangeResponse });
+          } else {
+            return Promise.reject(new Error(`Could not match ${url}`));
+          }
+        });
+
+        await request(app.getHttpServer())
+          .get(`/chains/${chainId}/safes/${safeAddress}/balances/usd`)
+          .expect(500)
+          .expect({
+            statusCode: 500,
+            message: 'Exchange rates unavailable',
+            error: 'Internal Server Error',
+          });
+
+        expect(axiosMock.get.mock.calls.length).toBe(3);
+      });
+
+      it(`from-rate missing`, async () => {
+        const chainId = '1';
+        const safeAddress = '0x0000000000000000000000000000000000000001';
+        const safeTransactionServiceBalancesResponse = safeBalanceFactory(1);
+        const exchangeResponse = exchangeResultFactory({ XYZ: 2 }); // Returns different rate than USD
+        const chainResponse = chainFactory(chainId);
+        axiosMock.get.mockImplementation((url) => {
+          if (url == `https://safe-config.gnosis.io/api/v1/chains/${chainId}`) {
+            return Promise.resolve({ data: chainResponse });
+          } else if (
+            url ==
+            `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/balances/usd/`
+          ) {
+            return Promise.resolve({
+              data: safeTransactionServiceBalancesResponse,
+            });
+          } else if (url == configuration().exchange.baseUri) {
+            return Promise.resolve({ data: exchangeResponse });
+          } else {
+            return Promise.reject(new Error(`Could not match ${url}`));
+          }
+        });
+
+        await request(app.getHttpServer())
+          .get(`/chains/${chainId}/safes/${safeAddress}/balances/usd`)
+          .expect(500)
+          .expect({
+            statusCode: 500,
+            message: 'Exchange rate for USD is not available',
+            error: 'Internal Server Error',
+          });
+
+        expect(axiosMock.get.mock.calls.length).toBe(3);
+      });
+
+      it(`from-rate is 0`, async () => {
+        const chainId = '1';
+        const safeAddress = '0x0000000000000000000000000000000000000001';
+        const safeTransactionServiceBalancesResponse = safeBalanceFactory(1);
+        const exchangeResponse = exchangeResultFactory({ USD: 0 }); // rate is zero
+        const chainResponse = chainFactory(chainId);
+        axiosMock.get.mockImplementation((url) => {
+          if (url == `https://safe-config.gnosis.io/api/v1/chains/${chainId}`) {
+            return Promise.resolve({ data: chainResponse });
+          } else if (
+            url ==
+            `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/balances/usd/`
+          ) {
+            return Promise.resolve({
+              data: safeTransactionServiceBalancesResponse,
+            });
+          } else if (url == configuration().exchange.baseUri) {
+            return Promise.resolve({ data: exchangeResponse });
+          } else {
+            return Promise.reject(new Error(`Could not match ${url}`));
+          }
+        });
+
+        await request(app.getHttpServer())
+          .get(`/chains/${chainId}/safes/${safeAddress}/balances/usd`)
+          .expect(500)
+          .expect({
+            statusCode: 500,
+            message: 'Exchange rate for USD is not available',
+            error: 'Internal Server Error',
+          });
+
+        expect(axiosMock.get.mock.calls.length).toBe(3);
+      });
+
+      it(`to-rate missing`, async () => {
+        const chainId = '1';
+        const toRate = 'XYZ';
+        const safeAddress = '0x0000000000000000000000000000000000000001';
+        const safeTransactionServiceBalancesResponse = safeBalanceFactory(1);
+        const exchangeResponse = exchangeResultFactory({ USD: 2 }); // Returns different rate than XYZ
+        const chainResponse = chainFactory(chainId);
+        axiosMock.get.mockImplementation((url) => {
+          if (url == `https://safe-config.gnosis.io/api/v1/chains/${chainId}`) {
+            return Promise.resolve({ data: chainResponse });
+          } else if (
+            url ==
+            `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/balances/usd/`
+          ) {
+            return Promise.resolve({
+              data: safeTransactionServiceBalancesResponse,
+            });
+          } else if (url == configuration().exchange.baseUri) {
+            return Promise.resolve({ data: exchangeResponse });
+          } else {
+            return Promise.reject(new Error(`Could not match ${url}`));
+          }
+        });
+
+        await request(app.getHttpServer())
+          .get(`/chains/${chainId}/safes/${safeAddress}/balances/${toRate}`)
+          .expect(500)
+          .expect({
+            statusCode: 500,
+            message: 'Exchange rate for XYZ is not available',
+            error: 'Internal Server Error',
+          });
+
+        expect(axiosMock.get.mock.calls.length).toBe(3);
+      });
+    });
+
+    describe('Transaction Service API Error', () => {
+      it(`500 error response`, async () => {
+        const chainId = '1';
+        const safeAddress = '0x0000000000000000000000000000000000000001';
+        const exchangeResponse = exchangeResultFactory({ USD: 2.0 });
+        const chainResponse = chainFactory(chainId);
+        axiosMock.get.mockImplementation((url) => {
+          if (url == `https://safe-config.gnosis.io/api/v1/chains/${chainId}`) {
+            return Promise.resolve({ data: chainResponse });
+          } else if (
+            url ==
+            `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/balances/usd/`
+          ) {
+            return Promise.reject({ status: 500 });
+          } else if (url == configuration().exchange.baseUri) {
+            return Promise.resolve({ data: exchangeResponse });
+          } else {
+            return Promise.reject(new Error(`Could not match ${url}`));
+          }
+        });
+
+        await request(app.getHttpServer())
+          .get(`/chains/${chainId}/safes/${safeAddress}/balances/usd`)
+          .expect(503)
+          .expect({ message: 'Service unavailable', code: 503 });
+
+        expect(axiosMock.get.mock.calls.length).toBe(2);
+      });
+    });
   });
 });

--- a/src/balances/balances.service.ts
+++ b/src/balances/balances.service.ts
@@ -83,7 +83,7 @@ export class BalancesService {
         name: txBalance.token?.name,
         logoUri: logoUri,
       },
-      balance: txBalance.balance,
+      balance: txBalance.balance.toString(),
       fiatBalance: fiatBalance,
       fiatConversion: fiatConversion,
     };

--- a/src/services/config-service/entities/__tests__/chain.factory.ts
+++ b/src/services/config-service/entities/__tests__/chain.factory.ts
@@ -1,0 +1,20 @@
+import { Chain } from '../chain.entity';
+import { NativeCurrency } from '../native.currency.entity';
+import { faker } from '@faker-js/faker';
+import nativeCurrencyFactory from './native.currency.factory';
+
+export default function (
+  chainId?: string,
+  chainName?: string,
+  transactionService?: string,
+  vpcTransactionService?: string,
+  nativeCurrency?: NativeCurrency,
+): Chain {
+  return <Chain>{
+    chainId: chainId || faker.datatype.number(),
+    chainName: chainId || faker.company.name(),
+    transactionService: transactionService || faker.internet.url(),
+    vpcTransactionService: vpcTransactionService || faker.internet.url(),
+    nativeCurrency: nativeCurrency || nativeCurrencyFactory(),
+  };
+}

--- a/src/services/config-service/entities/__tests__/native.currency.factory.ts
+++ b/src/services/config-service/entities/__tests__/native.currency.factory.ts
@@ -1,0 +1,16 @@
+import { NativeCurrency } from '../native.currency.entity';
+import { faker } from '@faker-js/faker';
+
+export default function (
+  name?: string,
+  symbol?: string,
+  decimals?: number,
+  logoUri?: string,
+): NativeCurrency {
+  return <NativeCurrency>{
+    name: name ?? faker.finance.currencyName(),
+    symbol: symbol ?? faker.finance.currencySymbol(),
+    decimals: decimals ?? 18,
+    logoUri: logoUri ?? faker.internet.url(),
+  };
+}

--- a/src/services/exchange/entities/__tests__/exchange.factory.ts
+++ b/src/services/exchange/entities/__tests__/exchange.factory.ts
@@ -1,0 +1,11 @@
+import { ExchangeResult } from '../exchange.entity';
+
+export default function (
+  rates?: Record<string, number>,
+  base?: string,
+): ExchangeResult {
+  return <ExchangeResult>{
+    base: base ?? 'EUR',
+    rates: rates ?? { USD: 1.5 },
+  };
+}

--- a/src/services/exchange/exchange.service.ts
+++ b/src/services/exchange/exchange.service.ts
@@ -19,12 +19,12 @@ export class ExchangeService {
     if (exchangeResult.rates === undefined)
       throw new InternalServerErrorException(`Exchange rates unavailable`);
 
-    const fromExchangeRate = exchangeResult.rates[from];
+    const fromExchangeRate = exchangeResult.rates[from.toUpperCase()];
     if (fromExchangeRate === undefined || fromExchangeRate == 0)
       throw new InternalServerErrorException(
         `Exchange rate for ${from} is not available`,
       );
-    const toExchangeRate = exchangeResult.rates[to];
+    const toExchangeRate = exchangeResult.rates[to.toUpperCase()];
     if (toExchangeRate === undefined)
       throw new InternalServerErrorException(
         `Exchange rate for ${to} is not available`,

--- a/src/services/transaction-service/entities/__tests__/balance.factory.ts
+++ b/src/services/transaction-service/entities/__tests__/balance.factory.ts
@@ -1,0 +1,24 @@
+import { Balance } from '../balance.entity';
+import { faker } from '@faker-js/faker';
+import balanceTokenFactory from './balance.token.factory';
+import { BalanceToken } from '../balance.token.entity';
+
+export default function factory(size?: number): Balance[] {
+  return [...Array(size ?? 1).keys()].map(() => balanceFactory());
+}
+
+export function balanceFactory(
+  tokenAddress?: string,
+  token?: BalanceToken,
+  balance?: bigint,
+  fiatBalance?: number,
+  fiatConversion?: number,
+): Balance {
+  return <Balance>{
+    tokenAddress: tokenAddress || faker.finance.ethereumAddress(),
+    token: token || balanceTokenFactory(),
+    balance: balance || faker.datatype.bigInt(),
+    fiatBalance: fiatBalance || faker.datatype.number(),
+    fiatConversion: fiatConversion || faker.datatype.number(),
+  };
+}

--- a/src/services/transaction-service/entities/__tests__/balance.token.factory.ts
+++ b/src/services/transaction-service/entities/__tests__/balance.token.factory.ts
@@ -1,0 +1,16 @@
+import { BalanceToken } from '../balance.token.entity';
+import { faker } from '@faker-js/faker';
+
+export default function (
+  decimals?: number,
+  logo_uri?: string,
+  name?: string,
+  symbol?: string,
+): BalanceToken {
+  return <BalanceToken>{
+    decimals: decimals || faker.datatype.number(),
+    logo_uri: logo_uri || faker.internet.url(),
+    name: name || faker.finance.currencyName(),
+    symbol: symbol || faker.finance.currencySymbol(),
+  };
+}

--- a/src/services/transaction-service/entities/balance.entity.ts
+++ b/src/services/transaction-service/entities/balance.entity.ts
@@ -3,7 +3,7 @@ import { BalanceToken } from './balance.token.entity';
 export interface Balance {
   tokenAddress?: string;
   token?: BalanceToken;
-  balance: string;
+  balance: bigint;
   fiatBalance: number;
   fiatConversion: number;
 }

--- a/src/services/transaction-service/transaction-service.service.spec.ts
+++ b/src/services/transaction-service/transaction-service.service.spec.ts
@@ -6,14 +6,14 @@ import { TransactionService } from './transaction-service.service';
 const BALANCES: Balance[] = [
   {
     tokenAddress: 'tokenAddress1',
-    balance: 'balanceStr1',
+    balance: BigInt(100),
     token: null,
     fiatBalance: 0,
     fiatConversion: 0,
   },
   {
     tokenAddress: 'tokenAddress2',
-    balance: 'balanceStr2',
+    balance: BigInt(100),
     token: null,
     fiatBalance: 0,
     fiatConversion: 0,

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,6 +487,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@faker-js/faker@npm:^7.4.0":
+  version: 7.4.0
+  resolution: "@faker-js/faker@npm:7.4.0"
+  checksum: 1acebb84bfb142c08e6ba2942910d16bd92ea147fa585fa2fa9ce9983f7a8c7c016002beb7fc20ef6f7aef6c4ae9cb3fa680b275823402e34802b8489d2b980d
+  languageName: node
+  linkType: hard
+
 "@gar/promisify@npm:^1.1.3":
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
@@ -5813,6 +5820,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "safe-client-gateway@workspace:."
   dependencies:
+    "@faker-js/faker": ^7.4.0
     "@nestjs/axios": ^0.1.0
     "@nestjs/cli": ^9.0.0
     "@nestjs/common": ^9.0.0


### PR DESCRIPTION
Closes #24, #19

- Add `@faker-js/faker` as a dev dependency – it allows to generate random data that can be used for testing
- Add factories for `Balance`, `BalanceToken` (from the Transaction Service)
- Add factories for `Chain` (from the Safe Config Service)
- Add factories for the Exchange Service response
- Add more unit tests to Balances Controller. Cases:
  * Success case
  * Exchange API Error – 500 error response
  * Exchange API Error – No rates returned
  * Exchange API Error – from-rate missing
  * Exchange API Error – from-rate is 0
  * Exchange API Error – to-rate missing
  * Transaction Service API Error – 500 error response
- `Balance` from Transaction Service is now a `bigint`