### PR TITLE
Run build step in tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           node-version: '16.x'
           cache: 'yarn'
       - run: yarn install --immutable
+      - run: yarn run build
       - run: yarn run test:cov
       - name: Upload coverage
         uses: coverallsapp/github-action@1.1.3


### PR DESCRIPTION
- The build step should be executed in order to catch files that fail on that step
- The test, linter and formatter steps would most likely catch those, but for the compilation itself we should rely on the build step.