### PR TITLE
Test Redis integration on E2E CI tests

### DIFF
--- a/src/domain/contracts/entities/schemas/contract.schema.ts
+++ b/src/domain/contracts/entities/schemas/contract.schema.ts
@@ -7,7 +7,7 @@ const contractSchema: JSONSchemaType<Contract> = {
     address: { type: 'string' },
     name: { type: 'string' },
     displayName: { type: 'string' },
-    logoUri: { type: 'string' },
+    logoUri: { type: 'string', nullable: true },
     contractAbi: { type: 'object', nullable: true },
     trustedForDelegateCall: { type: 'boolean' },
   },

--- a/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
+++ b/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
@@ -1,0 +1,59 @@
+import * as request from 'supertest';
+import { INestApplication, Logger } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { AppModule } from '../../../app.module';
+import { readFileSync } from 'fs';
+import { Contract } from '../entities/contract.entity';
+import { RedisClientType, createClient } from 'redis';
+
+const logger = new Logger(redisClientFactory.name);
+
+async function redisClientFactory(): Promise<RedisClientType> {
+  const { REDIS_HOST = 'localhost', REDIS_PORT = 6379 } = process.env;
+  const client: RedisClientType = createClient({
+    url: `redis://${REDIS_HOST}:${REDIS_PORT}`,
+  });
+  client.on('error', (err) => logger.error('Redis Client Error', err));
+  client.connect();
+  return client;
+}
+
+describe('Get contract e2e test', () => {
+  let app: INestApplication;
+  let redisClient: RedisClientType;
+  const chainId = '5'; // Görli testnet
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    redisClient = await redisClientFactory();
+    await app.init();
+  });
+
+  it('GET /contracts/<address>', async () => {
+    const contractAddress = '0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4';
+    const expectedResponse: Contract = JSON.parse(
+      readFileSync(
+        'src/routes/contracts/__tests__/resources/contract-expected-response.json',
+        {
+          encoding: 'utf-8',
+        },
+      ),
+    );
+
+    await request(app.getHttpServer())
+      .get(`/chains/${chainId}/contracts/${contractAddress}`)
+      .expect(200)
+      .then(({ body }) => {
+        expect(body).toEqual(expectedResponse);
+      });
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await redisClient.quit();
+  });
+});

--- a/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
+++ b/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
@@ -1,22 +1,10 @@
 import * as request from 'supertest';
-import { INestApplication, Logger } from '@nestjs/common';
+import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { AppModule } from '../../../app.module';
 import { readFileSync } from 'fs';
 import { Contract } from '../entities/contract.entity';
 import { RedisClientType, createClient } from 'redis';
-
-const logger = new Logger(redisClientFactory.name);
-
-async function redisClientFactory(): Promise<RedisClientType> {
-  const { REDIS_HOST = 'localhost', REDIS_PORT = 6379 } = process.env;
-  const client: RedisClientType = createClient({
-    url: `redis://${REDIS_HOST}:${REDIS_PORT}`,
-  });
-  client.on('error', (err) => logger.error('Redis Client Error', err));
-  client.connect();
-  return client;
-}
 
 describe('Get contract e2e test', () => {
   let app: INestApplication;
@@ -29,12 +17,15 @@ describe('Get contract e2e test', () => {
     }).compile();
 
     app = moduleRef.createNestApplication();
-    redisClient = await redisClientFactory();
     await app.init();
+
+    redisClient = await redisClientFactory();
+    await redisClient.flushAll();
   });
 
   it('GET /contracts/<address>', async () => {
     const contractAddress = '0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4';
+    const contractCacheKey = `${chainId}_${contractAddress}_contract`;
     const expectedResponse: Contract = JSON.parse(
       readFileSync(
         'src/routes/contracts/__tests__/resources/contract-expected-response.json',
@@ -50,10 +41,23 @@ describe('Get contract e2e test', () => {
       .then(({ body }) => {
         expect(body).toEqual(expectedResponse);
       });
+
+    const cacheContent = await redisClient.hGet(contractCacheKey, '');
+    expect(cacheContent).toEqual(JSON.stringify(expectedResponse));
   });
 
   afterAll(async () => {
     await app.close();
+    await redisClient.flushAll();
     await redisClient.quit();
   });
 });
+
+async function redisClientFactory(): Promise<RedisClientType> {
+  const { REDIS_HOST = 'localhost', REDIS_PORT = 6379 } = process.env;
+  const client: RedisClientType = createClient({
+    url: `redis://${REDIS_HOST}:${REDIS_PORT}`,
+  });
+  client.connect();
+  return client;
+}

--- a/src/routes/contracts/__tests__/resources/contract-expected-response.json
+++ b/src/routes/contracts/__tests__/resources/contract-expected-response.json
@@ -1,0 +1,79 @@
+{
+    "address": "0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4",
+    "name": "CreateCall",
+    "displayName": "",
+    "logoUri": null,
+    "contractAbi": {
+        "abi": [
+            {
+                "name": "ContractCreation",
+                "type": "event",
+                "inputs": [
+                    {
+                        "name": "newContract",
+                        "type": "address",
+                        "indexed": false,
+                        "internalType": "address"
+                    }
+                ],
+                "anonymous": false
+            },
+            {
+                "name": "performCreate",
+                "type": "function",
+                "inputs": [
+                    {
+                        "name": "value",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "deploymentData",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    }
+                ],
+                "outputs": [
+                    {
+                        "name": "newContract",
+                        "type": "address",
+                        "internalType": "address"
+                    }
+                ],
+                "stateMutability": "nonpayable"
+            },
+            {
+                "name": "performCreate2",
+                "type": "function",
+                "inputs": [
+                    {
+                        "name": "value",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "deploymentData",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    },
+                    {
+                        "name": "salt",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    }
+                ],
+                "outputs": [
+                    {
+                        "name": "newContract",
+                        "type": "address",
+                        "internalType": "address"
+                    }
+                ],
+                "stateMutability": "nonpayable"
+            }
+        ],
+        "description": "CreateCall",
+        "relevance": 100
+    },
+    "trustedForDelegateCall": false
+}


### PR DESCRIPTION
Closes #134 

This PR aims to test Redis integration during CI pipeline E2E tests execution.

I worked under the premise that abstracting the cache provider is not a priority here. Of course this is debatable, if you feel more confortable we could develop an specific cache client or an implementation on `ICacheService`, but since this is an E2E/blackbox test, I prefer to stay low-level, and avoid importing code from the service itself (i.e. `RedisCacheService`).

Of course this has the downside that if we want to change Redis by another caching solution in the future, we would need to rewrite some parts of the E2E tests, but this seems unlikely, and we could even encapsulate Redis-specific code in a E2E-related cache client as well if you prefer. 

Any feedback is appreciated of course :) 