### PR TITLE
Remove TODO from ExchangeApi

### DIFF
--- a/src/datasources/exchange-api/exchange-api.service.ts
+++ b/src/datasources/exchange-api/exchange-api.service.ts
@@ -19,8 +19,6 @@ import { exchangeResultSchema } from './entities/schemas/exchange-result.schema'
 
 @Injectable()
 export class ExchangeApi implements IExchangeApi {
-  // TODO can we depend on the base url instead?
-
   private readonly baseUrl: string;
   private readonly apiKey: string;
   private readonly isValidExchangeResult: ValidateFunction<ExchangeResult>;


### PR DESCRIPTION
As agreed on https://github.com/5afe/safe-client-gateway-nest/pull/80, we will continue injecting `IConfigurationService` (ie.: we will not inject the `BASE_URL` in the constructor) 