### PR TITLE
Use Redis Sets

### DIFF
--- a/src/datasources/cache/__tests__/fake.cache.service.spec.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.spec.ts
@@ -9,29 +9,31 @@ describe('FakeCacheService', () => {
 
   it(`sets key`, async () => {
     const key = 'test-key';
+    const field = 'test-field';
     const value = 'some-value';
 
-    await target.set(key, value, 0);
+    await target.set(key, field, value, 0);
 
-    await expect(target.get(key)).resolves.toBe(value);
+    await expect(target.get(key, field)).resolves.toBe(value);
     expect(target.keyCount()).toBe(1);
   });
 
   it(`deletes key`, async () => {
     const key = 'test-key';
+    const field = 'test-field';
     const value = 'some-value';
 
-    await target.set(key, value, 0);
+    await target.set(key, field, value, 0);
     await target.delete(key);
 
-    await expect(target.get(key)).resolves.toBe(undefined);
+    await expect(target.get(key, field)).resolves.toBe(undefined);
     expect(target.keyCount()).toBe(0);
   });
 
   it(`clears keys`, async () => {
     const actions: Promise<void>[] = [];
     for (let i = 0; i < 5; i++) {
-      actions.push(target.set(`key${i}`, `value${i}`, 0));
+      actions.push(target.set(`key${i}`, `field${i}`, `value${i}`, 0));
     }
 
     await Promise.all(actions);

--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -1,7 +1,7 @@
 import { ICacheService } from '../cache.service.interface';
 
 export class FakeCacheService implements ICacheService {
-  private cache: Record<string, any> = {};
+  private cache: Record<string, Record<string, any>> = {};
 
   keyCount(): number {
     return Object.keys(this.cache).length;
@@ -15,13 +15,24 @@ export class FakeCacheService implements ICacheService {
     delete this.cache[key];
   }
 
-  get<T>(key: string): Promise<T> {
-    return Promise.resolve(this.cache[key]);
+  get(key: string, field: string): Promise<string | undefined> {
+    const fields = this.cache[key];
+    if (fields === undefined) return Promise.resolve(undefined);
+    return Promise.resolve(this.cache[key][field]);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  set(key: string, value: string, expireTimeSeconds: number): Promise<void> {
-    this.cache[key] = value;
+  set(
+    key: string,
+    field: string,
+    value: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    expireTimeSeconds?: number,
+  ): Promise<void> {
+    const fields = this.cache[key];
+    if (fields === undefined) {
+      this.cache[key] = {};
+    }
+    this.cache[key][field] = value;
     return Promise.resolve();
   }
 }

--- a/src/datasources/cache/cache.service.interface.ts
+++ b/src/datasources/cache/cache.service.interface.ts
@@ -1,6 +1,12 @@
 export const CacheService = Symbol('ICacheService');
 
 export interface ICacheService {
-  set(key: string, value: string, expireTimeSeconds?: number): Promise<void>;
-  get<T>(key: string): Promise<T>;
+  set(
+    key: string,
+    field: string,
+    value: string,
+    expireTimeSeconds?: number,
+  ): Promise<void>;
+
+  get(key: string, field: string): Promise<string | undefined>;
 }

--- a/src/datasources/cache/redis.cache.service.spec.ts
+++ b/src/datasources/cache/redis.cache.service.spec.ts
@@ -4,19 +4,14 @@ import { FakeConfigurationService } from '../../common/config/__tests__/fake.con
 import { faker } from '@faker-js/faker';
 import clearAllMocks = jest.clearAllMocks;
 
-const json = {
-  set: jest.fn(),
-  del: jest.fn(),
-  get: jest.fn(),
-} as unknown as any;
-
 const redisClientType = {
-  json: json,
+  hGet: jest.fn(),
+  hSet: jest.fn(),
+  hDel: jest.fn(),
   expire: jest.fn(),
   quit: jest.fn(),
 } as unknown as RedisClientType;
 const redisClientTypeMock = jest.mocked(redisClientType);
-const jsonMock = jest.mocked(redisClientTypeMock.json);
 
 describe('RedisCacheService', () => {
   let redisCacheService: RedisCacheService;
@@ -40,89 +35,94 @@ describe('RedisCacheService', () => {
 
   it(`Setting key without setting expireTimeSeconds`, async () => {
     const key = faker.random.alphaNumeric();
-    const value = faker.datatype.number();
+    const field = faker.datatype.string();
+    const value = faker.datatype.json();
 
-    await redisCacheService.set(key, value, undefined);
+    await redisCacheService.set(key, field, value, undefined);
 
-    expect(redisClientTypeMock.json.set).toBeCalledTimes(1);
-    expect(redisClientTypeMock.json.set).toBeCalledWith(key, '$', value);
+    expect(redisClientTypeMock.hSet).toBeCalledTimes(1);
+    expect(redisClientTypeMock.hSet).toBeCalledWith(key, field, value);
     expect(redisClientTypeMock.expire).toBeCalledTimes(1);
     expect(redisClientTypeMock.expire).toBeCalledWith(
       key,
       defaultExpirationTime,
     );
-    expect(redisClientTypeMock.json.del).toBeCalledTimes(0);
-    expect(redisClientTypeMock.json.get).toBeCalledTimes(0);
+    expect(redisClientTypeMock.hDel).toBeCalledTimes(0);
+    expect(redisClientTypeMock.hGet).toBeCalledTimes(0);
   });
 
   it(`Setting key with expireTimeSeconds`, async () => {
     const key = faker.random.alphaNumeric();
-    const value = faker.datatype.number();
+    const field = faker.datatype.string();
+    const value = faker.datatype.json();
     const expireTime = faker.datatype.number();
 
-    await redisCacheService.set(key, value, expireTime);
+    await redisCacheService.set(key, field, value, expireTime);
 
-    expect(redisClientTypeMock.json.set).toBeCalledTimes(1);
-    expect(redisClientTypeMock.json.set).toBeCalledWith(key, '$', value);
+    expect(redisClientTypeMock.hSet).toBeCalledTimes(1);
+    expect(redisClientTypeMock.hSet).toBeCalledWith(key, field, value);
     expect(redisClientTypeMock.expire).toBeCalledTimes(1);
     expect(redisClientTypeMock.expire).toBeCalledWith(key, expireTime);
-    expect(redisClientTypeMock.json.del).toBeCalledTimes(0);
-    expect(redisClientTypeMock.json.get).toBeCalledTimes(0);
+    expect(redisClientTypeMock.hDel).toBeCalledTimes(0);
+    expect(redisClientTypeMock.hGet).toBeCalledTimes(0);
   });
 
   it(`Setting key throws on expire`, async () => {
     const key = faker.random.alphaNumeric();
-    const value = faker.datatype.number();
+    const field = faker.datatype.string();
+    const value = faker.datatype.json();
     redisClientTypeMock.expire.mockRejectedValueOnce(new Error('cache error'));
 
-    await expect(redisCacheService.set(key, value)).rejects.toThrow(
+    await expect(redisCacheService.set(key, field, value)).rejects.toThrow(
       'cache error',
     );
 
-    expect(redisClientTypeMock.json.set).toBeCalledTimes(1);
-    expect(redisClientTypeMock.json.set).toBeCalledWith(key, '$', value);
+    expect(redisClientTypeMock.hSet).toBeCalledTimes(1);
+    expect(redisClientTypeMock.hSet).toBeCalledWith(key, field, value);
     expect(redisClientTypeMock.expire).toBeCalledTimes(1);
     expect(redisClientTypeMock.expire).toBeCalledWith(
       key,
       defaultExpirationTime,
     );
-    expect(redisClientTypeMock.json.del).toBeCalledTimes(1);
-    expect(redisClientTypeMock.json.del).toBeCalledWith(key, '$');
+    expect(redisClientTypeMock.hDel).toBeCalledTimes(1);
+    expect(redisClientTypeMock.hDel).toBeCalledWith(key, field);
   });
 
   it(`Setting key throws on set`, async () => {
     const key = faker.random.alphaNumeric();
-    const value = faker.datatype.number();
-    jsonMock.set.mockRejectedValueOnce(new Error('cache error'));
+    const field = faker.datatype.string();
+    const value = faker.datatype.json();
+    redisClientTypeMock.hSet.mockRejectedValueOnce(new Error('cache error'));
 
-    await expect(redisCacheService.set(key, value)).rejects.toThrow(
+    await expect(redisCacheService.set(key, field, value)).rejects.toThrow(
       'cache error',
     );
 
-    expect(redisClientTypeMock.json.set).toBeCalledTimes(1);
-    expect(redisClientTypeMock.json.set).toBeCalledWith(key, '$', value);
+    expect(redisClientTypeMock.hSet).toBeCalledTimes(1);
+    expect(redisClientTypeMock.hSet).toBeCalledWith(key, field, value);
     expect(redisClientTypeMock.expire).toBeCalledTimes(0);
-    expect(redisClientTypeMock.json.del).toBeCalledTimes(1);
-    expect(redisClientTypeMock.json.del).toBeCalledWith(key, '$');
+    expect(redisClientTypeMock.hDel).toBeCalledTimes(1);
+    expect(redisClientTypeMock.hDel).toBeCalledWith(key, field);
   });
 
   it(`Getting key calls json.get`, async () => {
     const key = faker.random.alphaNumeric();
+    const field = faker.datatype.string();
 
-    await redisCacheService.get(key);
+    await redisCacheService.get(key, field);
 
-    expect(redisClientTypeMock.json.get).toBeCalledTimes(1);
-    expect(redisClientTypeMock.json.get).toBeCalledWith(key);
-    expect(redisClientTypeMock.json.set).toBeCalledTimes(0);
-    expect(redisClientTypeMock.json.del).toBeCalledTimes(0);
+    expect(redisClientTypeMock.hGet).toBeCalledTimes(1);
+    expect(redisClientTypeMock.hGet).toBeCalledWith(key, field);
+    expect(redisClientTypeMock.hSet).toBeCalledTimes(0);
+    expect(redisClientTypeMock.hDel).toBeCalledTimes(0);
   });
 
   it(`When Module gets destroyed, redis connection is closed`, async () => {
     await redisCacheService.onModuleDestroy();
 
-    expect(redisClientTypeMock.json.get).toBeCalledTimes(0);
-    expect(redisClientTypeMock.json.set).toBeCalledTimes(0);
-    expect(redisClientTypeMock.json.del).toBeCalledTimes(0);
+    expect(redisClientTypeMock.hGet).toBeCalledTimes(0);
+    expect(redisClientTypeMock.hSet).toBeCalledTimes(0);
+    expect(redisClientTypeMock.hDel).toBeCalledTimes(0);
     expect(redisClientTypeMock.quit).toBeCalledTimes(1);
   });
 });

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -22,23 +22,24 @@ export class RedisCacheService implements ICacheService, OnModuleDestroy {
 
   async set(
     key: string,
-    value: any,
+    field: string,
+    value: string,
     expireTimeSeconds?: number,
   ): Promise<void> {
     try {
-      await this.client.json.set(key, '$', value);
+      await this.client.hSet(key, field, value);
       await this.client.expire(
         key,
         expireTimeSeconds ?? this.defaultExpirationTimeInSeconds,
       );
     } catch (error) {
-      await this.client.json.del(key, '$');
+      await this.client.hDel(key, field);
       throw error;
     }
   }
 
-  async get<T>(key: string): Promise<T> {
-    return (await this.client.json.get(key)) as unknown as T;
+  async get(key: string, field: string): Promise<string | undefined> {
+    return await this.client.hGet(key, field);
   }
 
   /**

--- a/src/datasources/config-api/config-api.service.ts
+++ b/src/datasources/config-api/config-api.service.ts
@@ -19,9 +19,10 @@ export class ConfigApi implements IConfigApi {
   }
 
   async getChains(limit?: number, offset?: number): Promise<Page<Chain>> {
-    const key = `chains-limit=${limit}-offset=${offset}`; // TODO key is not final
+    const key = `chains`;
+    const field = `${limit}_${offset}`;
     const url = `${this.baseUri}/api/v1/chains`;
-    return this.dataSource.get(key, url, {
+    return this.dataSource.get(key, field, url, {
       params: {
         limit,
         offset,
@@ -30,8 +31,9 @@ export class ConfigApi implements IConfigApi {
   }
 
   async getChain(chainId: string): Promise<Chain> {
-    const key = `chains-${chainId}`; // TODO key is not final
+    const key = `${chainId}_chain`;
+    const field = '';
     const url = `${this.baseUri}/api/v1/chains/${chainId}`;
-    return this.dataSource.get(key, url);
+    return this.dataSource.get(key, field, url);
   }
 }

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -15,10 +15,10 @@ export class TransactionApi implements ITransactionApi {
     trusted?: boolean,
     excludeSpam?: boolean,
   ): Promise<Balance[]> {
-    // TODO key is not final
-    const cacheKey = `balances-${this.chainId}-${safeAddress}-${trusted}-${excludeSpam}`;
+    const cacheKey = `${this.chainId}_${safeAddress}_balances`;
+    const cacheKeyField = `${trusted}_${excludeSpam}`;
     const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/balances/usd/`;
-    return this.dataSource.get(cacheKey, url, {
+    return this.dataSource.get(cacheKey, cacheKeyField, url, {
       params: {
         trusted: trusted,
         excludeSpam: excludeSpam,
@@ -27,9 +27,9 @@ export class TransactionApi implements ITransactionApi {
   }
 
   async getBackbone(): Promise<Backbone> {
-    // TODO key is not final
-    const cacheKey = `backbone-${this.chainId}`;
+    const cacheKey = `${this.chainId}_backbone`;
+    const field = '';
     const url = `${this.baseUrl}/api/v1/about`;
-    return this.dataSource.get(cacheKey, url);
+    return this.dataSource.get(cacheKey, field, url);
   }
 }


### PR DESCRIPTION
- Use Sets as the main caching structure
  * Structure is: `<key> <field> <value>`
  * The key in this context represents the category that we want cache – it should be done in a way that makes it easy to invalidate a specific category
  * The field represents any substructure that should be cached under key but should also be deleted if the key is deleted – eg.: we can use the field to represent different query parameters used under the category (key)
- Updates the cache keys to reflect the new structure
  * Each key now has a field to be set
  * If a field is not required, an empty string can be used to represent it
- By using sets we can now invalidate the keys which would delete all the fields under it