### PR TITLE
Add swagger

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@nestjs/config": "^2.2.0",
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
+    "@nestjs/swagger": "^6.1.2",
     "@node-redis/json": "^1.0.2",
     "ajv": "^8.11.0",
     "axios": "^0.27.2",

--- a/src/common/openapi/api-token-info.ts
+++ b/src/common/openapi/api-token-info.ts
@@ -1,0 +1,18 @@
+import { TokenInfo as DomainTokenInfo } from '../entities/token-info.entity';
+import { ApiProperty } from '@nestjs/swagger';
+import { TokenType } from '../entities/token-type.entity';
+
+export class TokenInfo implements DomainTokenInfo {
+  @ApiProperty()
+  address: string;
+  @ApiProperty()
+  decimals: number;
+  @ApiProperty()
+  logoUri: string;
+  @ApiProperty()
+  name: string;
+  @ApiProperty()
+  symbol: string;
+  @ApiProperty({ enum: Object.values(TokenType) })
+  tokenType: TokenType;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { VersioningType } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -11,6 +12,15 @@ async function bootstrap() {
   // Starts listening for shutdown hooks
   app.enableShutdownHooks();
 
+  const config = new DocumentBuilder()
+    .setTitle('Safe Client Gateway')
+    .setVersion(process.env.npm_package_version ?? '')
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('', app, document);
+
   await app.listen(3000);
 }
+
 bootstrap();

--- a/src/routes/balances/balances.controller.ts
+++ b/src/routes/balances/balances.controller.ts
@@ -1,7 +1,10 @@
 import { Controller, Get, Param } from '@nestjs/common';
 import { BalancesService } from './balances.service';
 import { Balances } from './entities/balances.entity';
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { Balances as ApiBalances } from './openapi/api-balances';
 
+@ApiTags('balances')
 @Controller({
   path: '',
   version: '1',
@@ -9,6 +12,7 @@ import { Balances } from './entities/balances.entity';
 export class BalancesController {
   constructor(private readonly balancesService: BalancesService) {}
 
+  @ApiOkResponse({ type: ApiBalances })
   @Get('chains/:chainId/safes/:safeAddress/balances/:fiatCode')
   async getBalances(
     @Param('chainId') chainId: string,

--- a/src/routes/balances/openapi/api-balance.ts
+++ b/src/routes/balances/openapi/api-balance.ts
@@ -1,0 +1,14 @@
+import { Balance as DomainBalance } from '../entities/balance.entity';
+import { ApiProperty } from '@nestjs/swagger';
+import { TokenInfo as ApiTokenInfo } from '../../../common/openapi/api-token-info';
+
+export class Balance implements DomainBalance {
+  @ApiProperty()
+  balance: string;
+  @ApiProperty()
+  fiatBalance: number;
+  @ApiProperty()
+  fiatConversion: number;
+  @ApiProperty()
+  tokenInfo: ApiTokenInfo;
+}

--- a/src/routes/balances/openapi/api-balances.ts
+++ b/src/routes/balances/openapi/api-balances.ts
@@ -1,0 +1,11 @@
+import { Balances as DomainBalances } from '../entities/balances.entity';
+import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
+import { Balance as ApiBalance } from './api-balance';
+
+@ApiExtraModels(ApiBalance)
+export class Balances implements DomainBalances {
+  @ApiProperty()
+  fiatTotal: number;
+  @ApiProperty({ type: 'array', oneOf: [{ $ref: getSchemaPath(ApiBalance) }] })
+  items: ApiBalance[];
+}

--- a/src/routes/chains/chains.controller.ts
+++ b/src/routes/chains/chains.controller.ts
@@ -6,7 +6,11 @@ import { RouteUrlDecorator } from '../../common/decorators/route.url.decorator';
 import { PaginationDataDecorator } from '../../common/decorators/pagination.data.decorator';
 import { Backbone } from '../../domain/backbone/entities/backbone.entity';
 import { Chain } from '../../domain/chains/entities/chain.entity';
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { Backbone as ApiBackbone } from './openapi/api-backbone';
+import { Page as ApiPage } from './openapi/api-chain-page';
 
+@ApiTags('chains')
 @Controller({
   path: 'chains',
   version: '1',
@@ -14,6 +18,7 @@ import { Chain } from '../../domain/chains/entities/chain.entity';
 export class ChainsController {
   constructor(private readonly chainsService: ChainsService) {}
 
+  @ApiOkResponse({ type: ApiPage })
   @Get()
   async getChains(
     @RouteUrlDecorator() routeUrl: URL,
@@ -22,6 +27,7 @@ export class ChainsController {
     return this.chainsService.getChains(routeUrl, paginationData);
   }
 
+  @ApiOkResponse({ type: ApiBackbone })
   @Get('/:chainId/about/backbone')
   async getBackbone(@Param('chainId') chainId: string): Promise<Backbone> {
     return this.chainsService.getBackbone(chainId);

--- a/src/routes/chains/openapi/api-backbone.ts
+++ b/src/routes/chains/openapi/api-backbone.ts
@@ -1,0 +1,19 @@
+import { Backbone as DomainBackbone } from '../../../domain/backbone/entities/backbone.entity';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class Backbone implements DomainBackbone {
+  @ApiProperty()
+  api_version: string;
+  @ApiProperty()
+  headers: string[];
+  @ApiProperty()
+  host: string;
+  @ApiProperty()
+  name: string;
+  @ApiProperty()
+  secure: boolean;
+  @ApiProperty()
+  settings: object;
+  @ApiProperty()
+  version: string;
+}

--- a/src/routes/chains/openapi/api-chain-page.ts
+++ b/src/routes/chains/openapi/api-chain-page.ts
@@ -1,0 +1,16 @@
+import { Page as DomainPage } from '../../../common/entities/page.entity';
+import { ApiProperty } from '@nestjs/swagger';
+import { Chain as ApiChain } from './api-chain';
+
+export class Page implements DomainPage<ApiChain> {
+  @ApiProperty()
+  count: number;
+  @ApiProperty()
+  next: string;
+  @ApiProperty()
+  previous: string;
+  @ApiProperty({
+    type: ApiChain,
+  })
+  results: ApiChain[];
+}

--- a/src/routes/chains/openapi/api-chain.ts
+++ b/src/routes/chains/openapi/api-chain.ts
@@ -1,0 +1,16 @@
+import { Chain as DomainChain } from '../../../domain/chains/entities/chain.entity';
+import { ApiProperty } from '@nestjs/swagger';
+import { NativeCurrency as ApiNativeCurrency } from './api-native-currency';
+
+export class Chain implements DomainChain {
+  @ApiProperty()
+  chainId: string;
+  @ApiProperty()
+  chainName: string;
+  @ApiProperty()
+  nativeCurrency: ApiNativeCurrency;
+  @ApiProperty()
+  transactionService: string;
+  @ApiProperty()
+  vpcTransactionService: string;
+}

--- a/src/routes/chains/openapi/api-native-currency.ts
+++ b/src/routes/chains/openapi/api-native-currency.ts
@@ -1,0 +1,13 @@
+import { NativeCurrency as DomainNativeCurrency } from '../../../domain/chains/entities/native.currency.entity';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class NativeCurrency implements DomainNativeCurrency {
+  @ApiProperty()
+  decimals: number;
+  @ApiProperty()
+  logoUri: string;
+  @ApiProperty()
+  name: string;
+  @ApiProperty()
+  symbol: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -950,6 +950,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nestjs/mapped-types@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@nestjs/mapped-types@npm:1.1.0"
+  peerDependencies:
+    "@nestjs/common": ^7.0.8 || ^8.0.0 || ^9.0.0
+    class-transformer: ^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0
+    class-validator: ^0.11.1 || ^0.12.0 || ^0.13.0
+    reflect-metadata: ^0.1.12
+  peerDependenciesMeta:
+    class-transformer:
+      optional: true
+    class-validator:
+      optional: true
+  checksum: 22deac62c44a4c8a491aa2d9e94385092ef4644d6299ddf9b545b87858d4be861479c6e19de860550489f38699bf7cdc28fdedc9b09f5770ea35d347f9743c28
+  languageName: node
+  linkType: hard
+
 "@nestjs/platform-express@npm:^9.0.0":
   version: 9.0.7
   resolution: "@nestjs/platform-express@npm:9.0.7"
@@ -978,6 +995,27 @@ __metadata:
   peerDependencies:
     typescript: ^4.3.5
   checksum: c4a382a0b498f4a90e4d79c6a4bb479ad9bd38fc37d1f2bd65bb6034833f87604d04dad35991ec029a63e7bba50701dd71f68be90d49d8454c320260b15354b2
+  languageName: node
+  linkType: hard
+
+"@nestjs/swagger@npm:^6.1.2":
+  version: 6.1.2
+  resolution: "@nestjs/swagger@npm:6.1.2"
+  dependencies:
+    "@nestjs/mapped-types": 1.1.0
+    js-yaml: 4.1.0
+    lodash: 4.17.21
+    path-to-regexp: 3.2.0
+    swagger-ui-dist: 4.14.0
+  peerDependencies:
+    "@fastify/static": ^6.0.0
+    "@nestjs/common": ^9.0.0
+    "@nestjs/core": ^9.0.0
+    reflect-metadata: ^0.1.12
+  peerDependenciesMeta:
+    "@fastify/static":
+      optional: true
+  checksum: 1acfddac35f3c41298da30c865e1bd61a979c6d3fdba3056f71474f65aca51d001c5eff8775615d3459ee41e578ffbb577ee529409f4f7baaf9466b8e12626de
   languageName: node
   linkType: hard
 
@@ -4584,6 +4622,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-yaml@npm:4.1.0, js-yaml@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "js-yaml@npm:4.1.0"
+  dependencies:
+    argparse: ^2.0.1
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: c7830dfd456c3ef2c6e355cc5a92e6700ceafa1d14bba54497b34a99f0376cecbb3e9ac14d3e5849b426d5a5140709a66237a8c991c675431271c4ce5504151a
+  languageName: node
+  linkType: hard
+
 "js-yaml@npm:^3.13.1":
   version: 3.14.1
   resolution: "js-yaml@npm:3.14.1"
@@ -4593,17 +4642,6 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: bef146085f472d44dee30ec34e5cf36bf89164f5d585435a3d3da89e52622dff0b188a580e4ad091c3341889e14cb88cac6e4deb16dc5b1e9623bb0601fc255c
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "js-yaml@npm:4.1.0"
-  dependencies:
-    argparse: ^2.0.1
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: c7830dfd456c3ef2c6e355cc5a92e6700ceafa1d14bba54497b34a99f0376cecbb3e9ac14d3e5849b426d5a5140709a66237a8c991c675431271c4ce5504151a
   languageName: node
   linkType: hard
 
@@ -5876,6 +5914,7 @@ __metadata:
     "@nestjs/core": ^9.0.0
     "@nestjs/platform-express": ^9.0.0
     "@nestjs/schematics": ^9.0.0
+    "@nestjs/swagger": ^6.1.2
     "@nestjs/testing": ^9.0.0
     "@node-redis/json": ^1.0.2
     "@types/express": ^4.17.13
@@ -6314,6 +6353,13 @@ __metadata:
   version: 1.0.0
   resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
   checksum: 53b1e247e68e05db7b3808b99b892bd36fb096e6fba213a06da7fab22045e97597db425c724f2bbd6c99a3c295e1e73f3e4de78592289f38431049e1277ca0ae
+  languageName: node
+  linkType: hard
+
+"swagger-ui-dist@npm:4.14.0":
+  version: 4.14.0
+  resolution: "swagger-ui-dist@npm:4.14.0"
+  checksum: 8670e230ae841b16c983bf8420a3c52073fc3e6590cd1c700342ee788e6c46e329daeeff7e5dcfa59ffe58d2efce40cf51377b7f29ce36af9134b4112cd5c97e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #76

- Adds `@nestjs/swagger` – a framework which helps in building and providing a Swagger interface for NestJS
- Swagger is accessible in the root path of the server
- Adds `openapi` folders to `routes`
  * Here is where you can find the API representations that will be used in Swagger
  * They implement the respective domain interface and add the provided decorators required for generating Swagger stubs