### PR TITLE
Add Test Coverage to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,8 @@ jobs:
           node-version: '16.x'
           cache: 'yarn'
       - run: yarn --frozen-lockfile
-      - run: yarn run test
+      - run: yarn run test:cov
+      - name: Upload coverage
+        uses: coverallsapp/github-action@1.1.3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Safe Client Gateway
+
+[![Coverage Status](https://coveralls.io/repos/github/5afe/safe-client-gateway-nest/badge.svg?branch=coverage-action)](https://coveralls.io/github/5afe/safe-client-gateway-nest?branch=coverage-action)
+
 ## Requirements
 - Node 16.16.0 – https://nodejs.org/en/
 


### PR DESCRIPTION
Closes #17 

- Uses `coverallsapp/github-action` for Coveralls integration – https://github.com/coverallsapp/github-action
- Updates `README.md` with coverage badge