### PR TITLE
Split TokenTransfer into ERC20 and ERC721

### DIFF
--- a/src/domain/safe/entities/schemas/erc20-transfer.schema.ts
+++ b/src/domain/safe/entities/schemas/erc20-transfer.schema.ts
@@ -1,19 +1,19 @@
 import { JSONSchemaType } from 'ajv';
-import { TokenTransfer } from '../transfer.entity';
+import { ERC20Transfer } from '../transfer.entity';
 
-export const tokenTransferSchema: JSONSchemaType<TokenTransfer> = {
+export const erc20TransferSchema: JSONSchemaType<ERC20Transfer> = {
   type: 'object',
   properties: {
     type: {
       type: 'string',
-      enum: ['ERC721_TRANSFER', 'ERC20_TRANSFER'],
+      const: 'ERC20_TRANSFER',
     },
     executionDate: { type: 'string' },
     blockNumber: { type: 'number' },
     transactionHash: { type: 'string' },
     to: { type: 'string' },
     from: { type: 'string' },
-    tokenId: { type: 'string' },
+    value: { type: 'string' },
     tokenAddress: { type: 'string', nullable: true },
   },
   required: [
@@ -23,6 +23,6 @@ export const tokenTransferSchema: JSONSchemaType<TokenTransfer> = {
     'transactionHash',
     'to',
     'from',
-    'tokenId',
+    'value',
   ],
 };

--- a/src/domain/safe/entities/schemas/erc721-transfer.schema.ts
+++ b/src/domain/safe/entities/schemas/erc721-transfer.schema.ts
@@ -1,0 +1,28 @@
+import { JSONSchemaType } from 'ajv';
+import { ERC721Transfer } from '../transfer.entity';
+
+export const erc721TransferSchema: JSONSchemaType<ERC721Transfer> = {
+  type: 'object',
+  properties: {
+    type: {
+      type: 'string',
+      const: 'ERC721_TRANSFER',
+    },
+    executionDate: { type: 'string' },
+    blockNumber: { type: 'number' },
+    transactionHash: { type: 'string' },
+    to: { type: 'string' },
+    from: { type: 'string' },
+    tokenId: { type: 'string' },
+    tokenAddress: { type: 'string', nullable: true },
+  },
+  required: [
+    'type',
+    'executionDate',
+    'blockNumber',
+    'transactionHash',
+    'to',
+    'from',
+    'tokenId',
+  ],
+};

--- a/src/domain/safe/entities/schemas/transfer.schema.ts
+++ b/src/domain/safe/entities/schemas/transfer.schema.ts
@@ -1,6 +1,7 @@
 import { nativeTokenTransferSchema } from './native-token-transfer.schema';
-import { tokenTransferSchema } from './token-transfer.schema';
 import { Schema } from 'ajv';
+import { erc20TransferSchema } from './erc20-transfer.schema';
+import { erc721TransferSchema } from './erc721-transfer.schema';
 
 export const transferSchema: Schema = {
   type: 'object',
@@ -13,5 +14,5 @@ export const transferSchema: Schema = {
     'to',
     'from',
   ],
-  oneOf: [nativeTokenTransferSchema, tokenTransferSchema],
+  oneOf: [nativeTokenTransferSchema, erc20TransferSchema, erc721TransferSchema],
 };

--- a/src/domain/safe/entities/transfer.entity.ts
+++ b/src/domain/safe/entities/transfer.entity.ts
@@ -7,8 +7,14 @@ export type Transfer = {
   from: string;
 };
 
-export interface TokenTransfer extends Transfer {
-  type: 'ERC721_TRANSFER' | 'ERC20_TRANSFER';
+export interface ERC20Transfer extends Transfer {
+  type: 'ERC20_TRANSFER';
+  value: string;
+  tokenAddress?: string;
+}
+
+export interface ERC721Transfer extends Transfer {
+  type: 'ERC721_TRANSFER';
   tokenId: string;
   tokenAddress?: string;
 }


### PR DESCRIPTION
- The schema for `ERC20Transfer` and `ERC721Transfer` is different
- An `ERC20Transfer` has a required `value` field while `ERC721Transfer` has a required `tokenId` field. Both share an optional `tokenAddress`.
- Given these differences both entities and schemas were split and can be used independently