### PR TITLE
Ignore test factories in coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     ],
     "coverageDirectory": "../coverage",
     "coveragePathIgnorePatterns": [
-      "index.ts"
+      "index.ts",
+      ".+\\/__tests__\\/.+\\.factory.(t|j)s"
     ],
     "testEnvironment": "node"
   },


### PR DESCRIPTION
- Ignores test factories in coverage ie.: test files that are under any subfolder `__tests__` and end in `.factory.ts` or `.factory.js`