### PR TITLE
Use builder pattern for MultisigTransaction

### DIFF
--- a/src/domain/common/__tests__/builder.ts
+++ b/src/domain/common/__tests__/builder.ts
@@ -1,0 +1,3 @@
+export interface Builder<T> {
+  build(): T;
+}

--- a/src/domain/safe/entities/__tests__/multisig-transaction.factory.ts
+++ b/src/domain/safe/entities/__tests__/multisig-transaction.factory.ts
@@ -5,88 +5,207 @@ import {
 import { Operation } from '../operation.entity';
 import { faker } from '@faker-js/faker';
 import multisigTransactionConfirmationFactory from './multisig-transaction-confirmation.factory';
+import { Builder } from '../../../common/__tests__/builder';
 
-export default function (
-  baseGas?: number | null,
-  blockNumber?: number | null,
-  confirmations?: Confirmation[] | null,
-  confirmationsRequired?: number | null,
-  data?: string | null,
-  dataDecoded?: any | null,
-  ethGasPrice?: string | null,
-  executionDate?: Date | null,
-  executor?: string | null,
-  fee?: string | null,
-  gasPrice?: string | null,
-  gasToken?: string | null,
-  gasUsed?: number | null,
-  isExecuted?: boolean,
-  isSuccessful?: boolean | null,
-  modified?: Date | null,
-  nonce?: number,
-  operation?: Operation,
-  origin?: string | null,
-  refundReceiver?: string | null,
-  safe?: string,
-  safeTxGas?: number | null,
-  safeTxHash?: string,
-  signatures?: string | null,
-  submissionDate?: Date | null,
-  to?: string,
-  transactionHash?: string | null,
-  value?: string | null,
-): MultisigTransaction {
-  return <MultisigTransaction>{
-    baseGas: baseGas === undefined ? faker.datatype.number() : baseGas,
-    blockNumber:
-      blockNumber === undefined ? faker.datatype.number() : blockNumber,
-    confirmations:
-      confirmations === undefined
-        ? [multisigTransactionConfirmationFactory()]
-        : confirmations,
-    confirmationsRequired:
-      confirmationsRequired === confirmationsRequired
-        ? faker.datatype.number({ min: 0 })
-        : confirmationsRequired,
-    data: data === undefined ? faker.datatype.hexadecimal() : data,
-    dataDecoded:
-      dataDecoded === undefined ? faker.datatype.json() : dataDecoded,
-    ethGasPrice:
-      ethGasPrice === undefined ? faker.datatype.hexadecimal() : ethGasPrice,
-    executionDate:
-      executionDate === undefined ? faker.date.recent() : executionDate,
-    executor:
-      executor === undefined ? faker.finance.ethereumAddress() : executor,
-    fee: fee === undefined ? faker.datatype.hexadecimal() : fee,
-    gasPrice: gasPrice === undefined ? faker.datatype.hexadecimal() : gasPrice,
-    gasToken:
-      gasToken === undefined ? faker.finance.ethereumAddress() : gasToken,
-    gasUsed:
-      gasUsed === undefined ? faker.datatype.number({ min: 0 }) : gasUsed,
-    isExecuted: isExecuted ?? faker.datatype.boolean(),
-    isSuccessful:
-      isSuccessful === undefined ? faker.datatype.boolean() : isSuccessful,
-    modified: modified === undefined ? faker.date.recent() : modified,
-    nonce: nonce ?? faker.datatype.number({ min: 0 }),
-    operation: operation ?? faker.helpers.arrayElement([0, 1]),
-    origin: origin === undefined ? faker.internet.url() : origin,
-    refundReceiver:
-      refundReceiver === undefined
-        ? faker.finance.ethereumAddress()
-        : refundReceiver,
-    safe: safe ?? faker.finance.ethereumAddress(),
-    safeTxGas:
-      safeTxGas === undefined ? faker.datatype.number({ min: 0 }) : safeTxGas,
-    safeTxHash: safeTxHash ?? faker.datatype.hexadecimal(),
-    signatures:
-      signatures === undefined ? faker.datatype.hexadecimal() : signatures,
-    submissionDate:
-      submissionDate === undefined ? faker.date.recent() : submissionDate,
-    to: to ?? faker.finance.ethereumAddress(),
-    transactionHash:
-      transactionHash === undefined
-        ? faker.datatype.hexadecimal()
-        : transactionHash,
-    value: value === undefined ? faker.datatype.hexadecimal() : value,
-  };
+export class MultisigTransactionBuilder
+  implements Builder<MultisigTransaction>
+{
+  private baseGas: number = faker.datatype.number();
+  private blockNumber: number = faker.datatype.number();
+  private confirmations: Confirmation[] = [
+    multisigTransactionConfirmationFactory(),
+  ];
+  private confirmationsRequired: number = faker.datatype.number();
+  private data: string = faker.datatype.hexadecimal();
+  private dataDecoded: any = faker.datatype.json();
+  private ethGasPrice: string = faker.datatype.hexadecimal();
+  private executionDate: Date = faker.date.recent();
+  private executor: string = faker.finance.ethereumAddress();
+  private fee: string = faker.datatype.hexadecimal();
+  private gasPrice: string = faker.datatype.hexadecimal();
+  private gasToken: string = faker.finance.ethereumAddress();
+  private gasUsed: number = faker.datatype.number();
+  private isExecuted: boolean = faker.datatype.boolean();
+  private isSuccessful: boolean = faker.datatype.boolean();
+  private modified: Date = faker.date.recent();
+  private nonce: number = faker.datatype.number();
+  private operation: Operation = faker.helpers.arrayElement([0, 1]);
+  private origin: string = faker.internet.url();
+  private refundReceiver: string = faker.finance.ethereumAddress();
+  private safe: string = faker.finance.ethereumAddress();
+  private safeTxGas: number = faker.datatype.number();
+  private safeTxHash: string = faker.datatype.hexadecimal();
+  private signatures: string = faker.datatype.hexadecimal();
+  private submissionDate: Date = faker.date.recent();
+  private to: string = faker.finance.ethereumAddress();
+  private transactionHash: string = faker.datatype.hexadecimal();
+  private value: string = faker.datatype.hexadecimal();
+
+  withBaseGas(baseGas: number) {
+    this.baseGas = baseGas;
+    return this;
+  }
+
+  withBlockNumber(blockNumber: number) {
+    this.blockNumber = blockNumber;
+    return this;
+  }
+
+  withConfirmations(confirmations: Confirmation[]) {
+    this.confirmations = confirmations;
+    return this;
+  }
+
+  withConfirmationsRequired(confirmationRequired: number) {
+    this.confirmationsRequired = confirmationRequired;
+    return this;
+  }
+
+  withData(data: string) {
+    this.data = data;
+    return this;
+  }
+
+  withDataDecoded(dataDecoded: any) {
+    this.dataDecoded = dataDecoded;
+    return this;
+  }
+
+  withEthGasPrice(ethGasPrice: string) {
+    this.ethGasPrice = ethGasPrice;
+    return this;
+  }
+
+  withExecutionDate(executionDate: Date) {
+    this.executionDate = executionDate;
+    return this;
+  }
+
+  withExecutor(executor: string) {
+    this.executor = executor;
+    return this;
+  }
+
+  withFee(fee: string) {
+    this.fee = fee;
+    return this;
+  }
+
+  withGasPrice(gasPrice: string) {
+    this.gasPrice = gasPrice;
+    return this;
+  }
+
+  withGasToken(gasToken: string) {
+    this.gasToken = gasToken;
+    return this;
+  }
+
+  withGasUsed(gasUsed: number) {
+    this.gasUsed = gasUsed;
+    return this;
+  }
+
+  withIsExecuted(isExecuted: boolean) {
+    this.isExecuted = isExecuted;
+    return this;
+  }
+
+  withIsSuccessful(isSuccessful: boolean) {
+    this.isSuccessful = isSuccessful;
+    return this;
+  }
+
+  withModified(modified: Date) {
+    this.modified = modified;
+    return this;
+  }
+
+  withNonce(nonce: number) {
+    this.nonce = nonce;
+    return this;
+  }
+
+  withOperation(operation: Operation) {
+    this.operation = operation;
+    return this;
+  }
+
+  withOrigin(origin: string) {
+    this.origin = origin;
+    return this;
+  }
+
+  withRefundReceiver(refundReceiver: string) {
+    this.refundReceiver = refundReceiver;
+    return this;
+  }
+
+  withSafe(safe: string) {
+    this.safe = safe;
+    return this;
+  }
+
+  withSafeTxGas(safeTxGas: number) {
+    this.safeTxGas = safeTxGas;
+    return this;
+  }
+
+  withSignatures(signatures: string) {
+    this.signatures = signatures;
+    return this;
+  }
+
+  withSubmissionDate(submissionDate: Date) {
+    this.submissionDate = submissionDate;
+    return this;
+  }
+
+  withTo(to: string) {
+    this.to = to;
+    return this;
+  }
+
+  withTransactionHash(transactionHash: string) {
+    this.transactionHash = transactionHash;
+    return this;
+  }
+
+  withValue(value: string) {
+    this.value = value;
+    return this;
+  }
+
+  build(): MultisigTransaction {
+    return <MultisigTransaction>{
+      baseGas: this.baseGas,
+      blockNumber: this.blockNumber,
+      confirmations: this.confirmations,
+      confirmationsRequired: this.confirmationsRequired,
+      data: this.data,
+      dataDecoded: this.dataDecoded,
+      ethGasPrice: this.ethGasPrice,
+      executionDate: this.executionDate,
+      executor: this.executor,
+      fee: this.fee,
+      gasPrice: this.gasPrice,
+      gasToken: this.gasToken,
+      gasUsed: this.gasUsed,
+      isExecuted: this.isExecuted,
+      isSuccessful: this.isSuccessful,
+      modified: this.modified,
+      nonce: this.nonce,
+      operation: this.operation,
+      origin: this.origin,
+      refundReceiver: this.refundReceiver,
+      safe: this.safe,
+      safeTxGas: this.safeTxGas,
+      safeTxHash: this.safeTxHash,
+      signatures: this.signatures,
+      submissionDate: this.submissionDate,
+      to: this.to,
+      transactionHash: this.transactionHash,
+      value: this.value,
+    };
+  }
 }


### PR DESCRIPTION
- Introduces the Builder pattern for `MultisigTransaction`
- This avoids having to set most parameters when we want to set only one.

Example:

If we wanted to set the `dataDecoded` to the value "test" we'd have to do the following:

```typescript
factory(undefined, undefined, undefined, undefined, undefined, "test")
```

With the builder pattern we can instead do the following:

```typescript
new MultisigTransactionBuilder()
  .withDataDecoded('test')
  .build();
```