### PR TITLE
Add AddressInfoModule

### DIFF
--- a/src/routes/common/address-info/address-info.module.ts
+++ b/src/routes/common/address-info/address-info.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { AddressInfoHelper } from './address-info.helper';
+
+@Module({
+  providers: [AddressInfoHelper],
+  exports: [AddressInfoHelper],
+})
+export class AddressInfoModule {}


### PR DESCRIPTION
- Adds `AddressInfoModule` – this module exports the `AddressInfoHelper`
- Even though `AddressInfoHelper` was already present in the project it was not ready to be used in the project graph due to the lack of module that would provide this dependency