### PR TITLE
Add safe transfers support

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -155,8 +155,8 @@ export class TransactionApi implements ITransactionApi {
     safeAddress: string,
     onlyErc20: boolean,
     onlyErc721: boolean,
-    limit: number,
-    offset: number,
+    limit?: number,
+    offset?: number,
   ): Promise<Page<Transfer>> {
     try {
       const cacheKey = `${this.chainId}_${safeAddress}_transfers`;

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -10,6 +10,7 @@ import { MasterCopy } from '../../domain/chains/entities/master-copies.entity';
 import { Safe } from '../../domain/safe/entities/safe.entity';
 import { Contract } from '../../domain/contracts/entities/contract.entity';
 import { Delegate } from '../../domain/delegate/entities/delegate.entity';
+import { Transfer } from '../../domain/safe/entities/transfer.entity';
 
 function balanceCacheKey(chainId: string, safeAddress: string): string {
   return `${chainId}_${safeAddress}_balances`;
@@ -141,6 +142,30 @@ export class TransactionApi implements ITransactionApi {
           delegate: delegate,
           delegator: delegator,
           label: label,
+          limit: limit,
+          offset: offset,
+        },
+      });
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  async getTransfers(
+    safeAddress: string,
+    onlyErc20: boolean,
+    onlyErc721: boolean,
+    limit: number,
+    offset: number,
+  ): Promise<Page<Transfer>> {
+    try {
+      const cacheKey = `${this.chainId}_${safeAddress}_transfers`;
+      const cacheKeyField = `${onlyErc20}_${onlyErc721}_${limit}_${offset}`;
+      const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/transfers/`;
+      return await this.dataSource.get(cacheKey, cacheKeyField, url, {
+        params: {
+          erc20: onlyErc20,
+          erc721: onlyErc721,
           limit: limit,
           offset: offset,
         },

--- a/src/domain.module.ts
+++ b/src/domain.module.ts
@@ -31,6 +31,7 @@ import { ExchangeFiatCodesValidator } from './domain/exchange/exchange-fiat-code
 import { DelegateValidator } from './domain/delegate/delegate.validator';
 import { IDelegateRepository } from './domain/delegate/delegate.repository.interface';
 import { DelegateRepository } from './domain/delegate/delegate.repository';
+import { TransferValidator } from './domain/safe/transfer.validator';
 
 @Global()
 @Module({
@@ -49,12 +50,13 @@ import { DelegateRepository } from './domain/delegate/delegate.repository';
     ChainsValidator,
     CollectiblesValidator,
     ContractsValidator,
+    DelegateValidator,
     ExchangeFiatCodesValidator,
     ExchangeRatesValidator,
+    GenericValidator,
     MasterCopyValidator,
     SafeValidator,
-    GenericValidator,
-    DelegateValidator,
+    TransferValidator,
     ValidationErrorFactory,
     JsonSchemaService,
   ],

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -5,6 +5,7 @@ import { Collectible } from '../collectibles/entities/collectible.entity';
 import { MasterCopy } from '../chains/entities/master-copies.entity';
 import { Safe } from '../safe/entities/safe.entity';
 import { Contract } from '../contracts/entities/contract.entity';
+import { Transfer } from '../safe/entities/transfer.entity';
 
 export interface ITransactionApi {
   getBalances(
@@ -39,4 +40,12 @@ export interface ITransactionApi {
     limit?: number,
     offset?: number,
   );
+
+  getTransfers(
+    safeAddress: string,
+    onlyErc20?: boolean,
+    onlyErc721?: boolean,
+    limit?: number,
+    offset?: number,
+  ): Promise<Page<Transfer>>;
 }

--- a/src/domain/safe/entities/schemas/transfer.schema.ts
+++ b/src/domain/safe/entities/schemas/transfer.schema.ts
@@ -1,0 +1,58 @@
+import { JSONSchemaType } from 'ajv';
+import { NativeTokenTransfer, TokenTransfer } from '../transfer.entity';
+
+export const transferSchema: JSONSchemaType<
+  TokenTransfer | NativeTokenTransfer
+> = {
+  type: 'object',
+  required: [],
+  oneOf: [
+    {
+      type: 'object',
+      properties: {
+        type: {
+          type: 'string',
+          enum: ['ERC721_TRANSFER', 'ERC20_TRANSFER'],
+        },
+        executionDate: { type: 'string' },
+        blockNumber: { type: 'number' },
+        transactionHash: { type: 'string' },
+        to: { type: 'string' },
+        from: { type: 'string' },
+        tokenId: { type: 'string' },
+        tokenAddress: { type: 'string' },
+      },
+      required: [
+        'type',
+        'executionDate',
+        'blockNumber',
+        'transactionHash',
+        'to',
+        'from',
+        'tokenId',
+        'tokenAddress',
+      ],
+    },
+    {
+      type: 'object',
+      properties: {
+        type: { type: 'string', const: 'ETHER_TRANSFER' },
+        executionDate: { type: 'string' },
+        blockNumber: { type: 'number' },
+        transactionHash: { type: 'string' },
+        to: { type: 'string' },
+        from: { type: 'string' },
+        value: { type: 'string' },
+      },
+      required: [
+        'type',
+        'executionDate',
+        'blockNumber',
+        'transactionHash',
+        'to',
+        'from',
+        'value',
+      ],
+    },
+  ],
+};

--- a/src/domain/safe/entities/schemas/transfer.schema.ts
+++ b/src/domain/safe/entities/schemas/transfer.schema.ts
@@ -20,7 +20,7 @@ export const transferSchema: JSONSchemaType<
         to: { type: 'string' },
         from: { type: 'string' },
         tokenId: { type: 'string' },
-        tokenAddress: { type: 'string' },
+        tokenAddress: { type: 'string', nullable: true },
       },
       required: [
         'type',
@@ -30,7 +30,6 @@ export const transferSchema: JSONSchemaType<
         'to',
         'from',
         'tokenId',
-        'tokenAddress',
       ],
     },
     {

--- a/src/domain/safe/entities/transfer.entity.ts
+++ b/src/domain/safe/entities/transfer.entity.ts
@@ -1,0 +1,19 @@
+export type Transfer = {
+  type: string;
+  executionDate: string;
+  blockNumber: number;
+  transactionHash: string;
+  to: string;
+  from: string;
+};
+
+export interface TokenTransfer extends Transfer {
+  type: 'ERC721_TRANSFER' | 'ERC20_TRANSFER';
+  tokenId: string;
+  tokenAddress: string;
+}
+
+export interface NativeTokenTransfer extends Transfer {
+  type: 'ETHER_TRANSFER';
+  value: string;
+}

--- a/src/domain/safe/entities/transfer.entity.ts
+++ b/src/domain/safe/entities/transfer.entity.ts
@@ -10,7 +10,7 @@ export type Transfer = {
 export interface TokenTransfer extends Transfer {
   type: 'ERC721_TRANSFER' | 'ERC20_TRANSFER';
   tokenId: string;
-  tokenAddress: string;
+  tokenAddress?: string;
 }
 
 export interface NativeTokenTransfer extends Transfer {

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -1,7 +1,16 @@
 import { Safe } from './entities/safe.entity';
+import { Page } from '../entities/page.entity';
+import { Transfer } from './entities/transfer.entity';
 
 export const ISafeRepository = Symbol('ISafeRepository');
 
 export interface ISafeRepository {
   getSafe(chainId: string, address: string): Promise<Safe>;
+
+  getCollectibleTransfers(
+    chainId: string,
+    safeAddress: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<Page<Transfer>>;
 }

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -3,6 +3,9 @@ import { Safe } from './entities/safe.entity';
 import { ITransactionApiManager } from '../interfaces/transaction-api.manager.interface';
 import { ISafeRepository } from './safe.repository.interface';
 import { SafeValidator } from './safe.validator';
+import { Page } from '../entities/page.entity';
+import { Transfer } from './entities/transfer.entity';
+import { TransferValidator } from './transfer.validator';
 
 @Injectable()
 export class SafeRepository implements ISafeRepository {
@@ -10,6 +13,7 @@ export class SafeRepository implements ISafeRepository {
     @Inject(ITransactionApiManager)
     private readonly transactionApiManager: ITransactionApiManager,
     private readonly safeValidator: SafeValidator,
+    private readonly transferValidator: TransferValidator,
   ) {}
 
   async getSafe(chainId: string, address: string): Promise<Safe> {
@@ -17,5 +21,25 @@ export class SafeRepository implements ISafeRepository {
       await this.transactionApiManager.getTransactionApi(chainId);
     const safe: Safe = await transactionService.getSafe(address);
     return this.safeValidator.validate(safe);
+  }
+
+  async getCollectibleTransfers(
+    chainId: string,
+    safeAddress: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<Page<Transfer>> {
+    const transactionService =
+      await this.transactionApiManager.getTransactionApi(chainId);
+
+    const page = await transactionService.getTransfers(
+      safeAddress,
+      undefined,
+      true,
+      limit,
+      offset,
+    );
+    page.results.map((transfer) => this.transferValidator.validate(transfer));
+    return page;
   }
 }

--- a/src/domain/safe/transfer.validator.ts
+++ b/src/domain/safe/transfer.validator.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { ValidateFunction } from 'ajv';
+import { IValidator } from '../interfaces/validator.interface';
+import { JsonSchemaService } from '../schema/json-schema.service';
+import { Transfer } from './entities/transfer.entity';
+import { transferSchema } from './entities/schemas/transfer.schema';
+import { GenericValidator } from '../schema/generic.validator';
+
+@Injectable()
+export class TransferValidator implements IValidator<Transfer> {
+  private readonly isValidTransfer: ValidateFunction<Transfer>;
+
+  constructor(
+    private readonly genericValidator: GenericValidator,
+    private readonly jsonSchemaService: JsonSchemaService,
+  ) {
+    this.isValidTransfer = this.jsonSchemaService.compile(
+      transferSchema,
+    ) as ValidateFunction<Transfer>;
+  }
+
+  validate(data: unknown): Transfer {
+    return this.genericValidator.validate(this.isValidTransfer, data);
+  }
+}


### PR DESCRIPTION
Closes #125

- Adds support for getting transfers for a specific safe in `ITransactionApi`
  * It takes into account the token filters `onlyErc20` and  `onlyErc721`
- Adds support for getting collectibles for a specific safe in `ISafeRepository`


⚠️ Tests will be added at the route level