### PR TITLE
Add support for Record schema validation

### DIFF
--- a/src/domain/backbone/entities/backbone.entity.ts
+++ b/src/domain/backbone/entities/backbone.entity.ts
@@ -5,6 +5,5 @@ export interface Backbone {
   secure: boolean;
   host: string;
   headers: string[];
-  // TODO: use Record<string, string>, define a compatible JSONSchema
-  settings: object;
+  settings: Record<string, string>;
 }

--- a/src/domain/balances/entities/schemas/backbone.schema.ts
+++ b/src/domain/balances/entities/schemas/backbone.schema.ts
@@ -10,7 +10,11 @@ const backboneSchema: JSONSchemaType<Backbone> = {
     secure: { type: 'boolean' },
     host: { type: 'string' },
     headers: { type: 'array', items: { type: 'string' } },
-    settings: { type: 'object' },
+    settings: {
+      type: 'object',
+      propertyNames: { type: 'string' },
+      required: [],
+    },
   },
   required: ['name', 'version', 'api_version', 'secure', 'host'],
   additionalProperties: false,

--- a/src/domain/exchange/entities/exchange-result.entity.ts
+++ b/src/domain/exchange/entities/exchange-result.entity.ts
@@ -1,6 +1,5 @@
 export interface ExchangeResult {
   success: boolean;
-  // TODO: use Record<string, number>, define a compatible JSONSchema
-  rates: object;
+  rates: Record<string, number>;
   base: string;
 }

--- a/src/domain/exchange/entities/fiat-codes-result.entity.ts
+++ b/src/domain/exchange/entities/fiat-codes-result.entity.ts
@@ -1,5 +1,4 @@
 export interface FiatCodesExchangeResult {
   success: boolean;
-  // TODO: use Record<string, string>, define a compatible JSONSchema
-  symbols: object;
+  symbols: Record<string, string>;
 }

--- a/src/domain/exchange/entities/schemas/exchange-result.schema.ts
+++ b/src/domain/exchange/entities/schemas/exchange-result.schema.ts
@@ -5,7 +5,11 @@ const exchangeResultSchema: JSONSchemaType<ExchangeResult> = {
   type: 'object',
   properties: {
     success: { type: 'boolean' },
-    rates: { type: 'object' },
+    rates: {
+      type: 'object',
+      propertyNames: { type: 'string' },
+      required: [],
+    },
     base: { type: 'string' },
   },
   required: ['success', 'base', 'rates'],

--- a/src/domain/exchange/entities/schemas/fiat-codes-exchange-result.schema.ts
+++ b/src/domain/exchange/entities/schemas/fiat-codes-exchange-result.schema.ts
@@ -5,7 +5,11 @@ const fiatCodesExchangeResultSchema: JSONSchemaType<FiatCodesExchangeResult> = {
   type: 'object',
   properties: {
     success: { type: 'boolean' },
-    symbols: { type: 'object' },
+    symbols: {
+      type: 'object',
+      propertyNames: { type: 'string' },
+      required: [],
+    },
   },
   required: ['success', 'symbols'],
 };

--- a/src/routes/chains/entities/backbone.entity.ts
+++ b/src/routes/chains/entities/backbone.entity.ts
@@ -13,7 +13,7 @@ export class Backbone implements DomainBackbone {
   @ApiProperty()
   secure: boolean;
   @ApiProperty()
-  settings: object;
+  settings: Record<string, string>;
   @ApiProperty()
   version: string;
 }


### PR DESCRIPTION
- Adds validation support for types which had `Record<string, T>`
- `ExchangeResult`, `Backbone` and `FiatCodesExchangeResult` now use `Record<string, string>`