### PR TITLE
Execute e2e tests in serial

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json",
-    "test:e2e:cov": "jest --coverage --config ./test/jest-e2e.json",
-    "test:all": "jest --config ./test/jest-all.json",
-    "test:all:cov": "jest --coverage --config ./test/jest-all.json",
+    "test:e2e": "jest --config ./test/jest-e2e.json  --runInBand",
+    "test:e2e:cov": "jest --coverage --config ./test/jest-e2e.json  --runInBand",
+    "test:all": "jest --config ./test/jest-all.json --runInBand",
+    "test:all:cov": "jest --coverage --config ./test/jest-all.json --runInBand",
     "postinstall": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
**Issue**
Currently, we are flushing Redis contents in every end-to-end test suite run. This is fine when the test suites are executed in serial, but it causes some troubles sometimes on a parallel execution since one flush can delete data that is expected in another.

**Temporal solution**
This sets serial execution for each test suite in Jest configuration. This is just a workaround. We need to find a permanent solution to this issue.