### PR TITLE
Use number instead of bigint

### DIFF
--- a/src/datasources/transaction-api/entities/__tests__/balance.factory.ts
+++ b/src/datasources/transaction-api/entities/__tests__/balance.factory.ts
@@ -10,14 +10,14 @@ export default function factory(size?: number): Balance[] {
 export function balanceFactory(
   tokenAddress?: string,
   token?: BalanceToken,
-  balance?: bigint,
+  balance?: number,
   fiatBalance?: number,
   fiatConversion?: number,
 ): Balance {
   return <Balance>{
     tokenAddress: tokenAddress || faker.finance.ethereumAddress(),
     token: token || balanceTokenFactory(),
-    balance: balance || faker.datatype.bigInt(),
+    balance: balance || faker.datatype.number(),
     fiatBalance: fiatBalance || faker.datatype.number(),
     fiatConversion: fiatConversion || faker.datatype.number(),
   };

--- a/src/datasources/transaction-api/entities/balance.entity.ts
+++ b/src/datasources/transaction-api/entities/balance.entity.ts
@@ -3,7 +3,7 @@ import { BalanceToken } from './balance.token.entity';
 export interface Balance {
   tokenAddress?: string;
   token?: BalanceToken;
-  balance: bigint;
+  balance: number;
   fiatBalance: number;
   fiatConversion: number;
 }

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -7,14 +7,14 @@ import { mockNetworkService } from '../../common/network/__tests__/test.network.
 const BALANCES: Balance[] = [
   {
     tokenAddress: 'tokenAddress1',
-    balance: BigInt(100),
+    balance: 100,
     token: null,
     fiatBalance: 0,
     fiatConversion: 0,
   },
   {
     tokenAddress: 'tokenAddress2',
-    balance: BigInt(100),
+    balance: 100,
     token: null,
     fiatBalance: 0,
     fiatConversion: 0,


### PR DESCRIPTION
- Our current target is `es2017`. BigInt is available on `esnext`
- `number` right now provides what we need (given the current stage of the project)