### PR TITLE
Fix to import route entities instead of domain entities for ChainsController

### DIFF
--- a/src/routes/chains/chains.controller.ts
+++ b/src/routes/chains/chains.controller.ts
@@ -3,14 +3,13 @@ import { ChainsService } from './chains.service';
 import { PaginationData } from '../common/pagination/pagination.data';
 import { RouteUrlDecorator } from '../common/decorators/route.url.decorator';
 import { PaginationDataDecorator } from '../common/decorators/pagination.data.decorator';
-import { Backbone } from '../../domain/backbone/entities/backbone.entity';
-import { Chain } from '../../domain/chains/entities/chain.entity';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
-import { Backbone as ApiBackbone } from './entities/backbone.entity';
-import { Page } from '../../domain/entities/page.entity';
+import { Backbone as ApiBackbone, Backbone } from './entities/backbone.entity';
 import { ChainPage } from './entities/chain-page.entity';
 import { MasterCopy } from './entities/master-copy.entity';
 import { ApiImplicitQuery } from '@nestjs/swagger/dist/decorators/api-implicit-query.decorator';
+import { Page } from '../common/entities/page.entity';
+import { Chain } from './entities/chain.entity';
 
 @ApiTags('chains')
 @Controller({

--- a/src/routes/common/entities/page.entity.ts
+++ b/src/routes/common/entities/page.entity.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Page as DomainPage } from '../../../domain/entities/page.entity';
 
 /**
@@ -17,9 +17,9 @@ import { Page as DomainPage } from '../../../domain/entities/page.entity';
 export abstract class Page<T> implements DomainPage<T> {
   @ApiProperty()
   count: number;
-  @ApiProperty()
+  @ApiPropertyOptional()
   next?: string;
-  @ApiProperty()
+  @ApiPropertyOptional()
   previous?: string;
   abstract results: T[];
 }

--- a/src/routes/common/entities/page.entity.ts
+++ b/src/routes/common/entities/page.entity.ts
@@ -18,8 +18,8 @@ export abstract class Page<T> implements DomainPage<T> {
   @ApiProperty()
   count: number;
   @ApiProperty()
-  next: string;
+  next?: string;
   @ApiProperty()
-  previous: string;
+  previous?: string;
   abstract results: T[];
 }


### PR DESCRIPTION
This PR fixes some bad imports in the ChainsController class. Domain entities were imported instead of the routes ones.