### PR TITLE
Add ConflictType enum

### DIFF
--- a/src/routes/transactions/entities/conflict-type.entity.ts
+++ b/src/routes/transactions/entities/conflict-type.entity.ts
@@ -1,0 +1,5 @@
+export enum ConflictType {
+  None = 'None',
+  HasNext = 'HasNext',
+  End = 'End',
+}

--- a/src/routes/transactions/entities/multisig-transaction.entity.ts
+++ b/src/routes/transactions/entities/multisig-transaction.entity.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { ConflictType } from './conflict-type.entity';
 import { Transaction } from './transaction.entity';
 
 export class MultisigTransaction {
@@ -12,6 +13,6 @@ export class MultisigTransaction {
   constructor(transaction: Transaction) {
     this.type = 'TRANSACTION';
     this.transaction = transaction;
-    this.conflictType = 'None';
+    this.conflictType = ConflictType.None;
   }
 }


### PR DESCRIPTION
This PR adds a `ConflictType` enum, instead of relying on a simple string. This will be used in routes that need to be implemented, i.e. `QueuedTransactions` retrieval.