### PR TITLE
Add get safes by owners endpoint

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -61,7 +61,7 @@
         "--inspect-brk",
         "${workspaceRoot}/node_modules/.bin/jest",
         "--runInBand",
-        "--config=test/jest-ci.json",
+        "--config=test/jest-e2e.json",
         "false",
         "${relativeFile}"
       ],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import { DataDecodedModule } from './routes/data-decode/data-decoded.module';
 import { DelegatesModule } from './routes/delegates/delegates.module';
 import { SafeAppsModule } from './routes/safe-apps/safe-apps.module';
 import { HealthModule } from './routes/health/health.module';
+import { OwnersModule } from './routes/owners/owners.module';
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { HealthModule } from './routes/health/health.module';
     DataDecodedModule,
     DelegatesModule,
     HealthModule,
+    OwnersModule,
     SafeAppsModule,
     // common
     CacheModule,

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -168,7 +168,7 @@ export class SafeRepository implements ISafeRepository {
   ): Promise<SafeList> {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(chainId);
-    const safeList = transactionService.getSafesByOwner(ownerAddress);
+    const safeList = await transactionService.getSafesByOwner(ownerAddress);
 
     return this.safeListValidator.validate(safeList);
   }

--- a/src/routes/owners/__tests__/get-safes-by-owner.e2e-spec.ts
+++ b/src/routes/owners/__tests__/get-safes-by-owner.e2e-spec.ts
@@ -1,0 +1,49 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { RedisClientType } from 'redis';
+import * as request from 'supertest';
+import { AppModule } from '../../../app.module';
+import { redisClientFactory } from '../../../__tests__/redis-client.factory';
+
+describe('Get safes by owner e2e test', () => {
+  let app: INestApplication;
+  let redisClient: RedisClientType;
+  const chainId = '5'; // Görli testnet
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+    redisClient = await redisClientFactory();
+  });
+
+  beforeEach(async () => {
+    await redisClient.flushAll();
+  });
+
+  it('GET /owners/<owner_address>/safes', async () => {
+    const ownerAddress = '0xf10E2042ec19747401E5EA174EfB63A0058265E6';
+    const ownerCacheKey = `${chainId}_${ownerAddress}_owner_safes`;
+
+    await request(app.getHttpServer())
+      .get(`/chains/${chainId}/owners/${ownerAddress}/safes`)
+      .expect(200)
+      .then(({ body }) => {
+        expect(body).toEqual(
+          expect.objectContaining({ safes: expect.any(Array) }),
+        );
+      });
+
+    const cacheContent = await redisClient.hGet(ownerCacheKey, '');
+    expect(cacheContent).not.toBeNull();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await redisClient.flushAll();
+    await redisClient.quit();
+  });
+});

--- a/src/routes/owners/entities/safe-list.entity.ts
+++ b/src/routes/owners/entities/safe-list.entity.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SafeList as DomainSafeList } from '../../../domain/safe/entities/safe-list.entity';
+
+export class SafeList implements DomainSafeList {
+  @ApiProperty()
+  safes: string[];
+}

--- a/src/routes/owners/owners.controller.spec.ts
+++ b/src/routes/owners/owners.controller.spec.ts
@@ -1,0 +1,158 @@
+import { faker } from '@faker-js/faker';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import {
+  fakeConfigurationService,
+  TestConfigurationModule,
+} from '../../config/__tests__/test.configuration.module';
+import {
+  fakeCacheService,
+  TestCacheModule,
+} from '../../datasources/cache/__tests__/test.cache.module';
+import {
+  mockNetworkService,
+  TestNetworkModule,
+} from '../../datasources/network/__tests__/test.network.module';
+import { DomainModule } from '../../domain.module';
+import chainFactory from '../../domain/chains/entities/__tests__/chain.factory';
+import { DataSourceErrorFilter } from '../common/filters/data-source-error.filter';
+import { OwnersModule } from './owners.module';
+
+describe('Owners Controller (Unit)', () => {
+  let app: INestApplication;
+  let safeConfigApiUrl: string;
+
+  beforeAll(async () => {
+    safeConfigApiUrl = faker.internet.url();
+    fakeConfigurationService.set('safeConfig.baseUri', safeConfigApiUrl);
+    fakeConfigurationService.set('exchange.baseUri', faker.internet.url());
+    fakeConfigurationService.set('exchange.apiKey', faker.datatype.uuid());
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    fakeCacheService.clear();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        // feature
+        OwnersModule,
+        // common
+        DomainModule,
+        TestCacheModule,
+        TestConfigurationModule,
+        TestNetworkModule,
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalFilters(new DataSourceErrorFilter());
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET safes by owner address', () => {
+    it(`Success`, async () => {
+      const chainId = faker.random.numeric();
+      const ownerAddress = faker.finance.ethereumAddress();
+      const chainResponse = chainFactory(chainId);
+      const transactionApiSafeListResponse = {
+        safes: [
+          faker.finance.ethereumAddress(),
+          faker.finance.ethereumAddress(),
+          faker.finance.ethereumAddress(),
+        ],
+      };
+      mockNetworkService.get.mockResolvedValueOnce({ data: chainResponse });
+      mockNetworkService.get.mockResolvedValueOnce({
+        data: transactionApiSafeListResponse,
+      });
+
+      await request(app.getHttpServer())
+        .get(`/chains/${chainId}/owners/${ownerAddress}/safes`)
+        .expect(200)
+        .expect(transactionApiSafeListResponse);
+    });
+
+    it('Failure: Config API fails', async () => {
+      const chainId = faker.random.numeric();
+      const ownerAddress = faker.finance.ethereumAddress();
+      mockNetworkService.get.mockRejectedValueOnce({
+        status: 500,
+      });
+
+      await request(app.getHttpServer())
+        .get(`/chains/${chainId}/owners/${ownerAddress}/safes`)
+        .expect(500)
+        .expect({
+          message: 'An error occurred',
+          code: 500,
+        });
+
+      expect(mockNetworkService.get).toBeCalledTimes(1);
+      expect(mockNetworkService.get).toBeCalledWith(
+        `${safeConfigApiUrl}/api/v1/chains/${chainId}`,
+        undefined,
+      );
+    });
+
+    it('Failure: Transaction API fails', async () => {
+      const chainId = faker.random.numeric();
+      const ownerAddress = faker.finance.ethereumAddress();
+      const chainResponse = chainFactory(chainId);
+      mockNetworkService.get.mockResolvedValueOnce({ data: chainResponse });
+      mockNetworkService.get.mockRejectedValueOnce({
+        status: 500,
+      });
+
+      await request(app.getHttpServer())
+        .get(`/chains/${chainId}/owners/${ownerAddress}/safes`)
+        .expect(500)
+        .expect({
+          message: 'An error occurred',
+          code: 500,
+        });
+
+      expect(mockNetworkService.get).toBeCalledTimes(2);
+      expect(mockNetworkService.get).toBeCalledWith(
+        `${safeConfigApiUrl}/api/v1/chains/${chainId}`,
+        undefined,
+      );
+      expect(mockNetworkService.get).toBeCalledWith(
+        `${chainResponse.transactionService}/api/v1/owners/${ownerAddress}/safes/`,
+        undefined,
+      );
+    });
+
+    it('Failure: data validation fails', async () => {
+      const chainId = faker.random.numeric();
+      const ownerAddress = faker.finance.ethereumAddress();
+      const chainResponse = chainFactory(chainId);
+      const transactionApiSafeListResponse = {
+        safes: [
+          faker.finance.ethereumAddress(),
+          faker.datatype.number(),
+          faker.finance.ethereumAddress(),
+        ],
+      };
+      mockNetworkService.get.mockResolvedValueOnce({ data: chainResponse });
+      mockNetworkService.get.mockResolvedValueOnce({
+        data: transactionApiSafeListResponse,
+      });
+
+      await request(app.getHttpServer())
+        .get(`/chains/${chainId}/owners/${ownerAddress}/safes`)
+        .expect(500)
+        .expect({
+          message: 'Validation failed',
+          code: 42,
+          arguments: [],
+        });
+    });
+  });
+});

--- a/src/routes/owners/owners.controller.ts
+++ b/src/routes/owners/owners.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { SafeList } from '../../domain/safe/entities/safe-list.entity';
+import { SafeList as ApiSafeList } from './entities/safe-list.entity';
+import { OwnersService } from './owners.service';
+
+@ApiTags('owners')
+@Controller({
+  path: '',
+  version: '1',
+})
+export class OwnersController {
+  constructor(private readonly ownersService: OwnersService) {}
+
+  @ApiOkResponse({ type: ApiSafeList })
+  @Get('chains/:chainId/owners/:ownerAddress/safes')
+  async getSafesByOwner(
+    @Param('chainId') chainId: string,
+    @Param('ownerAddress') ownerAddress: string,
+  ): Promise<SafeList> {
+    return this.ownersService.getSafesByOwner(chainId, ownerAddress);
+  }
+}

--- a/src/routes/owners/owners.controller.ts
+++ b/src/routes/owners/owners.controller.ts
@@ -1,7 +1,6 @@
 import { Controller, Get, Param } from '@nestjs/common';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
-import { SafeList } from '../../domain/safe/entities/safe-list.entity';
-import { SafeList as ApiSafeList } from './entities/safe-list.entity';
+import { SafeList } from './entities/safe-list.entity';
 import { OwnersService } from './owners.service';
 
 @ApiTags('owners')
@@ -12,7 +11,7 @@ import { OwnersService } from './owners.service';
 export class OwnersController {
   constructor(private readonly ownersService: OwnersService) {}
 
-  @ApiOkResponse({ type: ApiSafeList })
+  @ApiOkResponse({ type: SafeList })
   @Get('chains/:chainId/owners/:ownerAddress/safes')
   async getSafesByOwner(
     @Param('chainId') chainId: string,

--- a/src/routes/owners/owners.module.ts
+++ b/src/routes/owners/owners.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { OwnersController } from './owners.controller';
+import { OwnersService } from './owners.service';
+
+@Module({
+  controllers: [OwnersController],
+  providers: [OwnersService],
+})
+export class OwnersModule {}

--- a/src/routes/owners/owners.service.ts
+++ b/src/routes/owners/owners.service.ts
@@ -1,0 +1,19 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { SafeList } from '../../domain/safe/entities/safe-list.entity';
+import { SafeRepository } from '../../domain/safe/safe.repository';
+import { ISafeRepository } from '../../domain/safe/safe.repository.interface';
+
+@Injectable()
+export class OwnersService {
+  constructor(
+    @Inject(ISafeRepository)
+    private readonly safeRepository: SafeRepository,
+  ) {}
+
+  async getSafesByOwner(
+    chainId: string,
+    ownerAddress: string,
+  ): Promise<SafeList> {
+    return this.safeRepository.getSafesByOwner(chainId, ownerAddress);
+  }
+}

--- a/src/routes/owners/owners.service.ts
+++ b/src/routes/owners/owners.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { SafeList } from '../../domain/safe/entities/safe-list.entity';
 import { SafeRepository } from '../../domain/safe/safe.repository';
 import { ISafeRepository } from '../../domain/safe/safe.repository.interface';
+import { SafeList } from './entities/safe-list.entity';
 
 @Injectable()
 export class OwnersService {


### PR DESCRIPTION
This PR implements the `chains/<chain_id>/owners/<owner_address>/safes route.