### PR TITLE
Add SAFE_CONFIG_BASE_URI to configuration.ts

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,3 +3,7 @@
 # The EXCHANGE_API_KEY should always be set
 #EXCHANGE_API_BASE_URI=
 #EXCHANGE_API_KEY=
+
+# The base url for the Safe Config Service
+# Default if none is set: https://safe-config.gnosis.io
+#SAFE_CONFIG_BASE_URI=https://safe-config.gnosis.io

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -5,4 +5,8 @@ export default () => ({
       'http://api.exchangeratesapi.io/latest',
     apiKey: process.env.EXCHANGE_API_KEY,
   },
+  safeConfig: {
+    baseUri:
+      process.env.SAFE_CONFIG_BASE_URI || 'https://safe-config.gnosis.io',
+  },
 });

--- a/src/services/config-service/config-service.module.ts
+++ b/src/services/config-service/config-service.module.ts
@@ -2,15 +2,17 @@ import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { HttpErrorHandler } from '../errors/http-error-handler';
 import { ConfigService } from './config-service.service';
-
-const BASE_URL_PROVIDER = {
-  provide: 'SAFE_CONFIG_BASE_URL',
-  useValue: 'https://safe-config.gnosis.io', // TODO extract to a config file
-};
+import { ConfigModule } from '@nestjs/config';
+import configuration from '../../config/configuration';
 
 @Module({
-  imports: [HttpModule],
-  providers: [ConfigService, BASE_URL_PROVIDER, HttpErrorHandler],
-  exports: [ConfigService, BASE_URL_PROVIDER],
+  imports: [
+    HttpModule,
+    ConfigModule.forRoot({
+      load: [configuration],
+    }),
+  ],
+  providers: [ConfigService, HttpErrorHandler],
+  exports: [ConfigService],
 })
 export class ConfigServiceModule {}

--- a/src/services/config-service/config-service.service.ts
+++ b/src/services/config-service/config-service.service.ts
@@ -1,20 +1,25 @@
 import { HttpService } from '@nestjs/axios';
-import { Inject, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Page } from './entities/page.entity';
 import { Chain } from './entities/chain.entity';
 import { HttpErrorHandler } from '../errors/http-error-handler';
+import { ConfigService as NestConfigService } from '@nestjs/config';
 
 @Injectable()
 export class ConfigService {
+  private readonly baseUri: string;
+
   constructor(
-    @Inject('SAFE_CONFIG_BASE_URL') private readonly baseUrl,
+    private readonly nestConfigService: NestConfigService,
     private readonly httpService: HttpService,
     private readonly httpErrorHandler: HttpErrorHandler,
-  ) {}
+  ) {
+    this.baseUri = nestConfigService.getOrThrow<string>('safeConfig.baseUri');
+  }
 
   async getChains(): Promise<Page<Chain>> {
     try {
-      const url = this.baseUrl + '/api/v1/chains';
+      const url = this.baseUri + '/api/v1/chains';
       const response = await this.httpService.axiosRef.get(url);
       return response.data;
     } catch (err) {
@@ -24,7 +29,7 @@ export class ConfigService {
 
   async getChain(chainId: string): Promise<Chain> {
     try {
-      const url = this.baseUrl + `/api/v1/chains/${chainId}`;
+      const url = this.baseUri + `/api/v1/chains/${chainId}`;
       const response = await this.httpService.axiosRef.get(url);
       return response.data;
     } catch (err) {


### PR DESCRIPTION
- The Safe Config Base URI is now read from the `configuration.ts`
- If `SAFE_CONFIG_BASE_URI` is set, then its value is used. Else defaults to `https://safe-config.gnosis.io`