### PR TITLE
Fix balances/usd/ exclude_spam query parameter

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -28,7 +28,7 @@ export class TransactionApi implements ITransactionApi {
     return this.dataSource.get(cacheKey, cacheKeyField, url, {
       params: {
         trusted: trusted,
-        excludeSpam: excludeSpam,
+        exclude_spam: excludeSpam,
       },
     });
   }

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -111,7 +111,7 @@ describe('Balances Controller (Unit)', () => {
         `${chainResponse.transactionService}/api/v1/safes/0x0000000000000000000000000000000000000001/balances/usd/`,
       );
       expect(mockNetworkService.get.mock.calls[1][1]).toStrictEqual({
-        params: { trusted: undefined, excludeSpam: undefined },
+        params: { trusted: undefined, exclude_spam: undefined },
       });
       expect(mockNetworkService.get.mock.calls[2][0]).toBe(
         'https://test.exchange/latest',


### PR DESCRIPTION
- The query parameter in `balances/usd/` endpoint is not `excludeSpam` but `exclude_spam`