### PR TITLE
Use allowUnionTypes AJV configuration option

### DIFF
--- a/src/domain/schema/json-schema.service.ts
+++ b/src/domain/schema/json-schema.service.ts
@@ -8,7 +8,11 @@ export class JsonSchemaService {
 
   constructor() {
     // coerceTypes param shouldn't be necessary when serialization is implemented.
-    this.ajv = new Ajv({ coerceTypes: true, useDefaults: true });
+    this.ajv = new Ajv({
+      allowUnionTypes: true,
+      coerceTypes: true,
+      useDefaults: true,
+    });
     addFormats(this.ajv, { formats: ['uri'] });
   }
 


### PR DESCRIPTION
This PR aims to remove the warning in test runs regarding the usage of union types in JSON Schemas. Example:

```
console.warn
      strict mode: use allowUnionTypes to allow union type keyword at "dataDecodedParameter/properties/valueDecoded" (strictTypes)
```

This is necessary for `DataDecoded` entity, since this is the first time we have an entity with a field which can be both an object or an array.
