### PR TITLE
Use undefined check instead of ||

### DIFF
--- a/src/domain/balances/entities/__tests__/backbone.factory.ts
+++ b/src/domain/balances/entities/__tests__/backbone.factory.ts
@@ -11,12 +11,12 @@ export default function (
   settings?: Record<string, string>,
 ): Backbone {
   return <Backbone>{
-    name: name || faker.random.word(),
-    version: version || faker.system.semver(),
-    api_version: api_version || faker.system.semver(),
-    secure: secure || faker.datatype.boolean(),
-    host: host || faker.internet.url(),
-    headers: headers || [...Array(3).keys()].map(() => faker.random.word()),
-    settings: settings || JSON.parse(faker.datatype.json()),
+    name: name ?? faker.random.word(),
+    version: version ?? faker.system.semver(),
+    api_version: api_version ?? faker.system.semver(),
+    secure: secure ?? faker.datatype.boolean(),
+    host: host ?? faker.internet.url(),
+    headers: headers ?? [...Array(3).keys()].map(() => faker.random.word()),
+    settings: settings ?? JSON.parse(faker.datatype.json()),
   };
 }

--- a/src/domain/balances/entities/__tests__/balance.factory.ts
+++ b/src/domain/balances/entities/__tests__/balance.factory.ts
@@ -11,10 +11,10 @@ export function balanceFactory(
   fiatConversion?: number,
 ): Balance {
   return <Balance>{
-    tokenAddress: tokenAddress || faker.finance.ethereumAddress(),
-    token: token || balanceTokenFactory(),
-    balance: balance || faker.datatype.number(),
-    fiatBalance: fiatBalance || faker.datatype.number(),
-    fiatConversion: fiatConversion || faker.datatype.number(),
+    tokenAddress: tokenAddress ?? faker.finance.ethereumAddress(),
+    token: token ?? balanceTokenFactory(),
+    balance: balance ?? faker.datatype.number(),
+    fiatBalance: fiatBalance ?? faker.datatype.number(),
+    fiatConversion: fiatConversion ?? faker.datatype.number(),
   };
 }

--- a/src/domain/balances/entities/__tests__/balance.token.factory.ts
+++ b/src/domain/balances/entities/__tests__/balance.token.factory.ts
@@ -8,9 +8,9 @@ export default function (
   symbol?: string,
 ): BalanceToken {
   return <BalanceToken>{
-    decimals: decimals || faker.datatype.number(),
-    logoUri: logo_uri || faker.internet.url(),
-    name: name || faker.finance.currencyName(),
-    symbol: symbol || faker.finance.currencySymbol(),
+    decimals: decimals ?? faker.datatype.number(),
+    logoUri: logo_uri ?? faker.internet.url(),
+    name: name ?? faker.finance.currencyName(),
+    symbol: symbol ?? faker.finance.currencySymbol(),
   };
 }


### PR DESCRIPTION
- Uses the undefined check (`??`) instead of `OR` (`||`)
- The main reason is that if a factory field is set to `false` (instead of `undefined`), the factory would not use that value but instead the fallback
- The change was applied to every field for consistency and the undefined check is more appropriate for these checks