### PR TITLE
Remove vpcTransactionService from Chain

### DIFF
--- a/src/routes/chains/chains.controller.spec.ts
+++ b/src/routes/chains/chains.controller.spec.ts
@@ -82,9 +82,44 @@ describe('Chains Controller (Unit)', () => {
       await request(app.getHttpServer())
         .get('/chains')
         .expect(200)
-        .expect(<Page<Chain>>{
+        .expect({
           count: chainsResponse.count,
-          results: chainsResponse.results,
+          results: [
+            {
+              chainId: chainsResponse.results[0].chainId,
+              chainName: chainsResponse.results[0].chainName,
+              shortName: chainsResponse.results[0].shortName,
+              rpcUri: chainsResponse.results[0].rpcUri,
+              safeAppsRpcUri: chainsResponse.results[0].safeAppsRpcUri,
+              publicRpcUri: chainsResponse.results[0].publicRpcUri,
+              blockExplorerUriTemplate:
+                chainsResponse.results[0].blockExplorerUriTemplate,
+              nativeCurrency: chainsResponse.results[0].nativeCurrency,
+              transactionService: chainsResponse.results[0].transactionService,
+              theme: chainsResponse.results[0].theme,
+              gasPrice: chainsResponse.results[0].gasPrice,
+              ensRegistryAddress: chainsResponse.results[0].ensRegistryAddress,
+              disabledWallets: chainsResponse.results[0].disabledWallets,
+              features: chainsResponse.results[0].features,
+            },
+            {
+              chainId: chainsResponse.results[1].chainId,
+              chainName: chainsResponse.results[1].chainName,
+              shortName: chainsResponse.results[1].shortName,
+              rpcUri: chainsResponse.results[1].rpcUri,
+              safeAppsRpcUri: chainsResponse.results[1].safeAppsRpcUri,
+              publicRpcUri: chainsResponse.results[1].publicRpcUri,
+              blockExplorerUriTemplate:
+                chainsResponse.results[1].blockExplorerUriTemplate,
+              nativeCurrency: chainsResponse.results[1].nativeCurrency,
+              transactionService: chainsResponse.results[1].transactionService,
+              theme: chainsResponse.results[1].theme,
+              gasPrice: chainsResponse.results[1].gasPrice,
+              ensRegistryAddress: chainsResponse.results[1].ensRegistryAddress,
+              disabledWallets: chainsResponse.results[1].disabledWallets,
+              features: chainsResponse.results[1].features,
+            },
+          ],
         });
 
       expect(mockNetworkService.get).toBeCalledTimes(1);

--- a/src/routes/chains/chains.service.ts
+++ b/src/routes/chains/chains.service.ts
@@ -5,10 +5,10 @@ import {
 } from '../common/pagination/pagination.data';
 import { IChainsRepository } from '../../domain/chains/chains.repository.interface';
 import { IBackboneRepository } from '../../domain/backbone/backbone.repository.interface';
-import { Chain } from '../../domain/chains/entities/chain.entity';
 import { Backbone } from '../../domain/backbone/entities/backbone.entity';
 import { Page } from '../../domain/entities/page.entity';
 import { MasterCopy } from '../../domain/chains/entities/master-copies.entity';
+import { Chain } from './entities/chain.entity';
 
 @Injectable()
 export class ChainsService {
@@ -31,11 +31,31 @@ export class ChainsService {
     const nextURL = cursorUrlFromLimitAndOffset(routeUrl, result.next);
     const previousURL = cursorUrlFromLimitAndOffset(routeUrl, result.previous);
 
+    const chains = result.results.map(
+      (chain) =>
+        new Chain(
+          chain.chainId,
+          chain.chainName,
+          chain.nativeCurrency,
+          chain.transactionService,
+          chain.blockExplorerUriTemplate,
+          chain.disabledWallets,
+          chain.features,
+          chain.gasPrice,
+          chain.publicRpcUri,
+          chain.rpcUri,
+          chain.safeAppsRpcUri,
+          chain.shortName,
+          chain.theme,
+          chain.ensRegistryAddress,
+        ),
+    );
+
     return <Page<Chain>>{
       count: result.count,
       next: nextURL?.toString(),
       previous: previousURL?.toString(),
-      results: result.results,
+      results: chains,
     };
   }
 

--- a/src/routes/chains/entities/chain.entity.ts
+++ b/src/routes/chains/entities/chain.entity.ts
@@ -1,19 +1,30 @@
-import { Chain as DomainChain } from '../../../domain/chains/entities/chain.entity';
 import {
   ApiExtraModels,
   ApiProperty,
   ApiPropertyOptional,
   getSchemaPath,
 } from '@nestjs/swagger';
-import { NativeCurrency as ApiNativeCurrency } from './native-currency.entity';
-import { BlockExplorerUriTemplate as ApiBlockExplorerUriTemplate } from './block-explorer-uri-template.entity';
-import { GasPriceOracle as ApiGasPriceOracle } from './gas-price-oracle.entity';
-import { GasPriceFixed as ApiGasPriceFixed } from './gas-price-fixed.entity';
-import { RpcUri as ApiRpcUri } from './rpc-uri.entity';
-import { Theme as ApiTheme } from './theme.entity';
+import {
+  NativeCurrency,
+  NativeCurrency as ApiNativeCurrency,
+} from './native-currency.entity';
+import {
+  BlockExplorerUriTemplate,
+  BlockExplorerUriTemplate as ApiBlockExplorerUriTemplate,
+} from './block-explorer-uri-template.entity';
+import {
+  GasPriceOracle,
+  GasPriceOracle as ApiGasPriceOracle,
+} from './gas-price-oracle.entity';
+import {
+  GasPriceFixed,
+  GasPriceFixed as ApiGasPriceFixed,
+} from './gas-price-fixed.entity';
+import { RpcUri, RpcUri as ApiRpcUri } from './rpc-uri.entity';
+import { Theme, Theme as ApiTheme } from './theme.entity';
 
 @ApiExtraModels(ApiGasPriceOracle, ApiGasPriceFixed)
-export class Chain implements DomainChain {
+export class Chain {
   @ApiProperty()
   chainId: string;
   @ApiProperty()
@@ -22,8 +33,6 @@ export class Chain implements DomainChain {
   nativeCurrency: ApiNativeCurrency;
   @ApiProperty()
   transactionService: string;
-  @ApiProperty()
-  vpcTransactionService: string;
   @ApiProperty()
   blockExplorerUriTemplate: ApiBlockExplorerUriTemplate;
   @ApiProperty()
@@ -52,4 +61,36 @@ export class Chain implements DomainChain {
   shortName: string;
   @ApiProperty()
   theme: ApiTheme;
+
+  constructor(
+    chainId: string,
+    chainName: string,
+    nativeCurrency: NativeCurrency,
+    transactionService: string,
+    blockExplorerUriTemplate: BlockExplorerUriTemplate,
+    disabledWallets: string[],
+    features: string[],
+    gasPrice: Array<GasPriceOracle | GasPriceFixed>,
+    publicRpcUri: RpcUri,
+    rpcUri: RpcUri,
+    safeAppsRpcUri: RpcUri,
+    shortName: string,
+    theme: Theme,
+    ensRegistryAddress?: string,
+  ) {
+    this.chainId = chainId;
+    this.chainName = chainName;
+    this.nativeCurrency = nativeCurrency;
+    this.transactionService = transactionService;
+    this.blockExplorerUriTemplate = blockExplorerUriTemplate;
+    this.disabledWallets = disabledWallets;
+    this.ensRegistryAddress = ensRegistryAddress;
+    this.features = features;
+    this.gasPrice = gasPrice;
+    this.publicRpcUri = publicRpcUri;
+    this.rpcUri = rpcUri;
+    this.safeAppsRpcUri = safeAppsRpcUri;
+    this.shortName = shortName;
+    this.theme = theme;
+  }
 }


### PR DESCRIPTION
- Removes the `vpcTransactionService` from the route entity `Chain`
- Adjusts tests accordingly to check that the `vpcTransactionService` is not serialized