### PR TITLE
Add injectable INetworkService

### DIFF
--- a/src/app.module.spec.ts
+++ b/src/app.module.spec.ts
@@ -1,0 +1,14 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from './app.module';
+
+describe('AppModule', () => {
+  it(`AppModule is successfully created`, async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    const app = moduleFixture.createNestApplication();
+    await app.init();
+    await app.close();
+  });
+});

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,9 +8,10 @@ import {
 import { ChainsModule } from './chains/chains.module';
 import { BalancesModule } from './balances/balances.module';
 import { LoggerMiddleware } from './common/middleware/logger.middleware';
+import { NetworkModule } from './common/network/network.module';
 
 @Module({
-  imports: [ChainsModule, BalancesModule],
+  imports: [BalancesModule, ChainsModule, NetworkModule],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/src/chains/chains.controller.spec.ts
+++ b/src/chains/chains.controller.spec.ts
@@ -1,14 +1,14 @@
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import axios from 'axios';
 import * as request from 'supertest';
 import chainFactory from '../services/config-service/entities/__tests__/chain.factory';
 import { ChainsModule } from './chains.module';
 import { Backbone, Chain, Page } from './entities';
 import backboneFactory from './entities/__tests__/backbone.factory';
-
-jest.mock('axios');
-const axiosMock = axios as jest.Mocked<typeof axios>;
+import {
+  mockNetworkService,
+  TestNetworkModule,
+} from '../common/network/__tests__/TestNetworkModule';
 
 describe('Chains Controller (Unit)', () => {
   let app: INestApplication;
@@ -26,7 +26,7 @@ describe('Chains Controller (Unit)', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [ChainsModule],
+      imports: [ChainsModule, TestNetworkModule],
     }).compile();
 
     app = moduleFixture.createNestApplication();
@@ -35,7 +35,7 @@ describe('Chains Controller (Unit)', () => {
 
   describe('GET /chains', () => {
     it('Success', async () => {
-      axiosMock.get.mockResolvedValueOnce({ data: chainsResponse });
+      mockNetworkService.get.mockResolvedValueOnce({ data: chainsResponse });
 
       await request(app.getHttpServer())
         .get('/chains')
@@ -49,14 +49,14 @@ describe('Chains Controller (Unit)', () => {
           })),
         });
 
-      expect(axiosMock.get).toBeCalledTimes(1);
-      expect(axiosMock.get).toBeCalledWith(
+      expect(mockNetworkService.get).toBeCalledTimes(1);
+      expect(mockNetworkService.get).toBeCalledWith(
         expect.stringContaining('/api/v1/chains'),
       );
     });
 
     it('Failure', async () => {
-      axiosMock.get.mockRejectedValueOnce({
+      mockNetworkService.get.mockRejectedValueOnce({
         status: HttpStatus.INTERNAL_SERVER_ERROR,
       });
 
@@ -68,8 +68,8 @@ describe('Chains Controller (Unit)', () => {
           code: HttpStatus.SERVICE_UNAVAILABLE,
         });
 
-      expect(axiosMock.get).toBeCalledTimes(1);
-      expect(axiosMock.get).toBeCalledWith(
+      expect(mockNetworkService.get).toBeCalledTimes(1);
+      expect(mockNetworkService.get).toBeCalledWith(
         expect.stringContaining('/api/v1/chains'),
       );
     });
@@ -77,27 +77,29 @@ describe('Chains Controller (Unit)', () => {
 
   describe('GET /:chainId/about/backbone', () => {
     it('Success', async () => {
-      axiosMock.get.mockResolvedValueOnce({ data: chainResponse });
-      axiosMock.get.mockResolvedValueOnce({ data: backboneResponse });
+      mockNetworkService.get.mockResolvedValueOnce({ data: chainResponse });
+      mockNetworkService.get.mockResolvedValueOnce({ data: backboneResponse });
 
       await request(app.getHttpServer())
         .get('/chains/1/about/backbone')
         .expect(HttpStatus.OK)
         .expect(backboneResponse);
 
-      expect(axiosMock.get).toBeCalledTimes(2);
-      expect(axiosMock.get).toHaveBeenNthCalledWith(
+      expect(mockNetworkService.get).toBeCalledTimes(2);
+      expect(mockNetworkService.get).toHaveBeenNthCalledWith(
         1,
         expect.stringContaining('/api/v1/chains/1'),
       );
-      expect(axiosMock.get).toHaveBeenNthCalledWith(
+      expect(mockNetworkService.get).toHaveBeenNthCalledWith(
         2,
         expect.stringContaining('/api/v1/about'),
       );
     });
 
     it('Failure getting the chain', async () => {
-      axiosMock.get.mockRejectedValueOnce({ status: HttpStatus.BAD_REQUEST });
+      mockNetworkService.get.mockRejectedValueOnce({
+        status: HttpStatus.BAD_REQUEST,
+      });
 
       await request(app.getHttpServer())
         .get('/chains/1/about/backbone')
@@ -107,15 +109,17 @@ describe('Chains Controller (Unit)', () => {
           code: HttpStatus.SERVICE_UNAVAILABLE,
         });
 
-      expect(axiosMock.get).toBeCalledTimes(1);
-      expect(axiosMock.get).toBeCalledWith(
+      expect(mockNetworkService.get).toBeCalledTimes(1);
+      expect(mockNetworkService.get).toBeCalledWith(
         expect.stringContaining('/api/v1/chains/1'),
       );
     });
 
     it('Failure getting the backbone data', async () => {
-      axiosMock.get.mockResolvedValueOnce({ data: chainResponse });
-      axiosMock.get.mockRejectedValueOnce({ status: HttpStatus.BAD_GATEWAY });
+      mockNetworkService.get.mockResolvedValueOnce({ data: chainResponse });
+      mockNetworkService.get.mockRejectedValueOnce({
+        status: HttpStatus.BAD_GATEWAY,
+      });
 
       await request(app.getHttpServer())
         .get('/chains/1/about/backbone')
@@ -125,12 +129,12 @@ describe('Chains Controller (Unit)', () => {
           code: HttpStatus.SERVICE_UNAVAILABLE,
         });
 
-      expect(axiosMock.get).toBeCalledTimes(2);
-      expect(axiosMock.get).toHaveBeenNthCalledWith(
+      expect(mockNetworkService.get).toBeCalledTimes(2);
+      expect(mockNetworkService.get).toHaveBeenNthCalledWith(
         1,
         expect.stringContaining('/api/v1/chains/1'),
       );
-      expect(axiosMock.get).toHaveBeenNthCalledWith(
+      expect(mockNetworkService.get).toHaveBeenNthCalledWith(
         2,
         expect.stringContaining('/api/v1/about'),
       );

--- a/src/common/network/__tests__/TestNetworkModule.ts
+++ b/src/common/network/__tests__/TestNetworkModule.ts
@@ -1,0 +1,31 @@
+import { Global, Module } from '@nestjs/common';
+import { NetworkService, INetworkService } from '../network.service.interface';
+
+const networkService: INetworkService = {
+  get: jest.fn(),
+};
+
+/**
+ * Mocked Network interface which can be used in a testing scenario
+ * to mock any external HTTP call made as long as it is done with
+ * the {@link NetworkService}
+ * @type {jest.Mocked}
+ */
+export const mockNetworkService = jest.mocked(networkService);
+
+/**
+ * The {@link TestNetworkModule} should be used whenever a mocked HTTP client
+ * should be used.
+ *
+ * Example:
+ * Test.createTestingModule({ imports: [ModuleA, TestNetworkModule]}).compile();
+ *
+ * This will create a TestModule which uses the implementation of ModuleA but
+ * overrides the real HTTP client with a mocked one – {@link mockNetworkService}
+ */
+@Global()
+@Module({
+  providers: [{ provide: NetworkService, useValue: mockNetworkService }],
+  exports: [NetworkService],
+})
+export class TestNetworkModule {}

--- a/src/common/network/axios.network.service.ts
+++ b/src/common/network/axios.network.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { INetworkService } from './network.service.interface';
+import { NetworkResponse } from './entities/network.response.entity';
+import { NetworkRequest } from './entities/network.request.entity';
+
+/**
+ * A {@link INetworkService} which uses Axios as the main HTTP client
+ */
+@Injectable()
+export class AxiosNetworkService implements INetworkService {
+  constructor(private readonly httpService: HttpService) {}
+
+  async get<T = any, R = NetworkResponse<T>>(
+    url: string,
+    config?: NetworkRequest,
+  ): Promise<R> {
+    return this.httpService.axiosRef.get(url, config);
+  }
+}

--- a/src/common/network/entities/network.request.entity.ts
+++ b/src/common/network/entities/network.request.entity.ts
@@ -1,0 +1,3 @@
+export interface NetworkRequest {
+  params?: any;
+}

--- a/src/common/network/entities/network.response.entity.ts
+++ b/src/common/network/entities/network.response.entity.ts
@@ -1,0 +1,4 @@
+export interface NetworkResponse<T = any> {
+  data: T;
+  status: number;
+}

--- a/src/common/network/network.module.spec.ts
+++ b/src/common/network/network.module.spec.ts
@@ -1,0 +1,14 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NetworkModule } from './network.module';
+
+describe('NetworkModule', () => {
+  it(`NetworkModule is successfully created`, async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [NetworkModule],
+    }).compile();
+
+    const app = moduleFixture.createNestApplication();
+    await app.init();
+    await app.close();
+  });
+});

--- a/src/common/network/network.module.ts
+++ b/src/common/network/network.module.ts
@@ -1,0 +1,19 @@
+import { Global, Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { AxiosNetworkService } from './axios.network.service';
+import { NetworkService } from './network.service.interface';
+
+/**
+ * A {@link Global} Module which provides HTTP support via {@link NetworkService}
+ * Feature Modules don't need to import this module directly in order to inject
+ * the {@link NetworkService}.
+ *
+ * This module should be included in the "root" application module
+ */
+@Global()
+@Module({
+  imports: [HttpModule],
+  providers: [{ provide: NetworkService, useClass: AxiosNetworkService }],
+  exports: [NetworkService],
+})
+export class NetworkModule {}

--- a/src/common/network/network.service.interface.ts
+++ b/src/common/network/network.service.interface.ts
@@ -1,0 +1,11 @@
+import { NetworkResponse } from './entities/network.response.entity';
+import { NetworkRequest } from './entities/network.request.entity';
+
+export const NetworkService = Symbol('INetworkService');
+
+export interface INetworkService {
+  get<T = any, R = NetworkResponse<T>>(
+    url: string,
+    config?: NetworkRequest,
+  ): Promise<R>;
+}

--- a/src/services/config-service/config-service.module.ts
+++ b/src/services/config-service/config-service.module.ts
@@ -1,4 +1,3 @@
-import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { HttpErrorHandler } from '../errors/http-error-handler';
 import { ConfigService } from './config-service.service';
@@ -7,7 +6,6 @@ import configuration from '../../config/configuration';
 
 @Module({
   imports: [
-    HttpModule,
     ConfigModule.forRoot({
       load: [configuration],
     }),

--- a/src/services/config-service/config-service.service.ts
+++ b/src/services/config-service/config-service.service.ts
@@ -1,9 +1,13 @@
-import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
 import { Page } from './entities/page.entity';
 import { Chain } from './entities/chain.entity';
 import { HttpErrorHandler } from '../errors/http-error-handler';
 import { ConfigService as NestConfigService } from '@nestjs/config';
+import { Inject } from '@nestjs/common';
+import {
+  INetworkService,
+  NetworkService,
+} from '../../common/network/network.service.interface';
 
 @Injectable()
 export class ConfigService {
@@ -11,7 +15,7 @@ export class ConfigService {
 
   constructor(
     private readonly nestConfigService: NestConfigService,
-    private readonly httpService: HttpService,
+    @Inject(NetworkService) private readonly networkService: INetworkService,
     private readonly httpErrorHandler: HttpErrorHandler,
   ) {
     this.baseUri = nestConfigService.getOrThrow<string>('safeConfig.baseUri');
@@ -20,7 +24,7 @@ export class ConfigService {
   async getChains(): Promise<Page<Chain>> {
     try {
       const url = this.baseUri + '/api/v1/chains';
-      const response = await this.httpService.axiosRef.get(url);
+      const response = await this.networkService.get(url);
       return response.data;
     } catch (err) {
       this.httpErrorHandler.handle(err);
@@ -30,7 +34,7 @@ export class ConfigService {
   async getChain(chainId: string): Promise<Chain> {
     try {
       const url = this.baseUri + `/api/v1/chains/${chainId}`;
-      const response = await this.httpService.axiosRef.get(url);
+      const response = await this.networkService.get(url);
       return response.data;
     } catch (err) {
       this.httpErrorHandler.handle(err);

--- a/src/services/exchange/exchange.module.ts
+++ b/src/services/exchange/exchange.module.ts
@@ -1,4 +1,3 @@
-import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import configuration from '../../config/configuration';
@@ -7,7 +6,6 @@ import { ExchangeService } from './exchange.service';
 
 @Module({
   imports: [
-    HttpModule,
     ConfigModule.forRoot({
       load: [configuration],
     }),

--- a/src/services/exchange/exchange.service.ts
+++ b/src/services/exchange/exchange.service.ts
@@ -1,15 +1,22 @@
-import { HttpService } from '@nestjs/axios';
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { HttpErrorHandler } from '../errors/http-error-handler';
 import { ExchangeResult } from './entities/exchange.entity';
+import {
+  INetworkService,
+  NetworkService,
+} from '../../common/network/network.service.interface';
 
 @Injectable()
 export class ExchangeService {
   // TODO can we depend on the base url instead?
   constructor(
     private readonly configService: ConfigService,
-    private readonly httpService: HttpService,
+    @Inject(NetworkService) private readonly networkService: INetworkService,
     private readonly httpErrorHandler: HttpErrorHandler,
   ) {}
 
@@ -38,7 +45,7 @@ export class ExchangeService {
     const apiKey = this.configService.get<string>('exchange.apiKey');
 
     try {
-      const { data } = await this.httpService.axiosRef.get(baseUrl, {
+      const { data } = await this.networkService.get(baseUrl, {
         params: { access_key: apiKey },
       });
       return data;

--- a/src/services/transaction-service/transaction-service.manager.ts
+++ b/src/services/transaction-service/transaction-service.manager.ts
@@ -1,9 +1,12 @@
-import { HttpService } from '@nestjs/axios';
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { HttpErrorHandler } from '../errors/http-error-handler';
 import { Chain } from '../config-service/entities/chain.entity';
 import { ConfigService } from '../config-service/config-service.service';
 import { TransactionService } from './transaction-service.service';
+import {
+  INetworkService,
+  NetworkService,
+} from '../../common/network/network.service.interface';
 
 @Injectable()
 export class TransactionServiceManager {
@@ -12,7 +15,7 @@ export class TransactionServiceManager {
 
   constructor(
     private readonly configService: ConfigService,
-    private readonly httpService: HttpService,
+    @Inject(NetworkService) private readonly networkService: INetworkService,
     private readonly httpErrorHandler: HttpErrorHandler,
   ) {}
 
@@ -27,7 +30,7 @@ export class TransactionServiceManager {
     const chain: Chain = await this.configService.getChain(chainId);
     this.transactionServiceMap[chainId] = new TransactionService(
       chain.transactionService,
-      this.httpService,
+      this.networkService,
       this.httpErrorHandler,
     );
     return this.transactionServiceMap[chainId];

--- a/src/services/transaction-service/transaction-service.module.ts
+++ b/src/services/transaction-service/transaction-service.module.ts
@@ -1,11 +1,10 @@
-import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { ConfigServiceModule } from '../config-service/config-service.module';
 import { HttpErrorHandler } from '../errors/http-error-handler';
 import { TransactionServiceManager } from './transaction-service.manager';
 
 @Module({
-  imports: [ConfigServiceModule, HttpModule],
+  imports: [ConfigServiceModule],
   providers: [TransactionServiceManager, HttpErrorHandler],
   exports: [TransactionServiceManager],
 })

--- a/src/services/transaction-service/transaction-service.service.spec.ts
+++ b/src/services/transaction-service/transaction-service.service.spec.ts
@@ -1,8 +1,8 @@
-import { HttpService } from '@nestjs/axios';
 import { Balance } from './entities/balance.entity';
 import { HttpErrorHandler } from '../errors/http-error-handler';
 import { TransactionService } from './transaction-service.service';
 import { Backbone } from '../../chains/entities';
+import { mockNetworkService } from '../../common/network/__tests__/TestNetworkModule';
 
 const BALANCES: Balance[] = [
   {
@@ -31,10 +31,6 @@ const BACKBONE: Backbone = {
   settings: undefined,
 };
 
-const mockHttpService = {
-  axiosRef: { get: jest.fn() },
-} as unknown as HttpService;
-
 const mockHttpErrorHandler = {
   handle: jest.fn(),
 } as unknown as HttpErrorHandler;
@@ -42,30 +38,26 @@ const mockHttpErrorHandler = {
 describe('TransactionService', () => {
   const service: TransactionService = new TransactionService(
     'baseUrl',
-    mockHttpService,
+    mockNetworkService,
     mockHttpErrorHandler,
   );
 
   it('should return the balances retrieved', async () => {
-    mockHttpService.axiosRef.get = jest
-      .fn()
-      .mockResolvedValue({ data: BALANCES });
+    mockNetworkService.get.mockResolvedValue({ data: BALANCES });
 
     const balances = await service.getBalances('test', true, true);
     expect(balances).toBe(BALANCES);
   });
 
   it('should return the backbone retrieved', async () => {
-    mockHttpService.axiosRef.get = jest
-      .fn()
-      .mockResolvedValueOnce({ data: BACKBONE });
+    mockNetworkService.get.mockResolvedValueOnce({ data: BACKBONE });
 
     const backbone = await service.getBackbone();
     expect(backbone).toBe(BACKBONE);
   });
 
   it('should call error handler when an error happens', async () => {
-    mockHttpService.axiosRef.get = jest.fn().mockImplementationOnce(() => {
+    mockNetworkService.get = jest.fn().mockImplementationOnce(() => {
       throw new Error();
     });
 

--- a/src/services/transaction-service/transaction-service.service.ts
+++ b/src/services/transaction-service/transaction-service.service.ts
@@ -1,12 +1,12 @@
-import { HttpService } from '@nestjs/axios';
 import { Balance } from './entities/balance.entity';
 import { HttpErrorHandler } from '../errors/http-error-handler';
 import { Backbone } from '../../chains/entities';
+import { INetworkService } from '../../common/network/network.service.interface';
 
 export class TransactionService {
   constructor(
     private readonly baseUrl: string,
-    private readonly httpService: HttpService,
+    private readonly networkService: INetworkService,
     private readonly httpErrorHandler: HttpErrorHandler,
   ) {}
 
@@ -17,7 +17,7 @@ export class TransactionService {
   ): Promise<Balance[]> {
     const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/balances/usd/`;
     try {
-      const { data } = await this.httpService.axiosRef.get(url, {
+      const { data } = await this.networkService.get(url, {
         params: { trusted: trusted, excludeSpam: excludeSpam },
       });
       return data;
@@ -29,7 +29,7 @@ export class TransactionService {
   async getBackbone(): Promise<Backbone> {
     const url = `${this.baseUrl}/api/v1/about`;
     try {
-      const { data } = await this.httpService.axiosRef.get(url);
+      const { data } = await this.networkService.get(url);
       return data;
     } catch (err) {
       this.httpErrorHandler.handle(err);


### PR DESCRIPTION
Closes #37

- Adds `INetworkService` – an interface which should be injected in order to perform network related operations. The default implementation provided is `AxiosNetworkService`
- Adds a `NetworkModule` – a Global module which is provided by the `AppModule`. This means that new features can assume that `INetworkService` will be provided by the main application without depending directly on it
- A TestNetworkModule can now be used in the tests where a mock HTTP client is needed