### PR TITLE
Remove AJV coerceTypes option

### DIFF
--- a/src/domain/chains/entities/__tests__/chain.factory.ts
+++ b/src/domain/chains/entities/__tests__/chain.factory.ts
@@ -34,7 +34,7 @@ export default function (
 ): Chain {
   return <Chain>{
     chainId: chainId ?? faker.datatype.number().toString(),
-    chainName: chainId ?? faker.company.name(),
+    chainName: chainName ?? faker.company.name(),
     description: description ?? faker.random.words(),
     l2: l2 ?? faker.datatype.boolean(),
     shortName: shortName ?? faker.company.companySuffix(),
@@ -49,7 +49,10 @@ export default function (
     theme: theme ?? themeFactory(),
     gasPrice: gasPrice ?? [gasPriceFixedFactory(), gasPriceOracleFactory()],
     ensRegistryAddress: ensRegistryAddress ?? faker.finance.ethereumAddress(),
-    disabledWallets: disabledWallets ?? faker.datatype.array(),
-    features: features ?? faker.datatype.array(),
+    disabledWallets: disabledWallets ?? [
+      faker.random.word(),
+      faker.random.word(),
+    ],
+    features: features ?? [faker.random.word(), faker.random.word()],
   };
 }

--- a/src/domain/safe-apps/entities/__tests__/safe-app.factory.ts
+++ b/src/domain/safe-apps/entities/__tests__/safe-app.factory.ts
@@ -22,7 +22,7 @@ export default function (
     name: name ?? faker.random.word(),
     iconUrl: iconUrl ?? faker.internet.url(),
     description: description ?? faker.random.word(),
-    chainIds: chainIds ?? [faker.random.numeric(), faker.random.numeric()],
+    chainIds: chainIds ?? [faker.datatype.number(), faker.datatype.number()],
     provider: provider ?? safeAppProviderFactory(),
     accessControl: accessControl ?? safeAppAccessControlFactory(),
     tags: tags ?? [faker.random.word(), faker.random.word()],

--- a/src/domain/safe-apps/entities/safe-app.entity.ts
+++ b/src/domain/safe-apps/entities/safe-app.entity.ts
@@ -7,7 +7,7 @@ export interface SafeApp {
   name: string;
   iconUrl: string;
   description: string;
-  chainIds: string[];
+  chainIds: number[];
   provider?: SafeAppProvider;
   accessControl: SafeAppAccessControl;
   tags: string[];

--- a/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
+++ b/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
@@ -28,7 +28,7 @@ export const safeAppSchema: Schema = {
     name: { type: 'string' },
     iconUrl: { type: 'string' },
     description: { type: 'string' },
-    chainIds: { type: 'array', items: { type: 'string' } },
+    chainIds: { type: 'array', items: { type: 'number' } },
     provider: { anyOf: [{ type: 'null' }, { $ref: 'safeAppProviderSchema' }] },
     accessControl: { $ref: 'safeAppAccessControlSchema' },
     tags: { type: 'array', items: { type: 'string' } },

--- a/src/domain/schema/json-schema.service.ts
+++ b/src/domain/schema/json-schema.service.ts
@@ -7,10 +7,8 @@ export class JsonSchemaService {
   private readonly ajv: Ajv;
 
   constructor() {
-    // coerceTypes param shouldn't be necessary when serialization is implemented.
     this.ajv = new Ajv({
       allowUnionTypes: true,
-      coerceTypes: true,
       useDefaults: true,
       discriminator: true,
     });

--- a/src/routes/safe-apps/entities/safe-app.entity.ts
+++ b/src/routes/safe-apps/entities/safe-app.entity.ts
@@ -1,9 +1,8 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { SafeApp as DomainSafeApp } from '../../../domain/safe-apps/entities/safe-app.entity';
 import { SafeAppAccessControl } from './safe-app-access-control.entity';
 import { SafeAppProvider } from './safe-app-provider.entity';
 
-export class SafeApp implements DomainSafeApp {
+export class SafeApp {
   @ApiProperty()
   id: number;
   @ApiProperty()
@@ -16,10 +15,32 @@ export class SafeApp implements DomainSafeApp {
   description: string;
   @ApiProperty()
   chainIds: string[];
-  @ApiPropertyOptional()
-  provider?: SafeAppProvider;
   @ApiProperty()
   accessControl: SafeAppAccessControl;
   @ApiProperty()
   tags: string[];
+  @ApiPropertyOptional()
+  provider?: SafeAppProvider;
+
+  constructor(
+    id: number,
+    url: string,
+    name: string,
+    iconUrl: string,
+    description: string,
+    chainIds: string[],
+    accessControl: SafeAppAccessControl,
+    tags: string[],
+    provider?: SafeAppProvider,
+  ) {
+    this.id = id;
+    this.url = url;
+    this.name = name;
+    this.iconUrl = iconUrl;
+    this.description = description;
+    this.chainIds = chainIds;
+    this.accessControl = accessControl;
+    this.tags = tags;
+    this.provider = provider;
+  }
 }

--- a/src/routes/safe-apps/safe-apps.service.ts
+++ b/src/routes/safe-apps/safe-apps.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { SafeApp } from '../../domain/safe-apps/entities/safe-app.entity';
 import { SafeAppsRepository } from '../../domain/safe-apps/safe-apps.repository';
 import { ISafeAppsRepository } from '../../domain/safe-apps/safe-apps.repository.interface';
+import { SafeApp } from './entities/safe-app.entity';
 
 @Injectable()
 export class SafeAppsService {
@@ -15,6 +15,24 @@ export class SafeAppsService {
     clientUrl?: string,
     url?: string,
   ): Promise<SafeApp[]> {
-    return this.safeAppsRepository.getSafeApps(chainId, clientUrl, url);
+    const result = await this.safeAppsRepository.getSafeApps(
+      chainId,
+      clientUrl,
+      url,
+    );
+    return result.map(
+      (safeApp) =>
+        new SafeApp(
+          safeApp.id,
+          safeApp.url,
+          safeApp.name,
+          safeApp.iconUrl,
+          safeApp.description,
+          safeApp.chainIds.map((chainId) => chainId.toString()),
+          safeApp.accessControl,
+          safeApp.tags,
+          safeApp.provider,
+        ),
+    );
   }
 }


### PR DESCRIPTION
This PR aims to remove the `coerceTypes` option which maps between types when validating with AJV. 

Some type definitions where updated, some factory functions had to be fixed, and an additional mapping for `SafeApp` entity was implemented to distinguish between domain entity and route entity, which have different a type for the `chainIds` array property.