### PR TITLE
Extend test timeout for development setup

### DIFF
--- a/test/jest-all.json
+++ b/test/jest-all.json
@@ -5,6 +5,7 @@
   "setupFiles": ["<rootDir>/test/e2e-setup.ts"],
   "testEnvironment": "node",
   "testRegex": [".*\\.spec\\.ts$", ".*\\e2e-spec\\.ts$"],
+  "testTimeout": 20000,
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },


### PR DESCRIPTION
This PR extends the Jest timeout for `test:all` task. Some e2e tests need more than 5 seconds (cold start) to finish due to app initialisation and network delays. This configuration is already present for `test:e2e`, but it's also useful for running `test:all`, which is intended to use during the development process.