### PR TITLE
Add incoming transfers datasource function

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -232,6 +232,36 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
+  async getIncomingTransfers(
+    safeAddress: string,
+    executionDateGte?: string,
+    executionDateLte?: string,
+    to?: string,
+    value?: string,
+    tokenAddress?: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<Page<Transfer>> {
+    try {
+      const cacheKey = `${this.chainId}_${safeAddress}_incoming_transfers`;
+      const cacheKeyField = `${executionDateGte}_${executionDateLte}_${to}_${value}_${tokenAddress}_${limit}_${offset}`;
+      const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/incoming-transfers/`;
+      return await this.dataSource.get(cacheKey, cacheKeyField, url, {
+        params: {
+          execution_date__gte: executionDateGte,
+          execution_date__lte: executionDateLte,
+          to,
+          value,
+          tokenAddress,
+          limit,
+          offset,
+        },
+      });
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
   async getMultisigTransactions(
     safeAddress: string,
     ordering?: string,

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -70,6 +70,17 @@ export interface ITransactionApi {
     offset?: number,
   ): Promise<Page<Transfer>>;
 
+  getIncomingTransfers(
+    safeAddress: string,
+    executionDateGte?: string,
+    executionDateLte?: string,
+    to?: string,
+    value?: string,
+    tokenAddress?: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<Page<Transfer>>;
+
   getMultisigTransactions(
     safeAddress: string,
     ordering?: string,

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -16,6 +16,18 @@ export interface ISafeRepository {
     offset?: number,
   ): Promise<Page<Transfer>>;
 
+  getIncomingTransfers(
+    chainId: string,
+    safeAddress: string,
+    executionDateGte?: string,
+    executionDateLte?: string,
+    to?: string,
+    value?: string,
+    tokenAddress?: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<Page<Transfer>>;
+
   getQueuedTransactions(
     chainId: string,
     safeAddress: string,

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -50,6 +50,34 @@ export class SafeRepository implements ISafeRepository {
     return page;
   }
 
+  async getIncomingTransfers(
+    chainId: string,
+    safeAddress: string,
+    executionDateGte?: string,
+    executionDateLte?: string,
+    to?: string,
+    value?: string,
+    tokenAddress?: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<Page<Transfer>> {
+    const transactionService =
+      await this.transactionApiManager.getTransactionApi(chainId);
+    const page = await transactionService.getIncomingTransfers(
+      safeAddress,
+      executionDateGte,
+      executionDateLte,
+      to,
+      value,
+      tokenAddress,
+      limit,
+      offset,
+    );
+    page.results.map((transfer) => this.transferValidator.validate(transfer));
+
+    return page;
+  }
+
   async getQueuedTransactions(
     chainId: string,
     safeAddress: string,


### PR DESCRIPTION
Closes #168 

This PR adds the datasource retrieval logic for incoming transfers endpoint.

It assumes the incoming transfers are `Transfer` domain entity instances. It also assumes we need to implement the query params we currently have in Rust implementation of Client Gateway (`executionDateGte`, `executionDateLte`, `to`, `value`, `tokenAddress`...).