### PR TITLE
Add support for cursor pagination

### DIFF
--- a/src/chains/chains.controller.spec.ts
+++ b/src/chains/chains.controller.spec.ts
@@ -76,7 +76,7 @@ describe('Chains Controller (Unit)', () => {
       expect(mockNetworkService.get).toBeCalledTimes(1);
       expect(mockNetworkService.get).toBeCalledWith(
         'https://test.safe.config/api/v1/chains',
-        undefined,
+        { params: { limit: undefined, offset: undefined } },
       );
     });
 
@@ -93,7 +93,7 @@ describe('Chains Controller (Unit)', () => {
       expect(mockNetworkService.get).toBeCalledTimes(1);
       expect(mockNetworkService.get).toBeCalledWith(
         'https://test.safe.config/api/v1/chains',
-        undefined,
+        { params: { limit: undefined, offset: undefined } },
       );
     });
   });

--- a/src/chains/chains.controller.ts
+++ b/src/chains/chains.controller.ts
@@ -1,6 +1,9 @@
 import { Controller, Get, Param } from '@nestjs/common';
 import { ChainsService } from './chains.service';
 import { Backbone, Chain, Page } from './entities';
+import { PaginationData } from '../common/pagination/pagination.data';
+import { RouteUrlDecorator } from '../common/decorators/route.url.decorator';
+import { PaginationDataDecorator } from '../common/decorators/pagination.data.decorator';
 
 @Controller({
   path: 'chains',
@@ -10,8 +13,11 @@ export class ChainsController {
   constructor(private readonly chainsService: ChainsService) {}
 
   @Get()
-  async getChains(): Promise<Page<Chain>> {
-    return this.chainsService.getChains();
+  async getChains(
+    @RouteUrlDecorator() routeUrl: URL,
+    @PaginationDataDecorator() paginationData?: PaginationData,
+  ): Promise<Page<Chain>> {
+    return this.chainsService.getChains(routeUrl, paginationData);
   }
 
   @Get('/:chainId/about/backbone')

--- a/src/common/decorators/pagination.data.decorator.spec.ts
+++ b/src/common/decorators/pagination.data.decorator.spec.ts
@@ -1,0 +1,55 @@
+import { PaginationDataDecorator } from './pagination.data.decorator';
+import { PaginationData } from '../pagination/pagination.data';
+import { Controller, Get, INestApplication, Module } from '@nestjs/common';
+import { fakeCacheService } from '../cache/__tests__/test.cache.module';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+
+describe('PaginationDataDecorator', () => {
+  let app: INestApplication;
+  let paginationData;
+
+  @Controller()
+  class TestController {
+    @Get()
+    route(@PaginationDataDecorator() data?: PaginationData) {
+      paginationData = data;
+      return;
+    }
+  }
+
+  @Module({ controllers: [TestController] })
+  class TestModule {}
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    fakeCacheService.clear();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [TestModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  it('no cursor', async () => {
+    await request(app.getHttpServer())
+      .get('')
+      .query('some_param=test')
+      .expect(200);
+
+    expect(paginationData.limit).toBe(undefined);
+    expect(paginationData.offset).toBe(undefined);
+  });
+
+  it('with cursor', async () => {
+    await request(app.getHttpServer())
+      .get('')
+      .query('cursor=limit%3D1%26offset%3D0')
+      .expect(200);
+
+    expect(paginationData.limit).toBe(1);
+    expect(paginationData.offset).toBe(0);
+  });
+});

--- a/src/common/decorators/pagination.data.decorator.ts
+++ b/src/common/decorators/pagination.data.decorator.ts
@@ -1,0 +1,16 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { PaginationData } from '../pagination/pagination.data';
+import { getRouteUrl } from './utils';
+
+/**
+ * Route decorator which parses {@link PaginationData} from a
+ * cursor query.
+ *
+ * If the cursor does not exist or is invalid null is returned instead
+ */
+export const PaginationDataDecorator = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): PaginationData | null => {
+    const request = ctx.switchToHttp().getRequest();
+    return PaginationData.fromCursor(getRouteUrl(request));
+  },
+);

--- a/src/common/decorators/route.url.decorator.ts
+++ b/src/common/decorators/route.url.decorator.ts
@@ -1,0 +1,13 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { getRouteUrl } from './utils';
+
+/**
+ * Route decorator which extracts the resulting
+ * route {@link URL}
+ */
+export const RouteUrlDecorator = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): URL => {
+    const request = ctx.switchToHttp().getRequest();
+    return getRouteUrl(request);
+  },
+);

--- a/src/common/decorators/utils.ts
+++ b/src/common/decorators/utils.ts
@@ -1,0 +1,5 @@
+export function getRouteUrl(request: any) {
+  return new URL(
+    `${request.protocol}://${request.get('Host')}${request.originalUrl}`,
+  );
+}

--- a/src/common/pagination/pagination.data.spec.ts
+++ b/src/common/pagination/pagination.data.spec.ts
@@ -1,0 +1,154 @@
+import { cursorUrlFromLimitAndOffset, PaginationData } from './pagination.data';
+
+describe('PaginationData', () => {
+  describe('fromCursor', () => {
+    it('url with cursor, limit and offset', async () => {
+      const url = new URL('https://safe.global/?cursor=limit%3D1%26offset%3D2');
+
+      const actual = PaginationData.fromCursor(url);
+
+      expect(actual.limit).toBe(1);
+      expect(actual.offset).toBe(2);
+    });
+
+    it('url with cursor, limit but no offset', async () => {
+      const url = new URL('https://safe.global/?cursor=limit%3D1%26');
+
+      const actual = PaginationData.fromCursor(url);
+
+      expect(actual.limit).toBe(1);
+      expect(actual.offset).toBe(undefined);
+    });
+
+    it('url with cursor, offset but no limit', async () => {
+      const url = new URL('https://safe.global/?cursor=offset%3D1%26');
+
+      const actual = PaginationData.fromCursor(url);
+
+      expect(actual.limit).toBe(undefined);
+      expect(actual.offset).toBe(1);
+    });
+
+    it('url with no cursor', async () => {
+      const url = new URL('https://safe.global/?another_query=offset%3D1%26');
+
+      const actual = PaginationData.fromCursor(url);
+
+      expect(actual.limit).toBe(undefined);
+      expect(actual.offset).toBe(undefined);
+    });
+
+    it('limit is not a number', async () => {
+      const url = new URL(
+        'https://safe.global/?cursor=limit%3Daa%26offset%3D2',
+      );
+
+      const actual = PaginationData.fromCursor(url);
+
+      expect(actual.limit).toBe(undefined);
+      expect(actual.offset).toBe(2);
+    });
+
+    it('offset is not a number', async () => {
+      const url = new URL(
+        'https://safe.global/?cursor=limit%3D1%26offset%3Daa',
+      );
+
+      const actual = PaginationData.fromCursor(url);
+
+      expect(actual.limit).toBe(1);
+      expect(actual.offset).toBe(undefined);
+    });
+  });
+
+  describe('fromLimitAndOffset', () => {
+    it('url with limit and offset', async () => {
+      const url = new URL('https://safe.global/?limit=10&offset=20');
+
+      const actual = PaginationData.fromLimitAndOffset(url);
+
+      expect(actual.limit).toBe(10);
+      expect(actual.offset).toBe(20);
+    });
+
+    it('url with limit but no offset', async () => {
+      const url = new URL('https://safe.global/?limit=10');
+
+      const actual = PaginationData.fromLimitAndOffset(url);
+
+      expect(actual.limit).toBe(10);
+      expect(actual.offset).toBe(undefined);
+    });
+
+    it('url with offset but no limit', async () => {
+      const url = new URL('https://safe.global/?offset=20');
+
+      const actual = PaginationData.fromLimitAndOffset(url);
+
+      expect(actual.limit).toBe(undefined);
+      expect(actual.offset).toBe(20);
+    });
+
+    it('url with neither limit no offset', async () => {
+      const url = new URL('https://safe.global/?another_query=test');
+
+      const actual = PaginationData.fromLimitAndOffset(url);
+
+      expect(actual.limit).toBe(undefined);
+      expect(actual.offset).toBe(undefined);
+    });
+
+    it('limit is not a number', async () => {
+      const url = new URL('https://safe.global/?limit=aa&offset=20');
+
+      const actual = PaginationData.fromLimitAndOffset(url);
+
+      expect(actual.limit).toBe(undefined);
+      expect(actual.offset).toBe(20);
+    });
+
+    it('offset is not a number', async () => {
+      const url = new URL('https://safe.global/?limit=10&offset=aa');
+
+      const actual = PaginationData.fromLimitAndOffset(url);
+
+      expect(actual.limit).toBe(10);
+      expect(actual.offset).toBe(undefined);
+    });
+  });
+
+  describe('cursorUrlFromLimitAndOffset', () => {
+    it('url is generated correctly', async () => {
+      const fromUrl = 'https://safe.global/?limit=10&offset=2';
+      const baseUrl = 'https://base.url/';
+
+      const actual = cursorUrlFromLimitAndOffset(baseUrl, fromUrl);
+
+      const expected = new URL(
+        'https://base.url/?cursor=limit%3D10%26offset%3D2',
+      );
+      expect(actual).toStrictEqual(expected);
+    });
+
+    it('cursor is updated', async () => {
+      const fromUrl = 'https://safe.global/?limit=10&offset=2';
+      // base url has limit=0 and offset=1
+      const baseUrl = 'https://base.url/?cursor=limit%3D0%26offset%3D1';
+
+      const actual = cursorUrlFromLimitAndOffset(baseUrl, fromUrl);
+
+      const expected = new URL(
+        'https://base.url/?cursor=limit%3D10%26offset%3D2',
+      );
+      expect(actual).toStrictEqual(expected);
+    });
+
+    it('returns undefined when from is undefined', async () => {
+      const baseUrl = 'https://base.url/';
+
+      const actual = cursorUrlFromLimitAndOffset(baseUrl, undefined);
+
+      expect(actual).toStrictEqual(null);
+    });
+  });
+});

--- a/src/common/pagination/pagination.data.ts
+++ b/src/common/pagination/pagination.data.ts
@@ -1,0 +1,88 @@
+const QUERY_PARAM_CURSOR = 'cursor';
+const QUERY_PARAM_LIMIT = 'limit';
+const QUERY_PARAM_OFFSET = 'offset';
+
+export class PaginationData {
+  private constructor(readonly limit?: number, readonly offset?: number) {}
+
+  /**
+   * Extracts {@link PaginationData} from {@link url}. The url
+   * must have a cursor query parameter to be extracted.
+   *
+   * This function should never fail. If the format is not the one
+   * expected it assumes that the respective pagination data does
+   * not exist
+   *
+   * @param url - url which contains the cursor query param
+   */
+  static fromCursor(url: Readonly<URL>): PaginationData {
+    // If we don't have a cursor, assume no pagination data
+    const cursorValue = url.searchParams.get(QUERY_PARAM_CURSOR) ?? '';
+    const cursorSearchParams = new URLSearchParams(cursorValue);
+    const limit = Number(cursorSearchParams.get(QUERY_PARAM_LIMIT) ?? NaN);
+    const offset = Number(cursorSearchParams.get(QUERY_PARAM_OFFSET) ?? NaN);
+
+    return new PaginationData(
+      isNaN(limit) ? undefined : limit,
+      isNaN(offset) ? undefined : offset,
+    );
+  }
+
+  /**
+   * Extracts {@link PaginationData} from {@link url}. The url
+   * must have a limit and/or offset query parameter(s) to be extracted.
+   *
+   * This function should never fail. If the format is not the one
+   * expected it assumes that the respective pagination data does
+   * not exist
+   *
+   * @param url - url which contains the limit and/or offset query param(s)
+   */
+  static fromLimitAndOffset(url: Readonly<URL>): PaginationData {
+    const limit = Number(url.searchParams.get(QUERY_PARAM_LIMIT) ?? NaN);
+    const offset = Number(url.searchParams.get(QUERY_PARAM_OFFSET) ?? NaN);
+    return new PaginationData(
+      isNaN(limit) ? undefined : limit,
+      isNaN(offset) ? undefined : offset,
+    );
+  }
+}
+
+/**
+ * Returns a URL with a cursor parameter added with the
+ * pagination data from the {@link from} url
+ *
+ * This is useful whenever we want to map a pagination url (from)
+ * to one of the Client Gateway (base)
+ *
+ * @param base - The base url which should serve as reference
+ * @param from - The url from where to extract the pagination data from
+ */
+export function cursorUrlFromLimitAndOffset(
+  base: Readonly<URL | string>,
+  from: Readonly<URL | string | undefined>,
+): Readonly<URL> | null {
+  if (from == null) return null;
+  const fromUrl = new URL(from);
+  const paginationData = PaginationData.fromLimitAndOffset(fromUrl);
+  return setCursor(base, paginationData);
+}
+
+/**
+ * Returns a new {@link URL} with the cursor query parameter updated
+ * with the data from {@link paginationData}
+ *
+ * If {@link url} does not have a cursor query param, it will be added
+ *
+ * @param url
+ * @param paginationData
+ */
+function setCursor(
+  url: Readonly<URL | string>,
+  paginationData: PaginationData,
+): URL {
+  const modifiedURL = new URL(url);
+  const cursorData = `${QUERY_PARAM_LIMIT}=${paginationData.limit}&${QUERY_PARAM_OFFSET}=${paginationData.offset}`;
+  modifiedURL.searchParams.set(QUERY_PARAM_CURSOR, cursorData);
+  return modifiedURL;
+}

--- a/src/datasources/config-api/config-api.service.ts
+++ b/src/datasources/config-api/config-api.service.ts
@@ -1,7 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { Page } from './entities/page.entity';
 import { Chain } from './entities/chain.entity';
-import { Inject } from '@nestjs/common';
 import { IConfigurationService } from '../../common/config/configuration.service.interface';
 import { CacheFirstDataSource } from '../cache/cache.first.data.source';
 
@@ -23,8 +22,8 @@ export class ConfigApi {
     const url = this.baseUri + '/api/v1/chains';
     return await this.dataSource.get(key, url, {
       params: {
-        limit: limit,
-        offset: offset,
+        limit,
+        offset,
       },
     });
   }

--- a/src/datasources/config-api/config-api.service.ts
+++ b/src/datasources/config-api/config-api.service.ts
@@ -18,10 +18,15 @@ export class ConfigApi {
       this.configurationService.getOrThrow<string>('safeConfig.baseUri');
   }
 
-  async getChains(): Promise<Page<Chain>> {
-    const key = 'chains'; // TODO key is not final
+  async getChains(limit?: number, offset?: number): Promise<Page<Chain>> {
+    const key = `chains-limit=${limit}-offset=${offset}`; // TODO key is not final
     const url = this.baseUri + '/api/v1/chains';
-    return await this.dataSource.get(key, url);
+    return await this.dataSource.get(key, url, {
+      params: {
+        limit: limit,
+        offset: offset,
+      },
+    });
   }
 
   async getChain(chainId: string): Promise<Chain> {


### PR DESCRIPTION
Closes #62

- Adds two decorators: `@RouteUrlDecorator` and `@PaginationDataDecorator`
  * `@RouteUrlDecorator` can be used to get the route URL (with query parameters)
  * `@PaginationDataDecorator` can be used to retrieve the pagination data associated with a `cursor` query param
- We have two ways of representing pagination data:
  * With `limit&offset` – this is mostly used by the Safe Config Service and Safe Transaction Service. `PaginationData` can be retrieved from these URLs with `PaginationData.fromLimitAndOffset`
  * With `cursor` – this is mostly used by the Safe Client Gateway. It encodes the `limit&offset` which can be forwarded to the other services. `PaginationData` can be retrieved from these URLs with `PaginationData.fromCursor`