### PR TITLE
Fix error instantiation in AxiosNetworkService

### DIFF
--- a/src/datasources/network/axios.network.service.ts
+++ b/src/datasources/network/axios.network.service.ts
@@ -42,8 +42,8 @@ export class AxiosNetworkService implements INetworkService {
   private handleError(error): never {
     if (error.response) {
       throw new NetworkResponseError(
-        error.response.data,
         error.response.status,
+        error.response.data,
       );
     } else if (error.request) {
       throw new NetworkRequestError(error.request);


### PR DESCRIPTION
- We have recently changed the body of `NetworkResponseError` to be optional – with this change the order of the parameters also changed
- However this was not reflected in `AxiosNetworkService.handleError` – this is now fixed and status comes as the first argument followed by data