### PR TITLE
Update base exchange URI

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,5 @@
 # The base Exchange Rate API to be used.
-# (default is http://api.exchangeratesapi.io/latest if none is set)
+# (default is http://api.exchangeratesapi.io/v1 if none is set)
 # The EXCHANGE_API_KEY should always be set
 #EXCHANGE_API_BASE_URI=
 #EXCHANGE_API_KEY=

--- a/src/common/config/entities/configuration.ts
+++ b/src/common/config/entities/configuration.ts
@@ -1,8 +1,7 @@
 export default () => ({
   exchange: {
     baseUri:
-      process.env.EXCHANGE_API_BASE_URI ||
-      'http://api.exchangeratesapi.io/latest',
+      process.env.EXCHANGE_API_BASE_URI || 'http://api.exchangeratesapi.io/v1',
     apiKey: process.env.EXCHANGE_API_KEY,
   },
   safeConfig: {


### PR DESCRIPTION
- Instead of `http://api.exchangeratesapi.io/latest` we should use `http://api.exchangeratesapi.io/v1` if none is set