### PR TITLE
Add default environment variables for E2E

### DIFF
--- a/test/e2e-setup.ts
+++ b/test/e2e-setup.ts
@@ -1,0 +1,1 @@
+process.env.SAFE_CONFIG_BASE_URI = 'https://safe-config.staging.5afe.dev';

--- a/test/jest-ci.json
+++ b/test/jest-ci.json
@@ -2,6 +2,7 @@
   "moduleFileExtensions": ["js", "json", "ts"],
   "rootDir": "../",
   "roots": ["./src"],
+  "setupFiles": ["<rootDir>/test/e2e-setup.ts"],
   "testEnvironment": "node",
   "testRegex": [".*\\.spec\\.ts$", ".*\\e2e-spec\\.ts$"],
   "transform": {

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -2,6 +2,7 @@
   "moduleFileExtensions": ["js", "json", "ts"],
   "rootDir": ".",
   "roots": ["../src"],
+  "setupFiles": ["<rootDir>/e2e-setup.ts"],
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {


### PR DESCRIPTION
This PR updates the test execution configuration for end to end tests. A `test/e2e-setup.ts` file is provided to overwrite the environment during both `test:ci` and `test:e2e` tasks.