### PR TITLE
Rename BalanceToken logo_uri to logoUri

### DIFF
--- a/src/domain/balances/entities/__tests__/balance.token.factory.ts
+++ b/src/domain/balances/entities/__tests__/balance.token.factory.ts
@@ -9,7 +9,7 @@ export default function (
 ): BalanceToken {
   return <BalanceToken>{
     decimals: decimals || faker.datatype.number(),
-    logo_uri: logo_uri || faker.internet.url(),
+    logoUri: logo_uri || faker.internet.url(),
     name: name || faker.finance.currencyName(),
     symbol: symbol || faker.finance.currencySymbol(),
   };

--- a/src/domain/balances/entities/balance.token.entity.ts
+++ b/src/domain/balances/entities/balance.token.entity.ts
@@ -2,5 +2,5 @@ export interface BalanceToken {
   name: string;
   symbol: string;
   decimals: number;
-  logo_uri: string;
+  logoUri: string;
 }

--- a/src/domain/balances/entities/schemas/balance.schema.ts
+++ b/src/domain/balances/entities/schemas/balance.schema.ts
@@ -7,9 +7,9 @@ const balanceTokenSchema: JSONSchemaType<BalanceToken> = {
     name: { type: 'string' },
     symbol: { type: 'string' },
     decimals: { type: 'number' },
-    logo_uri: { type: 'string' },
+    logoUri: { type: 'string' },
   },
-  required: ['name', 'symbol', 'decimals', 'logo_uri'],
+  required: ['name', 'symbol', 'decimals', 'logoUri'],
 };
 
 const balanceSchema: Schema = {

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -93,7 +93,7 @@ describe('Balances Controller (Unit)', () => {
                 decimals: expectedBalance.token?.decimals,
                 symbol: expectedBalance.token?.symbol,
                 name: expectedBalance.token?.name,
-                logoUri: expectedBalance?.token?.logo_uri,
+                logoUri: expectedBalance?.token?.logoUri,
               },
               balance: expectedBalance.balance.toString(),
               fiatBalance: expectedBalance.fiatBalance,

--- a/src/routes/balances/balances.service.ts
+++ b/src/routes/balances/balances.service.ts
@@ -75,7 +75,7 @@ export class BalancesService {
     const logoUri =
       tokenType === TokenType.NativeToken
         ? nativeCurrency.logoUri
-        : txBalance.token?.logo_uri;
+        : txBalance.token?.logoUri;
 
     return <Balance>{
       tokenInfo: <TokenInfo>{


### PR DESCRIPTION
Closes #87 

- The JSON payload does not have a logo_uri field but a logoUri instead
- Camel case is more consistent with the fields that we use for the domain entities