### PR TITLE
Fix AddressInfoHelper.getOrDefault return type

### DIFF
--- a/src/routes/common/address-info/address-info.helper.ts
+++ b/src/routes/common/address-info/address-info.helper.ts
@@ -47,8 +47,10 @@ export class AddressInfoHelper {
    * @param chainId - the chain id where the contract exists
    * @param address - the address of the contract to which we want to retrieve its metadata
    */
-  getOrDefault(chainId: string, address: string): Promise<AddressInfo | null> {
-    return this.get(chainId, address).catch(() => new AddressInfo(address));
+  getOrDefault(chainId: string, address: string): Promise<AddressInfo> {
+    return this.get(chainId, address)
+      .then((addressInfo) => addressInfo ?? new AddressInfo(address))
+      .catch(() => new AddressInfo(address));
   }
 
   /**


### PR DESCRIPTION
- The goal of `AddressInfoHelper.getOrDefault` is to always return an `AddressInfo`
- This means that a value should be returned if the function was successful or not
- However for the address `0x0000000000000000000000000000000000000000` we consider the function to be successful with a `null` value so instead of returning an `AddressInfo` we return `null` instead – we should also return an `AddressInfo` in these cases