### PR TITLE
Add custom isDate AJV keyword

### DIFF
--- a/src/domain/safe/entities/multisig-transaction.entity.ts
+++ b/src/domain/safe/entities/multisig-transaction.entity.ts
@@ -2,7 +2,7 @@ import { Operation } from './operation.entity';
 
 export interface Confirmation {
   owner: string;
-  submissionDate: string; // TODO check Date type validation
+  submissionDate: Date;
   transactionHash?: string;
   signatureType: string;
   signature?: string;
@@ -21,9 +21,9 @@ export type MultisigTransaction = {
   gasPrice?: string;
   refundReceiver?: string;
   nonce: number;
-  executionDate?: string; // TODO check Date type validation
-  submissionDate?: string; // TODO check Date type validation
-  modified?: string; // TODO check Date type validation
+  executionDate?: Date;
+  submissionDate?: Date;
+  modified?: Date;
   blockNumber?: number;
   transactionHash?: string;
   safeTxHash: string;

--- a/src/domain/safe/entities/schemas/multisig-transaction.schema.ts
+++ b/src/domain/safe/entities/schemas/multisig-transaction.schema.ts
@@ -1,14 +1,10 @@
-import { JSONSchemaType } from 'ajv';
-import {
-  Confirmation,
-  MultisigTransaction,
-} from '../multisig-transaction.entity';
+import { Schema } from 'ajv';
 
-export const confirmationSchema: JSONSchemaType<Confirmation> = {
+export const confirmationSchema: Schema = {
   type: 'object',
   properties: {
     owner: { type: 'string' },
-    submissionDate: { type: 'string' },
+    submissionDate: { type: 'string', isDate: true },
     transactionHash: { type: 'string', nullable: true },
     signatureType: { type: 'string' },
     signature: { type: 'string', nullable: true },
@@ -16,7 +12,7 @@ export const confirmationSchema: JSONSchemaType<Confirmation> = {
   required: ['owner', 'submissionDate', 'signatureType'],
 };
 
-export const multisigTransactionSchema: JSONSchemaType<MultisigTransaction> = {
+export const multisigTransactionSchema: Schema = {
   type: 'object',
   properties: {
     safe: { type: 'string' },
@@ -31,9 +27,21 @@ export const multisigTransactionSchema: JSONSchemaType<MultisigTransaction> = {
     gasPrice: { type: 'string', nullable: true },
     refundReceiver: { type: 'string', nullable: true },
     nonce: { type: 'number' },
-    executionDate: { type: 'string', nullable: true },
-    submissionDate: { type: 'string', nullable: true },
-    modified: { type: 'string', nullable: true },
+    executionDate: {
+      type: 'string',
+      nullable: true,
+      isDate: true,
+    },
+    submissionDate: {
+      type: 'string',
+      nullable: true,
+      isDate: true,
+    },
+    modified: {
+      type: 'string',
+      nullable: true,
+      isDate: true,
+    },
     blockNumber: { type: 'number', nullable: true },
     transactionHash: { type: 'string', nullable: true },
     safeTxHash: { type: 'string' },

--- a/src/domain/schema/json-schema.service.ts
+++ b/src/domain/schema/json-schema.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import Ajv, { JSONSchemaType, Schema, ValidateFunction } from 'ajv';
 import addFormats from 'ajv-formats';
+import { addIsDate } from './keywords/is-date.keyword';
 
 @Injectable()
 export class JsonSchemaService {
@@ -12,6 +13,8 @@ export class JsonSchemaService {
       useDefaults: true,
       discriminator: true,
     });
+
+    addIsDate(this.ajv);
     addFormats(this.ajv, { formats: ['uri'] });
   }
 

--- a/src/domain/schema/keywords/is-date.keyword.spec.ts
+++ b/src/domain/schema/keywords/is-date.keyword.spec.ts
@@ -1,0 +1,90 @@
+import Ajv, { Schema, ValidateFunction } from 'ajv';
+import { addIsDate } from './is-date.keyword';
+import { faker } from '@faker-js/faker';
+
+describe('AJV Keyword – isDate', () => {
+  let ajv: Ajv;
+
+  beforeEach(() => {
+    ajv = new Ajv();
+    addIsDate(ajv);
+  });
+
+  describe('isDate is true', () => {
+    const schema: Schema = {
+      type: 'object',
+      properties: {
+        date: { type: 'string', isDate: true, nullable: true },
+      },
+    };
+
+    let validateFunction: ValidateFunction;
+
+    beforeEach(() => {
+      validateFunction = ajv.compile(schema);
+    });
+
+    it('not valid if date is empty string', async () => {
+      const actual = validateFunction({
+        date: '',
+      });
+
+      expect(actual).toBe(false);
+    });
+
+    it('valid if date is ISO-8601', async () => {
+      const actual = validateFunction({
+        date: faker.date.past().toISOString(),
+      });
+
+      expect(actual).toBe(true);
+    });
+
+    it('valid if date is null', async () => {
+      const actual = validateFunction({
+        date: null,
+      });
+
+      expect(actual).toBe(true);
+    });
+  });
+
+  describe('isDate is false', () => {
+    const schema: Schema = {
+      type: 'object',
+      properties: {
+        date: { type: 'string', isDate: false, nullable: true },
+      },
+    };
+
+    let validateFunction: ValidateFunction;
+
+    beforeEach(() => {
+      validateFunction = ajv.compile(schema);
+    });
+
+    it('valid if date is empty string', async () => {
+      const actual = validateFunction({
+        date: '',
+      });
+
+      expect(actual).toBe(true);
+    });
+
+    it('valid on random string', async () => {
+      const actual = validateFunction({
+        date: faker.datatype.string(),
+      });
+
+      expect(actual).toBe(true);
+    });
+
+    it('valid if date is null', async () => {
+      const actual = validateFunction({
+        date: null,
+      });
+
+      expect(actual).toBe(true);
+    });
+  });
+});

--- a/src/domain/schema/keywords/is-date.keyword.spec.ts
+++ b/src/domain/schema/keywords/is-date.keyword.spec.ts
@@ -40,6 +40,16 @@ describe('AJV Keyword – isDate', () => {
       expect(actual).toBe(true);
     });
 
+    it('date is coerced on valid date', async () => {
+      const date = faker.date.past().toISOString();
+      const payload = { date };
+
+      const actual = validateFunction(payload);
+
+      expect(actual).toBe(true);
+      expect(payload.date).toEqual<Date>(new Date(date));
+    });
+
     it('valid if date is null', async () => {
       const actual = validateFunction({
         date: null,

--- a/src/domain/schema/keywords/is-date.keyword.ts
+++ b/src/domain/schema/keywords/is-date.keyword.ts
@@ -1,0 +1,37 @@
+import Ajv from 'ajv';
+
+/**
+ * Registers isDate keyword in AJV
+ *
+ * When the value of isDate is set to true, the field will be validated
+ * according to ISO 8601.
+ *
+ * If the date is valid, the target property is created as {@link Date}.
+ * If the date is invalid, a validation error is thrown.
+ *
+ * Null date values are supported – we assume that a null date is a valid
+ * date.
+ *
+ * @param ajv - the AJV instance to which the isDate keyword should be registered
+ */
+export function addIsDate(ajv: Ajv) {
+  ajv.addKeyword({
+    keyword: 'isDate',
+    compile: (schema) => (value, obj) => {
+      // isDate: false – no need to validate
+      if (schema === false) return true;
+      // Nullability support – if a date is null we skip validation
+      if (value == null) return true;
+
+      // From here we need to validate the date
+      if (obj == null) return false;
+
+      // Non valid date format
+      if (isNaN(Date.parse(value))) return false;
+
+      // We have a valid date. We can set the property in the parent object
+      obj.parentData[obj.parentDataProperty] = new Date(value);
+      return true;
+    },
+  });
+}

--- a/src/domain/schema/keywords/is-date.keyword.ts
+++ b/src/domain/schema/keywords/is-date.keyword.ts
@@ -17,20 +17,20 @@ import Ajv from 'ajv';
 export function addIsDate(ajv: Ajv) {
   ajv.addKeyword({
     keyword: 'isDate',
-    compile: (schema) => (value, obj) => {
+    compile: (schema) => (data, dataContext) => {
       // isDate: false – no need to validate
       if (schema === false) return true;
       // Nullability support – if a date is null we skip validation
-      if (value == null) return true;
+      if (data == null) return true;
 
       // From here we need to validate the date
-      if (obj == null) return false;
+      if (dataContext == null) return false;
 
       // Non valid date format
-      if (isNaN(Date.parse(value))) return false;
+      if (isNaN(Date.parse(data))) return false;
 
       // We have a valid date. We can set the property in the parent object
-      obj.parentData[obj.parentDataProperty] = new Date(value);
+      dataContext.parentData[dataContext.parentDataProperty] = new Date(data);
       return true;
     },
   });


### PR DESCRIPTION
Closes #180

- Adds a `isDate` – a custom keyword for AJV which validates date types. If a date is valid then a `Date` instance is created on the target property where `isDate` was applied
- `isDate` can be applied to any property. For the date validation and serialization to happen its value should be set to `true`: `{ isDate: true }`