### PR TITLE
Add v2 Collectibles route

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,7 @@ import { ConfigurationModule } from './config/configuration.module';
 import { CacheModule } from './datasources/cache/cache.module';
 import { DomainModule } from './domain.module';
 import { CacheHooksModule } from './routes/cache-hooks/cache-hooks.module';
+import { CollectiblesModule } from './routes/collectibles/collectibles.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { CacheHooksModule } from './routes/cache-hooks/cache-hooks.module';
     BalancesModule,
     CacheHooksModule,
     ChainsModule,
+    CollectiblesModule,
     // common
     CacheModule,
     ConfigurationModule,

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -4,6 +4,8 @@ import { Balance } from '../../domain/balances/entities/balance.entity';
 import { Backbone } from '../../domain/backbone/entities/backbone.entity';
 import { ICacheService } from '../cache/cache.service.interface';
 import { HttpErrorFactory } from '../errors/http-error-factory';
+import { Collectible } from '../../domain/collectibles/entities/collectible.entity';
+import { Page } from '../../domain/entities/page.entity';
 
 function balanceCacheKey(chainId: string, safeAddress: string): string {
   return `${chainId}_${safeAddress}_balances`;
@@ -41,6 +43,30 @@ export class TransactionApi implements ITransactionApi {
   async clearLocalBalances(safeAddress: string): Promise<void> {
     const cacheKey = balanceCacheKey(this.chainId, safeAddress);
     await this.cacheService.delete(cacheKey);
+  }
+
+  async getCollectibles(
+    safeAddress: string,
+    limit?: number,
+    offset?: number,
+    trusted?: boolean,
+    excludeSpam?: boolean,
+  ): Promise<Page<Collectible>> {
+    try {
+      const cacheKey = `${this.chainId}_${safeAddress}_collectibles`;
+      const cacheKeyField = `${limit}_${offset}_${trusted}_${excludeSpam}`;
+      const url = `${this.baseUrl}/api/v2/safes/${safeAddress}/collectibles/`;
+      return await this.dataSource.get(cacheKey, cacheKeyField, url, {
+        params: {
+          limit: limit,
+          offset: offset,
+          trusted: trusted,
+          exclude_spam: excludeSpam,
+        },
+      });
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
   }
 
   async getBackbone(): Promise<Backbone> {

--- a/src/domain.module.ts
+++ b/src/domain.module.ts
@@ -12,6 +12,8 @@ import { IBackboneRepository } from './domain/backbone/backbone.repository.inter
 import { BackboneRepository } from './domain/backbone/backbone.repository';
 import { ValidationErrorFactory } from './domain/schema/validation-error-factory';
 import { JsonSchemaService } from './domain/schema/json-schema.service';
+import { ICollectiblesRepository } from './domain/collectibles/collectibles.repository.interface';
+import { CollectiblesRepository } from './domain/collectibles/collectibles.repository';
 
 @Global()
 @Module({
@@ -20,6 +22,7 @@ import { JsonSchemaService } from './domain/schema/json-schema.service';
     { provide: IBackboneRepository, useClass: BackboneRepository },
     { provide: IBalancesRepository, useClass: BalancesRepository },
     { provide: IChainsRepository, useClass: ChainsRepository },
+    { provide: ICollectiblesRepository, useClass: CollectiblesRepository },
     { provide: IExchangeRepository, useClass: ExchangeRepository },
     ValidationErrorFactory,
     JsonSchemaService,
@@ -28,6 +31,7 @@ import { JsonSchemaService } from './domain/schema/json-schema.service';
     IBackboneRepository,
     IBalancesRepository,
     IChainsRepository,
+    ICollectiblesRepository,
     IExchangeRepository,
   ],
 })

--- a/src/domain/collectibles/collectibles.repository.interface.ts
+++ b/src/domain/collectibles/collectibles.repository.interface.ts
@@ -1,0 +1,17 @@
+import { Page } from '../entities/page.entity';
+import { Collectible } from './entities/collectible.entity';
+
+export const IChainsRepository = Symbol('IChainsRepository');
+
+export const ICollectiblesRepository = Symbol('ICollectiblesRepository');
+
+export interface ICollectiblesRepository {
+  getCollectibles(
+    chainId: string,
+    safeAddress: string,
+    limit?: number,
+    offset?: number,
+    trusted?: boolean,
+    excludeSpam?: boolean,
+  ): Promise<Page<Collectible>>;
+}

--- a/src/domain/collectibles/collectibles.repository.ts
+++ b/src/domain/collectibles/collectibles.repository.ts
@@ -1,0 +1,54 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ITransactionApiManager } from '../interfaces/transaction-api.manager.interface';
+import { Collectible } from './entities/collectible.entity';
+import { Page } from '../entities/page.entity';
+import { collectibleSchema } from './entities/schemas/collectible.schema';
+import { DefinedError, ValidateFunction } from 'ajv';
+import { ICollectiblesRepository } from './collectibles.repository.interface';
+import { ValidationErrorFactory } from '../schema/validation-error-factory';
+import { JsonSchemaService } from '../schema/json-schema.service';
+
+@Injectable()
+export class CollectiblesRepository implements ICollectiblesRepository {
+  private readonly isValidCollectible: ValidateFunction<Collectible>;
+
+  constructor(
+    @Inject(ITransactionApiManager)
+    private readonly transactionApiManager: ITransactionApiManager,
+    private readonly validationErrorFactory: ValidationErrorFactory,
+    private readonly jsonSchemaService: JsonSchemaService,
+  ) {
+    this.isValidCollectible = jsonSchemaService.compile(collectibleSchema);
+  }
+
+  async getCollectibles(
+    chainId: string,
+    safeAddress: string,
+    limit?: number,
+    offset?: number,
+    trusted?: boolean,
+    excludeSpam?: boolean,
+  ): Promise<Page<Collectible>> {
+    const transactionApi = await this.transactionApiManager.getTransactionApi(
+      chainId,
+    );
+    const page = await transactionApi.getCollectibles(
+      safeAddress,
+      limit,
+      offset,
+      trusted,
+      excludeSpam,
+    );
+
+    if (
+      !page.results.every((collectible: Collectible) =>
+        this.isValidCollectible(collectible),
+      )
+    ) {
+      const errors = this.isValidCollectible.errors as DefinedError[];
+      throw this.validationErrorFactory.from(errors);
+    }
+
+    return page;
+  }
+}

--- a/src/domain/collectibles/entities/__tests__/collectible.factory.ts
+++ b/src/domain/collectibles/entities/__tests__/collectible.factory.ts
@@ -1,0 +1,28 @@
+import { Collectible } from '../collectible.entity';
+import { faker } from '@faker-js/faker';
+
+export default function (
+  address?: string,
+  tokenName?: string,
+  tokenSymbol?: string,
+  logoUri?: string,
+  id?: string,
+  uri?: string,
+  name?: string,
+  description?: string,
+  imageUri?: string,
+  metadata?: Record<string, any>,
+): Collectible {
+  return <Collectible>{
+    address: address ?? faker.finance.ethereumAddress(),
+    tokenName: tokenName ?? faker.company.name(),
+    tokenSymbol: tokenSymbol ?? faker.finance.currencySymbol(),
+    logoUri: logoUri ?? faker.internet.url(),
+    id: id ?? faker.datatype.uuid(),
+    uri: uri ?? faker.internet.url(),
+    name: name ?? faker.company.name(),
+    description: description ?? faker.random.words(),
+    imageUri: imageUri ?? faker.internet.url(),
+    metadata: metadata ?? {},
+  };
+}

--- a/src/domain/collectibles/entities/collectible.entity.ts
+++ b/src/domain/collectibles/entities/collectible.entity.ts
@@ -1,0 +1,12 @@
+export interface Collectible {
+  address: string;
+  tokenName: string;
+  tokenSymbol: string;
+  logoUri: string;
+  id: string;
+  uri?: string;
+  name?: string;
+  description?: string;
+  imageUri?: string;
+  metadata?: Record<string, any>;
+}

--- a/src/domain/collectibles/entities/schemas/collectible.schema.ts
+++ b/src/domain/collectibles/entities/schemas/collectible.schema.ts
@@ -1,0 +1,19 @@
+import { JSONSchemaType } from 'ajv';
+import { Collectible } from '../collectible.entity';
+
+export const collectibleSchema: JSONSchemaType<Collectible> = {
+  type: 'object',
+  properties: {
+    address: { type: 'string' },
+    tokenName: { type: 'string' },
+    tokenSymbol: { type: 'string' },
+    logoUri: { type: 'string' },
+    id: { type: 'string' },
+    uri: { type: 'string', nullable: true, format: 'uri' },
+    name: { type: 'string', nullable: true },
+    description: { type: 'string', nullable: true },
+    imageUri: { type: 'string', nullable: true, format: 'uri' },
+    metadata: { type: 'object', nullable: true },
+  },
+  required: ['address', 'tokenName', 'tokenSymbol', 'logoUri', 'id'],
+};

--- a/src/domain/entities/__tests__/page.factory.ts
+++ b/src/domain/entities/__tests__/page.factory.ts
@@ -1,0 +1,31 @@
+import { Page } from '../page.entity';
+import { faker } from '@faker-js/faker';
+
+export default function <T>(
+  count?: number,
+  next?: string,
+  previous?: string,
+  results?: T[],
+): Page<T> {
+  return <Page<T>>{
+    count: count ?? faker.datatype.number(),
+    next: next ?? limitAndOffsetUrlFactory(),
+    previous: previous ?? limitAndOffsetUrlFactory(),
+    results: results ?? [],
+  };
+}
+
+export function limitAndOffsetUrlFactory(
+  limit?: number,
+  offset?: number,
+  url?: string,
+): string {
+  const _url = new URL(url ?? faker.internet.url());
+  if (limit) {
+    _url.searchParams.set('limit', limit.toString());
+  }
+  if (offset) {
+    _url.searchParams.set('offset', offset.toString());
+  }
+  return _url.toString();
+}

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -1,5 +1,7 @@
 import { Backbone } from '../backbone/entities/backbone.entity';
 import { Balance } from '../balances/entities/balance.entity';
+import { Page } from '../entities/page.entity';
+import { Collectible } from '../collectibles/entities/collectible.entity';
 
 export interface ITransactionApi {
   getBalances(
@@ -9,6 +11,14 @@ export interface ITransactionApi {
   ): Promise<Balance[]>;
 
   clearLocalBalances(safeAddress: string): Promise<void>;
+
+  getCollectibles(
+    safeAddress: string,
+    limit?: number,
+    offset?: number,
+    trusted?: boolean,
+    excludeSpam?: boolean,
+  ): Promise<Page<Collectible>>;
 
   getBackbone(): Promise<Backbone>;
 }

--- a/src/routes/collectibles/collectibles.controller.ts
+++ b/src/routes/collectibles/collectibles.controller.ts
@@ -1,0 +1,53 @@
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { CollectiblesService } from './collectibles.service';
+import { ApiImplicitQuery } from '@nestjs/swagger/dist/decorators/api-implicit-query.decorator';
+import { CollectiblePage } from './entities/collectible.page.entity';
+import { Collectible } from './entities/collectible.entity';
+import { RouteUrlDecorator } from '../common/decorators/route.url.decorator';
+import { PaginationDataDecorator } from '../common/decorators/pagination.data.decorator';
+import { PaginationData } from '../common/pagination/pagination.data';
+import { Page } from '../common/entities/page.entity';
+
+@ApiTags('collectibles')
+@Controller({
+  version: '2',
+})
+export class CollectiblesController {
+  constructor(private readonly service: CollectiblesService) {}
+
+  @ApiOkResponse({ type: CollectiblePage })
+  @ApiImplicitQuery({
+    name: 'trusted',
+    required: false,
+    type: Boolean,
+  })
+  @ApiImplicitQuery({
+    name: 'exclude_spam',
+    required: false,
+    type: Boolean,
+  })
+  @ApiImplicitQuery({
+    name: 'cursor',
+    required: false,
+    type: String,
+  })
+  @Get('chains/:chainId/safes/:safeAddress/collectibles')
+  async getChains(
+    @Param('chainId') chainId: string,
+    @Param('safeAddress') safeAddress: string,
+    @RouteUrlDecorator() routeUrl: URL,
+    @PaginationDataDecorator() paginationData?: PaginationData,
+    @Query('trusted') trusted?: boolean,
+    @Query('exclude_spam') excludeSpam?: boolean,
+  ): Promise<Page<Collectible>> {
+    return this.service.getCollectibles(
+      chainId,
+      safeAddress,
+      routeUrl,
+      paginationData,
+      trusted,
+      excludeSpam,
+    );
+  }
+}

--- a/src/routes/collectibles/collectibles.controlller.spec.ts
+++ b/src/routes/collectibles/collectibles.controlller.spec.ts
@@ -1,0 +1,237 @@
+import {
+  fakeCacheService,
+  TestCacheModule,
+} from '../../datasources/cache/__tests__/test.cache.module';
+import { Test, TestingModule } from '@nestjs/testing';
+import { DomainModule } from '../../domain.module';
+import {
+  mockNetworkService,
+  TestNetworkModule,
+} from '../../datasources/network/__tests__/test.network.module';
+import { INestApplication } from '@nestjs/common';
+import { CollectiblesModule } from './collectibles.module';
+import * as request from 'supertest';
+import { faker } from '@faker-js/faker';
+import chainFactory from '../../domain/chains/entities/__tests__/chain.factory';
+import pageFactory, {
+  limitAndOffsetUrlFactory,
+} from '../../domain/entities/__tests__/page.factory';
+import { Collectible } from '../../domain/collectibles/entities/collectible.entity';
+import collectibleFactory from '../../domain/collectibles/entities/__tests__/collectible.factory';
+import {
+  NetworkRequestError,
+  NetworkResponseError,
+} from '../../datasources/network/entities/network.error.entity';
+import { DataSourceErrorFilter } from '../common/filters/data-source-error.filter';
+import {
+  fakeConfigurationService,
+  TestConfigurationModule,
+} from '../../config/__tests__/test.configuration.module';
+
+describe('Collectibles Controller (Unit)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    fakeConfigurationService.set('exchange.baseUri', 'https://test.exchange');
+    fakeConfigurationService.set('exchange.apiKey', 'testKey');
+    fakeConfigurationService.set(
+      'safeConfig.baseUri',
+      'https://test.safe.config',
+    );
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    fakeCacheService.clear();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        // feature
+        CollectiblesModule,
+        // common
+        DomainModule,
+        TestCacheModule,
+        TestConfigurationModule,
+        TestNetworkModule,
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalFilters(new DataSourceErrorFilter());
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET /v2/collectibles', () => {
+    it('is successful', async () => {
+      const chainId = faker.random.numeric();
+      const safeAddress = faker.finance.ethereumAddress();
+      const chainResponse = chainFactory(chainId);
+      const pageLimit = 1;
+      const collectiblesResponse = pageFactory<Collectible>(
+        undefined,
+        limitAndOffsetUrlFactory(pageLimit, 0),
+        limitAndOffsetUrlFactory(pageLimit, 0),
+        [collectibleFactory(), collectibleFactory(), collectibleFactory()],
+      );
+      mockNetworkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `https://test.safe.config/api/v1/chains/${chainId}`:
+            return Promise.resolve({ data: chainResponse });
+          case `${chainResponse.transactionService}/api/v2/safes/${safeAddress}/collectibles/`:
+            return Promise.resolve({ data: collectiblesResponse });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/chains/${chainId}/safes/${safeAddress}/collectibles`)
+        .expect(200)
+        .expect((response) => {
+          expect(response.body.count).toBe(collectiblesResponse.count);
+          expect(response.body.results).toStrictEqual([
+            collectiblesResponse.results[0],
+            collectiblesResponse.results[1],
+            collectiblesResponse.results[2],
+          ]);
+          expect(response.body.next).toContain(`limit%3D${pageLimit}`);
+          expect(response.body.next).toContain(`limit%3D${pageLimit}`);
+        });
+    });
+
+    it('pagination data is forwarded to tx service', async () => {
+      const chainId = faker.random.numeric();
+      const safeAddress = faker.finance.ethereumAddress();
+      const chainResponse = chainFactory(chainId);
+      const limit = 10;
+      const offset = 20;
+      const collectiblesResponse = pageFactory<Collectible>(
+        undefined,
+        undefined,
+        undefined,
+        [collectibleFactory(), collectibleFactory(), collectibleFactory()],
+      );
+      mockNetworkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `https://test.safe.config/api/v1/chains/${chainId}`:
+            return Promise.resolve({ data: chainResponse });
+          case `${chainResponse.transactionService}/api/v2/safes/${safeAddress}/collectibles/`:
+            return Promise.resolve({ data: collectiblesResponse });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/chains/${chainId}/safes/${safeAddress}/collectibles/?cursor=limit%3D${limit}%26offset%3D${offset}`,
+        )
+        .expect(200);
+
+      expect(mockNetworkService.get.mock.calls[1][1]).toStrictEqual({
+        params: {
+          limit: 10,
+          offset: 20,
+          exclude_spam: undefined,
+          trusted: undefined,
+        },
+      });
+    });
+
+    it('excludeSpam and trusted params are forwarded to tx service', async () => {
+      const chainId = faker.random.numeric();
+      const safeAddress = faker.finance.ethereumAddress();
+      const chainResponse = chainFactory(chainId);
+      const excludeSpam = true;
+      const trusted = true;
+      const collectiblesResponse = pageFactory<Collectible>(
+        undefined,
+        undefined,
+        undefined,
+        [collectibleFactory(), collectibleFactory(), collectibleFactory()],
+      );
+      mockNetworkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `https://test.safe.config/api/v1/chains/${chainId}`:
+            return Promise.resolve({ data: chainResponse });
+          case `${chainResponse.transactionService}/api/v2/safes/${safeAddress}/collectibles/`:
+            return Promise.resolve({ data: collectiblesResponse });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/chains/${chainId}/safes/${safeAddress}/collectibles/?exclude_spam=${excludeSpam}&trusted=${trusted}`,
+        )
+        .expect(200);
+
+      expect(mockNetworkService.get.mock.calls[1][1]).toStrictEqual({
+        params: {
+          limit: undefined,
+          offset: undefined,
+          exclude_spam: excludeSpam.toString(),
+          trusted: trusted.toString(),
+        },
+      });
+    });
+
+    it('tx service collectibles returns 400', async () => {
+      const chainId = faker.random.numeric();
+      const safeAddress = faker.finance.ethereumAddress();
+      const chainResponse = chainFactory(chainId);
+      const transactionServiceError = new NetworkResponseError(
+        { message: 'some collectibles error' },
+        400,
+      );
+      mockNetworkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `https://test.safe.config/api/v1/chains/${chainId}`:
+            return Promise.resolve({ data: chainResponse });
+          case `${chainResponse.transactionService}/api/v2/safes/${safeAddress}/collectibles/`:
+            return Promise.reject(transactionServiceError);
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/chains/${chainId}/safes/${safeAddress}/collectibles`)
+        .expect(transactionServiceError.status)
+        .expect({
+          code: transactionServiceError.status,
+          message: transactionServiceError.data.message,
+        });
+    });
+
+    it('tx service collectibles does not return a response', async () => {
+      const chainId = faker.random.numeric();
+      const safeAddress = faker.finance.ethereumAddress();
+      const chainResponse = chainFactory(chainId);
+      const transactionServiceError = new NetworkRequestError({});
+      mockNetworkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `https://test.safe.config/api/v1/chains/${chainId}`:
+            return Promise.resolve({ data: chainResponse });
+          case `${chainResponse.transactionService}/api/v2/safes/${safeAddress}/collectibles/`:
+            return Promise.reject(transactionServiceError);
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/chains/${chainId}/safes/${safeAddress}/collectibles`)
+        .expect(503)
+        .expect({
+          code: 503,
+          message: 'Service unavailable',
+        });
+    });
+  });
+});

--- a/src/routes/collectibles/collectibles.module.ts
+++ b/src/routes/collectibles/collectibles.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CollectiblesController } from './collectibles.controller';
+import { CollectiblesService } from './collectibles.service';
+
+@Module({
+  controllers: [CollectiblesController],
+  providers: [CollectiblesService],
+})
+export class CollectiblesModule {}

--- a/src/routes/collectibles/collectibles.service.ts
+++ b/src/routes/collectibles/collectibles.service.ts
@@ -1,0 +1,47 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ICollectiblesRepository } from '../../domain/collectibles/collectibles.repository.interface';
+import { Collectible } from './entities/collectible.entity';
+import { Page } from '../common/entities/page.entity';
+import {
+  cursorUrlFromLimitAndOffset,
+  PaginationData,
+} from '../common/pagination/pagination.data';
+
+@Injectable()
+export class CollectiblesService {
+  constructor(
+    @Inject(ICollectiblesRepository)
+    private readonly repository: ICollectiblesRepository,
+  ) {}
+
+  async getCollectibles(
+    chainId: string,
+    safeAddress: string,
+    routeUrl: Readonly<URL>,
+    paginationData?: PaginationData,
+    trusted?: boolean,
+    excludeSpam?: boolean,
+  ): Promise<Page<Collectible>> {
+    const collectibles = await this.repository.getCollectibles(
+      chainId,
+      safeAddress,
+      paginationData?.limit,
+      paginationData?.offset,
+      trusted,
+      excludeSpam,
+    );
+
+    const nextURL = cursorUrlFromLimitAndOffset(routeUrl, collectibles.next);
+    const previousURL = cursorUrlFromLimitAndOffset(
+      routeUrl,
+      collectibles.previous,
+    );
+
+    return <Page<Collectible>>{
+      count: collectibles.count,
+      next: nextURL?.toString(),
+      previous: previousURL?.toString(),
+      results: collectibles.results,
+    };
+  }
+}

--- a/src/routes/collectibles/entities/collectible.entity.ts
+++ b/src/routes/collectibles/entities/collectible.entity.ts
@@ -1,0 +1,25 @@
+import { Collectible as DomainCollectible } from '../../../domain/collectibles/entities/collectible.entity';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class Collectible implements DomainCollectible {
+  @ApiProperty()
+  address: string;
+  @ApiProperty()
+  tokenName: string;
+  @ApiProperty()
+  tokenSymbol: string;
+  @ApiProperty()
+  logoUri: string;
+  @ApiProperty()
+  id: string;
+  @ApiPropertyOptional()
+  uri?: string;
+  @ApiPropertyOptional()
+  name?: string;
+  @ApiPropertyOptional()
+  description?: string;
+  @ApiPropertyOptional()
+  imageUri?: string;
+  @ApiPropertyOptional()
+  metadata?: Record<string, any>;
+}

--- a/src/routes/collectibles/entities/collectible.page.entity.ts
+++ b/src/routes/collectibles/entities/collectible.page.entity.ts
@@ -1,0 +1,8 @@
+import { Collectible } from './collectible.entity';
+import { ApiProperty } from '@nestjs/swagger';
+import { Page } from '../../common/entities/page.entity';
+
+export class CollectiblePage extends Page<Collectible> {
+  @ApiProperty({ type: Collectible })
+  results: Collectible[];
+}


### PR DESCRIPTION
Closes #97

- Adds `chains/:chainId/safes/:safeAddress/collectibles` route
- Adds a `page.factory.ts` which helps creating a `Page` payload which can be used in the tests
  * Additionally you can now use `limitAndOffsetUrlFactory` to generate a URL which contains a `limit` and `offset` query parameters
