### PR TITLE
Add MultisigTransaction retrieval by safeTxHash

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -232,6 +232,36 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
+  async getIncomingTransfers(
+    safeAddress: string,
+    executionDateGte?: string,
+    executionDateLte?: string,
+    to?: string,
+    value?: string,
+    tokenAddress?: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<Page<Transfer>> {
+    try {
+      const cacheKey = `${this.chainId}_${safeAddress}_incoming_transfers`;
+      const cacheKeyField = `${executionDateGte}_${executionDateLte}_${to}_${value}_${tokenAddress}_${limit}_${offset}`;
+      const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/incoming-transfers/`;
+      return await this.dataSource.get(cacheKey, cacheKeyField, url, {
+        params: {
+          execution_date__gte: executionDateGte,
+          execution_date__lte: executionDateLte,
+          to,
+          value,
+          tokenAddress,
+          limit,
+          offset,
+        },
+      });
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
   async getMultisigTransactions(
     safeAddress: string,
     ordering?: string,

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -259,6 +259,18 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
+  async getMultisigTransaction(
+    safeTransactionHash: string,
+  ): Promise<MultisigTransaction> {
+    try {
+      const cacheKey = `${this.chainId}_${safeTransactionHash}_multisig_transaction`;
+      const url = `${this.baseUrl}/api/v1/multisig-transactions/${safeTransactionHash}/`;
+      return await this.dataSource.get(cacheKey, '', url);
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
   async getAllTransactions(
     safeAddress: string,
     ordering?: string,

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -70,6 +70,10 @@ export interface ITransactionApi {
     offset?: number,
   ): Promise<Page<Transfer>>;
 
+  getMultisigTransaction(
+    safeTransactionHash: string,
+  ): Promise<MultisigTransaction>;
+
   getMultisigTransactions(
     safeAddress: string,
     ordering?: string,

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -74,6 +74,17 @@ export interface ITransactionApi {
     safeTransactionHash: string,
   ): Promise<MultisigTransaction>;
 
+  getIncomingTransfers(
+    safeAddress: string,
+    executionDateGte?: string,
+    executionDateLte?: string,
+    to?: string,
+    value?: string,
+    tokenAddress?: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<Page<Transfer>>;
+
   getMultisigTransactions(
     safeAddress: string,
     ordering?: string,

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -80,7 +80,7 @@ export interface ITransactionApi {
     limit?: number,
     offset?: number,
   ): Promise<Page<Transfer>>;
-  
+
   getMultisigTransaction(
     safeTransactionHash: string,
   ): Promise<MultisigTransaction>;

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -16,6 +16,18 @@ export interface ISafeRepository {
     offset?: number,
   ): Promise<Page<Transfer>>;
 
+  getIncomingTransfers(
+    chainId: string,
+    safeAddress: string,
+    executionDateGte?: string,
+    executionDateLte?: string,
+    to?: string,
+    value?: string,
+    tokenAddress?: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<Page<Transfer>>;
+
   getQueuedTransactions(
     chainId: string,
     safeAddress: string,

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -27,4 +27,9 @@ export interface ISafeRepository {
     chainId: string,
     safeAddress: string,
   ): Promise<Page<TransactionType>>;
+
+  getMultiSigTransaction(
+    chainId: string,
+    safeTransactionHash: string,
+  ): Promise<MultisigTransaction>;
 }

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -90,4 +90,17 @@ export class SafeRepository implements ISafeRepository {
 
     return page;
   }
+
+  async getMultiSigTransaction(
+    chainId: string,
+    safeTransactionHash: string,
+  ): Promise<MultisigTransaction> {
+    const transactionService =
+      await this.transactionApiManager.getTransactionApi(chainId);
+    const multiSigTransaction = await transactionService.getMultisigTransaction(
+      safeTransactionHash,
+    );
+
+    return this.multisigTransactionValidator.validate(multiSigTransaction);
+  }
 }

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -50,6 +50,34 @@ export class SafeRepository implements ISafeRepository {
     return page;
   }
 
+  async getIncomingTransfers(
+    chainId: string,
+    safeAddress: string,
+    executionDateGte?: string,
+    executionDateLte?: string,
+    to?: string,
+    value?: string,
+    tokenAddress?: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<Page<Transfer>> {
+    const transactionService =
+      await this.transactionApiManager.getTransactionApi(chainId);
+    const page = await transactionService.getIncomingTransfers(
+      safeAddress,
+      executionDateGte,
+      executionDateLte,
+      to,
+      value,
+      tokenAddress,
+      limit,
+      offset,
+    );
+    page.results.map((transfer) => this.transferValidator.validate(transfer));
+
+    return page;
+  }
+
   async getQueuedTransactions(
     chainId: string,
     safeAddress: string,


### PR DESCRIPTION
Closes #164

This PR adds the datasource retrieval logic for pulling one Multisig Transaction from Tx Service by `SafeTransactionHash`.
