### PR TITLE
Generate more meaningful MasterCopy fake values

### DIFF
--- a/src/domain/chains/entities/__tests__/master-copy.factory.ts
+++ b/src/domain/chains/entities/__tests__/master-copy.factory.ts
@@ -10,11 +10,13 @@ export default function (
   l2?: boolean,
 ): MasterCopy {
   return <MasterCopy>{
-    address: address ?? faker.random.word(),
-    version: version ?? faker.random.word(),
-    deployer: deployer ?? faker.random.word(),
-    deployedBlockNumber: deployedBlockNumber ?? 10,
-    lastIndexedBlockNumber: lastIndexedBlockNumber ?? 11,
-    l2: l2 ?? false,
+    address: address ?? faker.finance.ethereumAddress(),
+    version: version ?? faker.system.semver(),
+    deployer: deployer ?? faker.finance.ethereumAddress(),
+    deployedBlockNumber:
+      deployedBlockNumber ?? faker.datatype.number({ min: 0 }),
+    lastIndexedBlockNumber:
+      lastIndexedBlockNumber ?? faker.datatype.number({ min: 0 }),
+    l2: l2 ?? faker.datatype.boolean(),
   };
 }


### PR DESCRIPTION
- `address` is now a random ethereum address (it was a random word before)
- `version` now generates a fake `semver` string (it was a random word before)
- `deployer` is now a random ethereum address (it was a random word before)
- `deployedBlockNumber` now generates a random positive integer (it was `10` before)
- `lastIndexedBlockNumber` now generates a random positive integer (it was `11` before)
- `l2` now generates a random boolean (it was `false` before)