### PR TITLE
Change balance schema

### DIFF
--- a/src/domain/balances/entities/__tests__/balance.factory.ts
+++ b/src/domain/balances/entities/__tests__/balance.factory.ts
@@ -6,15 +6,15 @@ import { BalanceToken } from '../balance.token.entity';
 export function balanceFactory(
   tokenAddress?: string,
   token?: BalanceToken,
-  balance?: number,
-  fiatBalance?: number,
-  fiatConversion?: number,
+  balance?: string,
+  fiatBalance?: string,
+  fiatConversion?: string,
 ): Balance {
   return <Balance>{
     tokenAddress: tokenAddress ?? faker.finance.ethereumAddress(),
     token: token ?? balanceTokenFactory(),
-    balance: balance ?? faker.datatype.number(),
-    fiatBalance: fiatBalance ?? faker.datatype.number(),
-    fiatConversion: fiatConversion ?? faker.datatype.number(),
+    balance: balance ?? faker.random.numeric(),
+    fiatBalance: fiatBalance ?? faker.random.numeric(),
+    fiatConversion: fiatConversion ?? faker.random.numeric(),
   };
 }

--- a/src/domain/balances/entities/balance.entity.ts
+++ b/src/domain/balances/entities/balance.entity.ts
@@ -3,7 +3,7 @@ import { BalanceToken } from './balance.token.entity';
 export interface Balance {
   tokenAddress?: string;
   token?: BalanceToken;
-  balance: number;
-  fiatBalance: number;
-  fiatConversion: number;
+  balance: string;
+  fiatBalance: string;
+  fiatConversion: string;
 }

--- a/src/domain/balances/entities/schemas/balance.schema.ts
+++ b/src/domain/balances/entities/schemas/balance.schema.ts
@@ -17,9 +17,9 @@ const balanceSchema: Schema = {
   properties: {
     tokenAddress: { type: 'string', nullable: true },
     token: { anyOf: [{ type: 'null' }, { $ref: 'balanceToken' }] },
-    balance: { type: 'number' },
-    fiatBalance: { type: 'number' },
-    fiatConversion: { type: 'number' },
+    balance: { type: 'string' },
+    fiatBalance: { type: 'string' },
+    fiatConversion: { type: 'string' },
   },
   required: ['balance', 'fiatBalance', 'fiatConversion'],
 };

--- a/src/routes/balances/balances.service.ts
+++ b/src/routes/balances/balances.service.ts
@@ -47,16 +47,16 @@ export class BalancesService {
 
     // Get total fiat from [balances]
     const totalFiat: number = balances.reduce((acc, b) => {
-      return acc + b.fiatBalance;
+      return acc + Number(b.fiatBalance);
     }, 0);
 
     // Sort balances in place
     balances.sort((b1, b2) => {
-      return b2.fiatBalance - b1.fiatBalance;
+      return Number(b2.fiatBalance) - Number(b1.fiatBalance);
     });
 
     return <Balances>{
-      fiatTotal: totalFiat,
+      fiatTotal: totalFiat.toString(),
       items: balances,
     };
   }
@@ -66,8 +66,8 @@ export class BalancesService {
     usdToFiatRate: number,
     nativeCurrency: NativeCurrency,
   ): Balance {
-    const fiatConversion = txBalance.fiatConversion * usdToFiatRate;
-    const fiatBalance = txBalance.fiatBalance * usdToFiatRate;
+    const fiatConversion = Number(txBalance.fiatConversion) * usdToFiatRate;
+    const fiatBalance = Number(txBalance.fiatBalance) * usdToFiatRate;
     const tokenType =
       txBalance.tokenAddress === undefined
         ? TokenType.NativeToken
@@ -87,8 +87,8 @@ export class BalancesService {
         logoUri: logoUri,
       },
       balance: txBalance.balance.toString(),
-      fiatBalance: fiatBalance,
-      fiatConversion: fiatConversion,
+      fiatBalance: fiatBalance.toString(),
+      fiatConversion: fiatConversion.toString(),
     };
   }
 

--- a/src/routes/balances/entities/balance.entity.ts
+++ b/src/routes/balances/entities/balance.entity.ts
@@ -5,9 +5,9 @@ export class Balance {
   @ApiProperty()
   balance: string;
   @ApiProperty()
-  fiatBalance: number;
+  fiatBalance: string;
   @ApiProperty()
-  fiatConversion: number;
+  fiatConversion: string;
   @ApiProperty()
   tokenInfo: TokenInfo;
 }

--- a/src/routes/balances/entities/balances.entity.ts
+++ b/src/routes/balances/entities/balances.entity.ts
@@ -4,7 +4,7 @@ import { Balance } from './balance.entity';
 @ApiExtraModels(Balance)
 export class Balances {
   @ApiProperty()
-  fiatTotal: number;
+  fiatTotal: string;
   @ApiProperty({ type: 'array', oneOf: [{ $ref: getSchemaPath(Balance) }] })
   items: Balance[];
 }


### PR DESCRIPTION
This PR fixes the balance AJV schema, in order to avoid getting a `ValidationError` when using the `/v1/chains/<chainId>/safes/<safeAddress>/balances/<currency>` endpoint.

This is related to the `coerceTypes` option change that was introduced [here](https://github.com/5afe/safe-client-gateway-nest/pull/174).

Note: this only fix the `ValidationError` but this endpoint still needs some mappings to have feature-parity with Rust implementation of Client Gateway.