### PR TITLE
Set data field as optional in NetworkResponseError

### DIFF
--- a/src/datasources/errors/http-error-factory.spec.ts
+++ b/src/datasources/errors/http-error-factory.spec.ts
@@ -11,8 +11,8 @@ describe('HttpErrorFactory', () => {
 
   it('should create an HttpException when there is an error with the response', async () => {
     const httpError = new NetworkResponseError(
-      { message: faker.random.words() },
       faker.internet.httpStatusCode({ types: ['serverError', 'clientError'] }),
+      { message: faker.random.words() },
     );
 
     const actual = httpErrorFactory.from(httpError);

--- a/src/datasources/errors/http-error-factory.ts
+++ b/src/datasources/errors/http-error-factory.ts
@@ -37,8 +37,9 @@ export class HttpErrorFactory {
   }
 }
 
-function isNetworkResponseError(error: any): error is NetworkResponseError {
-  return (
-    error.status !== undefined && error.status >= 400 && error.status < 600
-  );
+function isNetworkResponseError(
+  error: NetworkError | Error,
+): error is NetworkResponseError {
+  const responseError = error as NetworkResponseError;
+  return responseError.status >= 400 && responseError.status < 600;
 }

--- a/src/datasources/errors/http-error-factory.ts
+++ b/src/datasources/errors/http-error-factory.ts
@@ -20,7 +20,8 @@ export class HttpErrorFactory {
 
   private mapError(error: NetworkError | Error): DataSourceError {
     if (isNetworkResponseError(error)) {
-      return new DataSourceError(error.data.message, error.status);
+      const errorMessage: string = error.data?.message ?? 'An error occurred';
+      return new DataSourceError(errorMessage, error.status);
     } else {
       return new DataSourceError(
         'Service unavailable',
@@ -36,9 +37,8 @@ export class HttpErrorFactory {
   }
 }
 
-function isNetworkResponseError(
-  error: NetworkError,
-): error is NetworkResponseError {
-  const e = error as NetworkResponseError;
-  return e.data !== undefined && e.status !== undefined;
+function isNetworkResponseError(error: any): error is NetworkResponseError {
+  return (
+    error.status !== undefined && error.status >= 400 && error.status < 600
+  );
 }

--- a/src/datasources/network/entities/network.error.entity.ts
+++ b/src/datasources/network/entities/network.error.entity.ts
@@ -10,7 +10,7 @@ export type NetworkError =
  * {@link data} represents the payload which was received in the response
  */
 export class NetworkResponseError extends Error {
-  constructor(readonly data: any, readonly status) {
+  constructor(readonly status, readonly data?: any) {
     super();
   }
 }

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -130,10 +130,10 @@ describe('Balances Controller (Unit)', () => {
 
         await request(app.getHttpServer())
           .get(`/chains/${chainId}/safes/${safeAddress}/balances/usd`)
-          .expect(503)
+          .expect(500)
           .expect({
-            message: 'Service unavailable',
-            code: 503,
+            message: 'An error occurred',
+            code: 500,
           });
 
         expect(mockNetworkService.get.mock.calls.length).toBe(1);
@@ -339,10 +339,10 @@ describe('Balances Controller (Unit)', () => {
 
         await request(app.getHttpServer())
           .get(`/chains/${chainId}/safes/${safeAddress}/balances/usd`)
-          .expect(503)
+          .expect(500)
           .expect({
-            message: 'Service unavailable',
-            code: 503,
+            message: 'An error occurred',
+            code: 500,
           });
 
         expect(mockNetworkService.get.mock.calls.length).toBe(2);

--- a/src/routes/chains/chains.controller.spec.ts
+++ b/src/routes/chains/chains.controller.spec.ts
@@ -24,6 +24,7 @@ import { DataSourceErrorFilter } from '../common/filters/data-source-error.filte
 import { MasterCopy as DomainMasterCopy } from '../../domain/chains/entities/master-copies.entity';
 import masterCopyFactory from '../../domain/chains/entities/__tests__/master-copy.factory';
 import { MasterCopy } from './entities/master-copy.entity';
+import { NetworkResponseError } from '../../datasources/network/entities/network.error.entity';
 
 describe('Chains Controller (Unit)', () => {
   let app: INestApplication;
@@ -94,13 +95,13 @@ describe('Chains Controller (Unit)', () => {
     });
 
     it('Failure: network service fails', async () => {
-      mockNetworkService.get.mockRejectedValueOnce({
+      mockNetworkService.get.mockRejectedValueOnce(<NetworkResponseError>{
         status: 500,
       });
 
-      await request(app.getHttpServer()).get('/chains').expect(503).expect({
-        message: 'Service unavailable',
-        code: 503,
+      await request(app.getHttpServer()).get('/chains').expect(500).expect({
+        message: 'An error occurred',
+        code: 500,
       });
 
       expect(mockNetworkService.get).toBeCalledTimes(1);
@@ -159,10 +160,10 @@ describe('Chains Controller (Unit)', () => {
 
       await request(app.getHttpServer())
         .get('/chains/1/about/backbone')
-        .expect(503)
+        .expect(400)
         .expect({
-          message: 'Service unavailable',
-          code: 503,
+          message: 'An error occurred',
+          code: 400,
         });
 
       expect(mockNetworkService.get).toBeCalledTimes(1);
@@ -180,10 +181,10 @@ describe('Chains Controller (Unit)', () => {
 
       await request(app.getHttpServer())
         .get('/chains/1/about/backbone')
-        .expect(503)
+        .expect(502)
         .expect({
-          message: 'Service unavailable',
-          code: 503,
+          message: 'An error occurred',
+          code: 502,
         });
 
       expect(mockNetworkService.get).toBeCalledTimes(2);
@@ -240,10 +241,10 @@ describe('Chains Controller (Unit)', () => {
 
       await request(app.getHttpServer())
         .get('/chains/1/about/master-copies')
-        .expect(503)
+        .expect(400)
         .expect({
-          message: 'Service unavailable',
-          code: 503,
+          message: 'An error occurred',
+          code: 400,
         });
 
       expect(mockNetworkService.get).toBeCalledTimes(1);
@@ -261,10 +262,10 @@ describe('Chains Controller (Unit)', () => {
 
       await request(app.getHttpServer())
         .get('/chains/1/about/master-copies')
-        .expect(503)
+        .expect(502)
         .expect({
-          message: 'Service unavailable',
-          code: 503,
+          message: 'An error occurred',
+          code: 502,
         });
 
       expect(mockNetworkService.get).toBeCalledTimes(2);

--- a/src/routes/collectibles/collectibles.controller.spec.ts
+++ b/src/routes/collectibles/collectibles.controller.spec.ts
@@ -185,10 +185,9 @@ describe('Collectibles Controller (Unit)', () => {
       const chainId = faker.random.numeric();
       const safeAddress = faker.finance.ethereumAddress();
       const chainResponse = chainFactory(chainId);
-      const transactionServiceError = new NetworkResponseError(
-        { message: 'some collectibles error' },
-        400,
-      );
+      const transactionServiceError = new NetworkResponseError(400, {
+        message: 'some collectibles error',
+      });
       mockNetworkService.get.mockImplementation((url) => {
         switch (url) {
           case `https://test.safe.config/api/v1/chains/${chainId}`:


### PR DESCRIPTION
- A network responses do not require a body – the same applies to an error response
- `DataSourceError` now sets its error message as "An error occurred" if no message was present in the body (in the format of `{ message: <string> }`
- Improves `NetworkResponseError` type predicate – it now checks for the error range
- Adjusts tests that were relying on error responses – errors are now correctly forwarded to the routes