### PR TITLE
Remove @nestjs/axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "postinstall": "husky install"
   },
   "dependencies": {
-    "@nestjs/axios": "^0.1.0",
     "@nestjs/common": "^9.0.0",
     "@nestjs/config": "^2.2.0",
     "@nestjs/core": "^9.0.0",
@@ -73,7 +72,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "coveragePathIgnorePatterns": ["index.ts"],
+    "coveragePathIgnorePatterns": [
+      "index.ts"
+    ],
     "testEnvironment": "node"
   },
   "main": "main.ts",

--- a/src/common/network/axios.network.service.spec.ts
+++ b/src/common/network/axios.network.service.spec.ts
@@ -1,26 +1,21 @@
 import { AxiosNetworkService } from './axios.network.service';
-import { AxiosInstance } from 'axios';
-import { HttpService } from '@nestjs/axios';
+import { Axios } from 'axios';
 import { faker } from '@faker-js/faker';
 import { NetworkRequest } from './entities/network.request.entity';
 import { jest } from '@jest/globals';
 
-const axiosRef = {
+const axios = {
   get: jest.fn(),
-} as unknown as AxiosInstance;
+} as unknown as Axios;
 
-const httpService = {
-  axiosRef: axiosRef,
-} as unknown as HttpService;
-const httpServiceMock = jest.mocked<HttpService>(httpService);
-const axiosRefMock = jest.mocked<AxiosInstance>(httpServiceMock.axiosRef);
+const axiosMock = jest.mocked<Axios>(axios);
 
 describe('AxiosNetworkService', () => {
   let target: AxiosNetworkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    target = new AxiosNetworkService(httpServiceMock);
+    target = new AxiosNetworkService(axiosMock);
   });
 
   it(`get calls axios get`, async () => {
@@ -28,8 +23,8 @@ describe('AxiosNetworkService', () => {
 
     await target.get(url);
 
-    expect(axiosRefMock.get).toBeCalledTimes(1);
-    expect(axiosRefMock.get).toBeCalledWith(url, undefined);
+    expect(axiosMock.get).toBeCalledTimes(1);
+    expect(axiosMock.get).toBeCalledWith(url, undefined);
   });
 
   it(`get calls axios get with request`, async () => {
@@ -40,17 +35,17 @@ describe('AxiosNetworkService', () => {
 
     await target.get(url, request);
 
-    expect(axiosRefMock.get).toBeCalledTimes(1);
-    expect(axiosRefMock.get).toBeCalledWith(url, request);
+    expect(axiosMock.get).toBeCalledTimes(1);
+    expect(axiosMock.get).toBeCalledWith(url, request);
   });
 
   it(`get forwards error`, async () => {
     const url = faker.internet.url();
-    (axiosRefMock.get as any).mockRejectedValueOnce(new Error('Axios error'));
+    (axiosMock.get as any).mockRejectedValueOnce(new Error('Axios error'));
 
     await expect(target.get(url)).rejects.toThrow('Axios error');
 
-    expect(axiosRefMock.get).toBeCalledTimes(1);
-    expect(axiosRefMock.get).toBeCalledWith(url, undefined);
+    expect(axiosMock.get).toBeCalledTimes(1);
+    expect(axiosMock.get).toBeCalledWith(url, undefined);
   });
 });

--- a/src/common/network/axios.network.service.ts
+++ b/src/common/network/axios.network.service.ts
@@ -1,20 +1,20 @@
-import { Injectable } from '@nestjs/common';
-import { HttpService } from '@nestjs/axios';
+import { Inject, Injectable } from '@nestjs/common';
 import { INetworkService } from './network.service.interface';
 import { NetworkResponse } from './entities/network.response.entity';
 import { NetworkRequest } from './entities/network.request.entity';
+import { Axios } from 'axios';
 
 /**
  * A {@link INetworkService} which uses Axios as the main HTTP client
  */
 @Injectable()
 export class AxiosNetworkService implements INetworkService {
-  constructor(private readonly httpService: HttpService) {}
+  constructor(@Inject('AxiosClient') private readonly client: Axios) {}
 
   async get<T = any, R = NetworkResponse<T>>(
     url: string,
     config?: NetworkRequest,
   ): Promise<R> {
-    return this.httpService.axiosRef.get(url, config);
+    return this.client.get(url, config);
   }
 }

--- a/src/common/network/network.module.ts
+++ b/src/common/network/network.module.ts
@@ -1,7 +1,15 @@
 import { Global, Module } from '@nestjs/common';
-import { HttpModule } from '@nestjs/axios';
 import { AxiosNetworkService } from './axios.network.service';
 import { NetworkService } from './network.service.interface';
+import axios, { Axios } from 'axios';
+
+/**
+ * Use this factory to add any default parameter to the
+ * {@link Axios} instance
+ */
+function axiosFactory(): Axios {
+  return axios.create();
+}
 
 /**
  * A {@link Global} Module which provides HTTP support via {@link NetworkService}
@@ -12,8 +20,10 @@ import { NetworkService } from './network.service.interface';
  */
 @Global()
 @Module({
-  imports: [HttpModule],
-  providers: [{ provide: NetworkService, useClass: AxiosNetworkService }],
+  providers: [
+    { provide: 'AxiosClient', useFactory: axiosFactory },
+    { provide: NetworkService, useClass: AxiosNetworkService },
+  ],
   exports: [NetworkService],
 })
 export class NetworkModule {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -849,19 +849,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nestjs/axios@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@nestjs/axios@npm:0.1.0"
-  dependencies:
-    axios: 0.27.2
-  peerDependencies:
-    "@nestjs/common": ^7.0.0 || ^8.0.0 || ^9.0.0
-    reflect-metadata: ^0.1.12
-    rxjs: ^6.0.0 || ^7.0.0
-  checksum: 72929b25caacb85517bae962b13d865a31aa3984aa9e55305e0a2306e54338fe51a7eb38ca38cab0fe8b4116fb35219bd02c8b0c4cac70e7b5aeb84d03a1db3f
-  languageName: node
-  linkType: hard
-
 "@nestjs/cli@npm:^9.0.0":
   version: 9.0.0
   resolution: "@nestjs/cli@npm:9.0.0"
@@ -1959,7 +1946,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:0.27.2, axios@npm:^0.27.2":
+"axios@npm:^0.27.2":
   version: 0.27.2
   resolution: "axios@npm:0.27.2"
   dependencies:
@@ -5790,7 +5777,6 @@ __metadata:
   resolution: "safe-client-gateway@workspace:."
   dependencies:
     "@faker-js/faker": ^7.4.0
-    "@nestjs/axios": ^0.1.0
     "@nestjs/cli": ^9.0.0
     "@nestjs/common": ^9.0.0
     "@nestjs/config": ^2.2.0


### PR DESCRIPTION
- Removes @nestjs/axios and adds uses Axios directly
- We are not currently using any feature from the HttpModule of NestJS