### PR TITLE
Change-cache-hooks-in-contracts-e2e-test

### DIFF
--- a/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
+++ b/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
@@ -15,11 +15,13 @@ describe('Get contract e2e test', () => {
     const moduleRef = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
-
+    
     app = moduleRef.createNestApplication();
     await app.init();
-
     redisClient = await redisClientFactory();
+  });
+
+  beforeEach(async () => {
     await redisClient.flushAll();
   });
 
@@ -46,9 +48,12 @@ describe('Get contract e2e test', () => {
     expect(cacheContent).toEqual(JSON.stringify(expectedResponse));
   });
 
+  afterEach(async () => {
+    await redisClient.flushAll();
+  });
+
   afterAll(async () => {
     await app.close();
-    await redisClient.flushAll();
     await redisClient.quit();
   });
 });

--- a/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
+++ b/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
@@ -15,7 +15,7 @@ describe('Get contract e2e test', () => {
     const moduleRef = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
-    
+
     app = moduleRef.createNestApplication();
     await app.init();
     redisClient = await redisClientFactory();

--- a/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
+++ b/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
@@ -48,12 +48,9 @@ describe('Get contract e2e test', () => {
     expect(cacheContent).toEqual(JSON.stringify(expectedResponse));
   });
 
-  afterEach(async () => {
-    await redisClient.flushAll();
-  });
-
   afterAll(async () => {
     await app.close();
+    await redisClient.flushAll();
     await redisClient.quit();
   });
 });


### PR DESCRIPTION
This changes the hooks for GET /contracts E2E tests. See https://github.com/5afe/safe-client-gateway-nest/pull/143/files/0ac6686a098896bef201a51b1bd5b1094495b2d7#r1003061782 for context