### PR TITLE
Add /hooks/events route

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,11 +12,13 @@ import { NetworkModule } from './datasources/network/network.module';
 import { ConfigurationModule } from './common/config/configuration.module';
 import { CacheModule } from './datasources/cache/cache.module';
 import { DomainModule } from './domain.module';
+import { CacheHooksModule } from './routes/cache-hooks/cache-hooks.module';
 
 @Module({
   imports: [
     // features
     BalancesModule,
+    CacheHooksModule,
     ChainsModule,
     // common
     CacheModule,

--- a/src/common/schemas/json-schema.service.ts
+++ b/src/common/schemas/json-schema.service.ts
@@ -14,7 +14,7 @@ export class JsonSchemaService {
     this.ajv.addSchema(schema, name);
   }
 
-  compile<T>(schema: Schema | JSONSchemaType<T>): ValidateFunction {
+  compile<T>(schema: Schema | JSONSchemaType<T>): ValidateFunction<T> {
     return this.ajv.compile(schema);
   }
 }

--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -11,8 +11,9 @@ export class FakeCacheService implements ICacheService {
     this.cache = {};
   }
 
-  delete(key: string) {
+  delete(key: string): Promise<number> {
     delete this.cache[key];
+    return Promise.resolve(1);
   }
 
   get(key: string, field: string): Promise<string | undefined> {

--- a/src/datasources/cache/cache.service.interface.ts
+++ b/src/datasources/cache/cache.service.interface.ts
@@ -9,4 +9,6 @@ export interface ICacheService {
   ): Promise<void>;
 
   get(key: string, field: string): Promise<string | undefined>;
+
+  delete(key: string): Promise<number>;
 }

--- a/src/datasources/cache/redis.cache.service.spec.ts
+++ b/src/datasources/cache/redis.cache.service.spec.ts
@@ -9,6 +9,7 @@ const redisClientType = {
   hSet: jest.fn(),
   hDel: jest.fn(),
   expire: jest.fn(),
+  unlink: jest.fn(),
   quit: jest.fn(),
 } as unknown as RedisClientType;
 const redisClientTypeMock = jest.mocked(redisClientType);
@@ -49,6 +50,7 @@ describe('RedisCacheService', () => {
     );
     expect(redisClientTypeMock.hDel).toBeCalledTimes(0);
     expect(redisClientTypeMock.hGet).toBeCalledTimes(0);
+    expect(redisClientTypeMock.quit).toBeCalledTimes(0);
   });
 
   it(`Setting key with expireTimeSeconds`, async () => {
@@ -65,6 +67,7 @@ describe('RedisCacheService', () => {
     expect(redisClientTypeMock.expire).toBeCalledWith(key, expireTime);
     expect(redisClientTypeMock.hDel).toBeCalledTimes(0);
     expect(redisClientTypeMock.hGet).toBeCalledTimes(0);
+    expect(redisClientTypeMock.quit).toBeCalledTimes(0);
   });
 
   it(`Setting key throws on expire`, async () => {
@@ -86,6 +89,7 @@ describe('RedisCacheService', () => {
     );
     expect(redisClientTypeMock.hDel).toBeCalledTimes(1);
     expect(redisClientTypeMock.hDel).toBeCalledWith(key, field);
+    expect(redisClientTypeMock.quit).toBeCalledTimes(0);
   });
 
   it(`Setting key throws on set`, async () => {
@@ -103,9 +107,10 @@ describe('RedisCacheService', () => {
     expect(redisClientTypeMock.expire).toBeCalledTimes(0);
     expect(redisClientTypeMock.hDel).toBeCalledTimes(1);
     expect(redisClientTypeMock.hDel).toBeCalledWith(key, field);
+    expect(redisClientTypeMock.quit).toBeCalledTimes(0);
   });
 
-  it(`Getting key calls json.get`, async () => {
+  it(`Getting key calls hGet`, async () => {
     const key = faker.random.alphaNumeric();
     const field = faker.datatype.string();
 
@@ -115,6 +120,19 @@ describe('RedisCacheService', () => {
     expect(redisClientTypeMock.hGet).toBeCalledWith(key, field);
     expect(redisClientTypeMock.hSet).toBeCalledTimes(0);
     expect(redisClientTypeMock.hDel).toBeCalledTimes(0);
+    expect(redisClientTypeMock.quit).toBeCalledTimes(0);
+  });
+
+  it(`Deleting key calls delete`, async () => {
+    const key = faker.random.alphaNumeric();
+
+    await redisCacheService.delete(key);
+
+    expect(redisClientTypeMock.unlink).toBeCalledTimes(1);
+    expect(redisClientTypeMock.hGet).toBeCalledTimes(0);
+    expect(redisClientTypeMock.hSet).toBeCalledTimes(0);
+    expect(redisClientTypeMock.hDel).toBeCalledTimes(0);
+    expect(redisClientTypeMock.quit).toBeCalledTimes(0);
   });
 
   it(`When Module gets destroyed, redis connection is closed`, async () => {

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -42,6 +42,11 @@ export class RedisCacheService implements ICacheService, OnModuleDestroy {
     return await this.client.hGet(key, field);
   }
 
+  async delete(key: string): Promise<number> {
+    // see https://redis.io/commands/unlink/
+    return await this.client.unlink(key);
+  }
+
   /**
    * Closes the connection to Redis when the module associated with this service
    * is destroyed. This tries to gracefully close the connection. If the Redis

--- a/src/datasources/transaction-api/transaction-api.manager.ts
+++ b/src/datasources/transaction-api/transaction-api.manager.ts
@@ -4,6 +4,7 @@ import { TransactionApi } from './transaction-api.service';
 import { CacheFirstDataSource } from '../cache/cache.first.data.source';
 import { ITransactionApiManager } from '../../domain/interfaces/transaction-api.manager.interface';
 import { IConfigApi } from '../../domain/interfaces/config-api.interface';
+import { CacheService, ICacheService } from '../cache/cache.service.interface';
 
 @Injectable()
 export class TransactionApiManager implements ITransactionApiManager {
@@ -13,6 +14,7 @@ export class TransactionApiManager implements ITransactionApiManager {
   constructor(
     @Inject(IConfigApi) private readonly configApi: IConfigApi,
     private readonly dataSource: CacheFirstDataSource,
+    @Inject(CacheService) private readonly cacheService: ICacheService,
   ) {}
 
   async getTransactionApi(chainId: string): Promise<TransactionApi> {
@@ -28,6 +30,7 @@ export class TransactionApiManager implements ITransactionApiManager {
       chainId,
       chain.transactionService,
       this.dataSource,
+      this.cacheService,
     );
     return this.transactionApiMap[chainId];
   }

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -4,6 +4,8 @@ import backboneFactory from '../../domain/balances/entities/__tests__/backbone.f
 import { Backbone } from '../../domain/backbone/entities/backbone.entity';
 import { Balance } from '../../domain/balances/entities/balance.entity';
 import { balanceFactory } from '../../domain/balances/entities/__tests__/balance.factory';
+import { ICacheService } from '../cache/cache.service.interface';
+import { faker } from '@faker-js/faker';
 
 const BALANCES: Balance[] = [balanceFactory(), balanceFactory()];
 const BACKBONE: Backbone = backboneFactory();
@@ -11,14 +13,19 @@ const BACKBONE: Backbone = backboneFactory();
 const dataSource = {
   get: jest.fn(),
 } as unknown as CacheFirstDataSource;
-
 const mockDataSource = jest.mocked(dataSource);
+
+const cacheService = {
+  delete: jest.fn(),
+} as unknown as ICacheService;
+const mockCacheService = jest.mocked(cacheService);
 
 describe('TransactionApi', () => {
   const service: TransactionApi = new TransactionApi(
     '1',
     'baseUrl',
     mockDataSource,
+    mockCacheService,
   );
 
   beforeEach(() => {
@@ -57,6 +64,20 @@ describe('TransactionApi', () => {
       mockDataSource.get = jest.fn().mockRejectedValueOnce(err);
       await expect(service.getBackbone()).rejects.toThrow(err.message);
       expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Clear Local Balances', () => {
+    it('should call delete', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+      mockCacheService.delete.mockResolvedValueOnce(1);
+
+      await service.clearLocalBalances(safeAddress);
+
+      expect(mockCacheService.delete).toBeCalledTimes(1);
+      expect(mockCacheService.delete).toBeCalledWith(
+        `1_${safeAddress}_balances`,
+      );
     });
   });
 });

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -2,12 +2,19 @@ import { CacheFirstDataSource } from '../cache/cache.first.data.source';
 import { ITransactionApi } from '../../domain/interfaces/transaction-api.interface';
 import { Balance } from '../../domain/balances/entities/balance.entity';
 import { Backbone } from '../../domain/backbone/entities/backbone.entity';
+import { Inject } from '@nestjs/common';
+import { CacheService, ICacheService } from '../cache/cache.service.interface';
+
+function balanceCacheKey(chainId: string, safeAddress: string): string {
+  return `${chainId}_${safeAddress}_balances`;
+}
 
 export class TransactionApi implements ITransactionApi {
   constructor(
     private readonly chainId: string,
     private readonly baseUrl: string,
     private readonly dataSource: CacheFirstDataSource,
+    @Inject(CacheService) private readonly cacheService: ICacheService,
   ) {}
 
   async getBalances(
@@ -15,7 +22,7 @@ export class TransactionApi implements ITransactionApi {
     trusted?: boolean,
     excludeSpam?: boolean,
   ): Promise<Balance[]> {
-    const cacheKey = `${this.chainId}_${safeAddress}_balances`;
+    const cacheKey = balanceCacheKey(this.chainId, safeAddress);
     const cacheKeyField = `${trusted}_${excludeSpam}`;
     const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/balances/usd/`;
     return this.dataSource.get(cacheKey, cacheKeyField, url, {
@@ -24,6 +31,11 @@ export class TransactionApi implements ITransactionApi {
         excludeSpam: excludeSpam,
       },
     });
+  }
+
+  async clearLocalBalances(safeAddress: string): Promise<void> {
+    const cacheKey = balanceCacheKey(this.chainId, safeAddress);
+    await this.cacheService.delete(cacheKey);
   }
 
   async getBackbone(): Promise<Backbone> {

--- a/src/domain/balances/balances.repository.interface.ts
+++ b/src/domain/balances/balances.repository.interface.ts
@@ -18,4 +18,12 @@ export interface IBalancesRepository {
     trusted?: boolean,
     excludeSpam?: boolean,
   ): Promise<Balance[]>;
+
+  /**
+   * Clears any stored local balance data of {@link safeAddress} on {@link chainId}
+   *
+   * @param chainId
+   * @param safeAddress
+   */
+  clearLocalBalances(chainId: string, safeAddress: string): Promise<void>;
 }

--- a/src/domain/balances/balances.repository.ts
+++ b/src/domain/balances/balances.repository.ts
@@ -6,8 +6,8 @@ import { DefinedError, ValidateFunction } from 'ajv';
 import { JsonSchemaService } from '../../common/schemas/json-schema.service';
 import { ValidationErrorFactory } from '../errors/validation-error-factory';
 import {
-  balanceTokenSchema,
   balanceSchema,
+  balanceTokenSchema,
 } from './entities/schemas/balance.schema';
 
 @Injectable()
@@ -41,5 +41,13 @@ export class BalancesRepository implements IBalancesRepository {
     }
 
     return balances;
+  }
+
+  async clearLocalBalances(
+    chainId: string,
+    safeAddress: string,
+  ): Promise<void> {
+    const api = await this.transactionApiManager.getTransactionApi(chainId);
+    await api.clearLocalBalances(safeAddress);
   }
 }

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -8,5 +8,7 @@ export interface ITransactionApi {
     excludeSpam?: boolean,
   ): Promise<Balance[]>;
 
+  clearLocalBalances(safeAddress: string): Promise<void>;
+
   getBackbone(): Promise<Backbone>;
 }

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -1,0 +1,184 @@
+import { INestApplication } from '@nestjs/common';
+import {
+  fakeConfigurationService,
+  TestConfigurationModule,
+} from '../../common/config/__tests__/test.configuration.module';
+import {
+  fakeCacheService,
+  TestCacheModule,
+} from '../../datasources/cache/__tests__/test.cache.module';
+import { Test, TestingModule } from '@nestjs/testing';
+import { DomainModule } from '../../domain.module';
+import {
+  mockNetworkService,
+  TestNetworkModule,
+} from '../../datasources/network/__tests__/test.network.module';
+import { CacheHooksModule } from './cache-hooks.module';
+import * as request from 'supertest';
+import { faker } from '@faker-js/faker';
+import chainFactory from '../../domain/chains/entities/__tests__/chain.factory';
+
+describe('Post Hook Events (Unit)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    fakeConfigurationService.set('exchange.baseUri', 'https://test.exchange');
+    fakeConfigurationService.set('exchange.apiKey', 'testKey');
+    fakeConfigurationService.set(
+      'safeConfig.baseUri',
+      'https://test.safe.config',
+    );
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    fakeCacheService.clear();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        // feature
+        CacheHooksModule,
+        // common
+        DomainModule,
+        TestCacheModule,
+        TestConfigurationModule,
+        TestNetworkModule,
+      ],
+    }).compile();
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('Accepts payloads', () => {
+    it('accepts ExecutedTransaction', async () => {
+      const chainId = '1';
+      const data = {
+        address: faker.finance.ethereumAddress(),
+        chainId: chainId,
+        type: 'EXECUTED_MULTISIG_TRANSACTION',
+        safeTxHash: 'some-safe-tx-hash',
+        txHash: 'some-tx-hash',
+      };
+      mockNetworkService.get.mockImplementation((url) => {
+        switch (url) {
+          case 'https://test.safe.config/api/v1/chains/1':
+            return Promise.resolve({ data: chainFactory(chainId) });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+
+      await request(app.getHttpServer())
+        .post(`/chains/1/hooks/events`)
+        .send(data)
+        .expect(200);
+    });
+
+    it('accepts NewConfirmation', async () => {
+      const chainId = '1';
+      const safeAddress = faker.finance.ethereumAddress();
+      const data = {
+        address: safeAddress,
+        chainId: chainId,
+        type: 'NEW_CONFIRMATION',
+        owner: faker.finance.ethereumAddress(),
+        safeTxHash: 'some-safe-tx-hash',
+      };
+      mockNetworkService.get.mockImplementation((url) => {
+        switch (url) {
+          case 'https://test.safe.config/api/v1/chains/1':
+            return Promise.resolve({ data: chainFactory(chainId) });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+
+      await request(app.getHttpServer())
+        .post(`/chains/1/hooks/events`)
+        .send(data)
+        .expect(200);
+    });
+
+    it('accepts PendingTransaction', async () => {
+      const chainId = '1';
+      const safeAddress = faker.finance.ethereumAddress();
+      const data = {
+        address: safeAddress,
+        chainId: chainId,
+        type: 'PENDING_MULTISIG_TRANSACTION',
+        safeTxHash: 'some-safe-tx-hash',
+      };
+      mockNetworkService.get.mockImplementation((url) => {
+        switch (url) {
+          case 'https://test.safe.config/api/v1/chains/1':
+            return Promise.resolve({ data: chainFactory(chainId) });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+
+      await request(app.getHttpServer())
+        .post(`/chains/1/hooks/events`)
+        .send(data)
+        .expect(200);
+    });
+
+    it('returns 400 (Bad Request) on unknown payload', async () => {
+      const data = {
+        type: 'SOME_TEST_TYPE_THAT_WE_DO_NOT_SUPPORT',
+        safeTxHash: 'some-safe-tx-hash',
+      };
+      mockNetworkService.get.mockImplementation((url) => {
+        switch (url) {
+          case 'https://test.safe.config/api/v1/chains/1':
+            return Promise.resolve({ data: chainFactory('1') });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+
+      await request(app.getHttpServer())
+        .post(`/chains/1/hooks/events`)
+        .send(data)
+        .expect(400);
+    });
+  });
+
+  describe('on EXECUTED_MULTISIG_TRANSACTION', () => {
+    it('clears local balances', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const chainId = '1';
+      const cacheKey = `${chainId}_${safeAddress}_balances`;
+      const cacheField = faker.random.alpha();
+      await fakeCacheService.set(cacheKey, cacheField, faker.random.alpha());
+      const data = {
+        address: safeAddress,
+        chainId: chainId,
+        type: 'EXECUTED_MULTISIG_TRANSACTION',
+        safeTxHash: 'some-safe-tx-hash',
+        txHash: 'some-tx-hash',
+      };
+      mockNetworkService.get.mockImplementation((url) => {
+        switch (url) {
+          case 'https://test.safe.config/api/v1/chains/1':
+            return Promise.resolve({ data: chainFactory(chainId) });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+
+      await request(app.getHttpServer())
+        .post(`/chains/1/hooks/events`)
+        .send(data)
+        .expect(200);
+
+      await expect(
+        fakeCacheService.get(cacheKey, cacheField),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/routes/cache-hooks/cache-hooks.controller.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.ts
@@ -1,0 +1,25 @@
+import { Body, Controller, HttpCode, Param, Post } from '@nestjs/common';
+import { ExecutedTransaction } from './entities/executed-transaction.entity';
+import { NewConfirmation } from './entities/new-confirmation.entity';
+import { PendingTransaction } from './entities/pending-transaction.entity';
+import { EventValidationPipe } from './pipes/event-validation.pipe';
+import { CacheHooksService } from './cache-hooks.service';
+
+@Controller({
+  path: '',
+  version: '1',
+})
+export class CacheHooksController {
+  constructor(private readonly service: CacheHooksService) {}
+
+  // TODO this endpoint should implement authentication
+  @Post('/chains/:chainId/hooks/events')
+  @HttpCode(200)
+  async postEvent(
+    @Param('chainId') chainId: string,
+    @Body(EventValidationPipe)
+    eventPayload: ExecutedTransaction | NewConfirmation | PendingTransaction,
+  ): Promise<void> {
+    return await this.service.onEvent(chainId, eventPayload);
+  }
+}

--- a/src/routes/cache-hooks/cache-hooks.module.ts
+++ b/src/routes/cache-hooks/cache-hooks.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { CacheHooksController } from './cache-hooks.controller';
+import { JsonSchemaService } from '../../common/schemas/json-schema.service';
+import { CacheHooksService } from './cache-hooks.service';
+
+@Module({
+  providers: [JsonSchemaService, CacheHooksService],
+  controllers: [CacheHooksController],
+})
+export class CacheHooksModule {}

--- a/src/routes/cache-hooks/cache-hooks.service.ts
+++ b/src/routes/cache-hooks/cache-hooks.service.ts
@@ -1,0 +1,32 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ExecutedTransaction } from './entities/executed-transaction.entity';
+import { NewConfirmation } from './entities/new-confirmation.entity';
+import { PendingTransaction } from './entities/pending-transaction.entity';
+import { EventType } from './entities/event-payload.entity';
+import { IBalancesRepository } from '../../domain/balances/balances.repository.interface';
+
+@Injectable()
+export class CacheHooksService {
+  constructor(
+    @Inject(IBalancesRepository)
+    private readonly balancesRepository: IBalancesRepository,
+  ) {}
+
+  async onEvent(
+    chainId: string,
+    event: ExecutedTransaction | NewConfirmation | PendingTransaction,
+  ): Promise<void> {
+    switch (event.type) {
+      case EventType.PENDING_MULTISIG_TRANSACTION:
+        break;
+      case EventType.EXECUTED_MULTISIG_TRANSACTION:
+        await this.balancesRepository.clearLocalBalances(
+          chainId,
+          event.address,
+        );
+        break;
+      case EventType.NEW_CONFIRMATION:
+        break;
+    }
+  }
+}

--- a/src/routes/cache-hooks/entities/event-payload.entity.ts
+++ b/src/routes/cache-hooks/entities/event-payload.entity.ts
@@ -1,0 +1,11 @@
+export enum EventType {
+  NEW_CONFIRMATION = 'NEW_CONFIRMATION',
+  EXECUTED_MULTISIG_TRANSACTION = 'EXECUTED_MULTISIG_TRANSACTION',
+  PENDING_MULTISIG_TRANSACTION = 'PENDING_MULTISIG_TRANSACTION',
+}
+
+export type EventPayload<T extends EventType> = {
+  address: string;
+  chainId: string;
+  type: T;
+};

--- a/src/routes/cache-hooks/entities/executed-transaction.entity.ts
+++ b/src/routes/cache-hooks/entities/executed-transaction.entity.ts
@@ -1,0 +1,7 @@
+import { EventPayload, EventType } from './event-payload.entity';
+
+export interface ExecutedTransaction
+  extends EventPayload<EventType.EXECUTED_MULTISIG_TRANSACTION> {
+  safeTxHash: string;
+  txHash: string;
+}

--- a/src/routes/cache-hooks/entities/new-confirmation.entity.ts
+++ b/src/routes/cache-hooks/entities/new-confirmation.entity.ts
@@ -1,0 +1,7 @@
+import { EventPayload, EventType } from './event-payload.entity';
+
+export interface NewConfirmation
+  extends EventPayload<EventType.NEW_CONFIRMATION> {
+  owner: string;
+  safeTxHash: string;
+}

--- a/src/routes/cache-hooks/entities/pending-transaction.entity.ts
+++ b/src/routes/cache-hooks/entities/pending-transaction.entity.ts
@@ -1,0 +1,6 @@
+import { EventPayload, EventType } from './event-payload.entity';
+
+export interface PendingTransaction
+  extends EventPayload<EventType.PENDING_MULTISIG_TRANSACTION> {
+  safeTxHash: string;
+}

--- a/src/routes/cache-hooks/entities/schemas/executed-transaction.schema.ts
+++ b/src/routes/cache-hooks/entities/schemas/executed-transaction.schema.ts
@@ -1,0 +1,16 @@
+import { JSONSchemaType } from 'ajv';
+import { ExecutedTransaction } from '../executed-transaction.entity';
+import { EventType } from '../event-payload.entity';
+
+export const executedTransactionEventSchema: JSONSchemaType<ExecutedTransaction> =
+  {
+    type: 'object',
+    properties: {
+      address: { type: 'string' },
+      chainId: { type: 'string' },
+      type: { type: 'string', enum: [EventType.EXECUTED_MULTISIG_TRANSACTION] },
+      safeTxHash: { type: 'string' },
+      txHash: { type: 'string' },
+    },
+    required: ['address', 'chainId', 'type', 'safeTxHash', 'txHash'],
+  };

--- a/src/routes/cache-hooks/entities/schemas/new-confirmation.schema.ts
+++ b/src/routes/cache-hooks/entities/schemas/new-confirmation.schema.ts
@@ -1,0 +1,15 @@
+import { JSONSchemaType } from 'ajv';
+import { EventType } from '../event-payload.entity';
+import { NewConfirmation } from '../new-confirmation.entity';
+
+export const newConfirmationEventSchema: JSONSchemaType<NewConfirmation> = {
+  type: 'object',
+  properties: {
+    address: { type: 'string' },
+    chainId: { type: 'string' },
+    type: { type: 'string', enum: [EventType.NEW_CONFIRMATION] },
+    owner: { type: 'string' },
+    safeTxHash: { type: 'string' },
+  },
+  required: ['address', 'chainId', 'type', 'owner', 'safeTxHash'],
+};

--- a/src/routes/cache-hooks/entities/schemas/pending-transaction.schema.ts
+++ b/src/routes/cache-hooks/entities/schemas/pending-transaction.schema.ts
@@ -1,0 +1,15 @@
+import { JSONSchemaType } from 'ajv';
+import { EventType } from '../event-payload.entity';
+import { PendingTransaction } from '../pending-transaction.entity';
+
+export const pendingTransactionEventSchema: JSONSchemaType<PendingTransaction> =
+  {
+    type: 'object',
+    properties: {
+      address: { type: 'string' },
+      chainId: { type: 'string' },
+      type: { type: 'string', enum: [EventType.PENDING_MULTISIG_TRANSACTION] },
+      safeTxHash: { type: 'string' },
+    },
+    required: ['address', 'chainId', 'type', 'safeTxHash'],
+  };

--- a/src/routes/cache-hooks/pipes/event-validation.pipe.ts
+++ b/src/routes/cache-hooks/pipes/event-validation.pipe.ts
@@ -1,0 +1,49 @@
+import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
+import { ValidateFunction } from 'ajv';
+import { JsonSchemaService } from '../../../common/schemas/json-schema.service';
+import { executedTransactionEventSchema } from '../entities/schemas/executed-transaction.schema';
+import { ExecutedTransaction } from '../entities/executed-transaction.entity';
+import { newConfirmationEventSchema } from '../entities/schemas/new-confirmation.schema';
+import { NewConfirmation } from '../entities/new-confirmation.entity';
+import { PendingTransaction } from '../entities/pending-transaction.entity';
+import { pendingTransactionEventSchema } from '../entities/schemas/pending-transaction.schema';
+
+@Injectable()
+export class EventValidationPipe
+  implements
+    PipeTransform<
+      any,
+      ExecutedTransaction | NewConfirmation | PendingTransaction
+    >
+{
+  private readonly isExecutedTransactionEvent: ValidateFunction<ExecutedTransaction>;
+  private readonly isNewConfirmationEvent: ValidateFunction<NewConfirmation>;
+  private readonly isPendingTransactionEvent: ValidateFunction<PendingTransaction>;
+
+  constructor(private readonly jsonSchemaService: JsonSchemaService) {
+    this.isExecutedTransactionEvent = jsonSchemaService.compile(
+      executedTransactionEventSchema,
+    );
+    this.isNewConfirmationEvent = jsonSchemaService.compile(
+      newConfirmationEventSchema,
+    );
+    this.isPendingTransactionEvent = jsonSchemaService.compile(
+      pendingTransactionEventSchema,
+    );
+  }
+
+  transform(
+    value: any,
+  ): ExecutedTransaction | NewConfirmation | PendingTransaction {
+    this.isExecutedTransactionEvent(value);
+
+    if (
+      this.isExecutedTransactionEvent(value) ||
+      this.isNewConfirmationEvent(value) ||
+      this.isPendingTransactionEvent(value)
+    ) {
+      return value;
+    }
+    throw new BadRequestException('Validation failed');
+  }
+}


### PR DESCRIPTION
Closes #86

- Adds `POST /chains/:chainId/hooks/events`
  * This route accepts the following events: `NEW_CONFIRMATION`, `EXECUTED_MULTISIG_TRANSACTION`, `PENDING_MULTISIG_TRANSACTION`
  * If the payload is not recognised the route returns `400`
  * Payload validation is done with the `EventValidationPipe` which uses AJV to validate the schema of the request body.
- `ITransactionApi` now exposes `clearLocalBalances(safeAddress)` – this method can be used on the route level whenever the locally stored (cached) balances of a specific `address` should be removed.
- `ICacheService` now exposes `delete(key)` – it can be used by other `datasources` if a key needs to be deleted.
  * The Redis implementation calls `unlink` on the key https://redis.io/commands/unlink/