### PR TITLE
Set DataDecodedParameter value as unknown

### DIFF
--- a/src/domain/data-decoder/entities/data-decoded.entity.ts
+++ b/src/domain/data-decoder/entities/data-decoded.entity.ts
@@ -1,7 +1,7 @@
 export interface DataDecodedParameter {
   name: string;
   type: string;
-  value: string | number;
+  value: unknown;
   valueDecoded?: Record<string, any> | Record<string, any>[];
 }
 

--- a/src/domain/data-decoder/entities/schemas/data-decoded.schema.ts
+++ b/src/domain/data-decoder/entities/schemas/data-decoded.schema.ts
@@ -5,10 +5,10 @@ export const dataDecodedParameterSchema: Schema = {
   properties: {
     name: { type: 'string' },
     type: { type: 'string' },
-    value: { anyOf: [{ type: 'string' }, { type: 'number' }] },
+    value: {},
     valueDecoded: { type: ['object', 'array', 'null'] },
   },
-  required: ['name', 'value'],
+  required: ['name', 'type', 'value'],
   additionalProperties: true,
 };
 

--- a/src/routes/data-decode/entities/data-decoded-parameter.ts
+++ b/src/routes/data-decode/entities/data-decoded-parameter.ts
@@ -6,7 +6,7 @@ export class DataDecodedParameter {
   @ApiProperty()
   paramType: string;
   @ApiProperty()
-  value: string | number;
+  value: unknown;
   @ApiProperty()
   valueDecoded?: Record<string, any> | Record<string, any>[] | undefined;
 }


### PR DESCRIPTION
- The parameter value can be of any type
- Sets `type` as a required field in the JSON schema