### PR TITLE
Explicitly return null for empty pagination data

### DIFF
--- a/src/routes/chains/chains.controller.spec.ts
+++ b/src/routes/chains/chains.controller.spec.ts
@@ -85,6 +85,8 @@ describe('Chains Controller (Unit)', () => {
         .expect(200)
         .expect({
           count: chainsResponse.count,
+          next: null,
+          previous: null,
           results: [
             {
               chainId: chainsResponse.results[0].chainId,

--- a/src/routes/chains/chains.service.ts
+++ b/src/routes/chains/chains.service.ts
@@ -55,8 +55,8 @@ export class ChainsService {
 
     return <Page<Chain>>{
       count: result.count,
-      next: nextURL?.toString(),
-      previous: previousURL?.toString(),
+      next: nextURL?.toString() ?? null,
+      previous: previousURL?.toString() ?? null,
       results: chains,
     };
   }

--- a/src/routes/collectibles/collectibles.service.ts
+++ b/src/routes/collectibles/collectibles.service.ts
@@ -39,8 +39,8 @@ export class CollectiblesService {
 
     return <Page<Collectible>>{
       count: collectibles.count,
-      next: nextURL?.toString(),
-      previous: previousURL?.toString(),
+      next: nextURL?.toString() ?? null,
+      previous: previousURL?.toString() ?? null,
       results: collectibles.results,
     };
   }

--- a/src/routes/transactions/__tests__/resources/multisig-transactions/custom/expected-response.json
+++ b/src/routes/transactions/__tests__/resources/multisig-transactions/custom/expected-response.json
@@ -1,4 +1,6 @@
 {
+  "next": null,
+  "previous": null,
   "results": [
     {
       "type": "TRANSACTION",

--- a/src/routes/transactions/__tests__/resources/multisig-transactions/e2e/erc20-expected-response.json
+++ b/src/routes/transactions/__tests__/resources/multisig-transactions/e2e/erc20-expected-response.json
@@ -1,4 +1,6 @@
 {
+  "next": null,
+  "previous": null,
   "results": [
     {
       "type": "TRANSACTION",

--- a/src/routes/transactions/__tests__/resources/multisig-transactions/e2e/erc721-expected-response.json
+++ b/src/routes/transactions/__tests__/resources/multisig-transactions/e2e/erc721-expected-response.json
@@ -1,4 +1,6 @@
 {
+  "next": null,
+  "previous": null,
   "results": [
     {
       "type": "TRANSACTION",

--- a/src/routes/transactions/__tests__/resources/multisig-transactions/e2e/native-token-expected-response.json
+++ b/src/routes/transactions/__tests__/resources/multisig-transactions/e2e/native-token-expected-response.json
@@ -1,4 +1,6 @@
 {
+  "next": null,
+  "previous": null,
   "results": [
     {
       "type": "TRANSACTION",

--- a/src/routes/transactions/__tests__/resources/multisig-transactions/erc20/expected-response.json
+++ b/src/routes/transactions/__tests__/resources/multisig-transactions/erc20/expected-response.json
@@ -1,4 +1,6 @@
 {
+  "next": null,
+  "previous": null,
   "results": [
     {
       "type": "TRANSACTION",

--- a/src/routes/transactions/__tests__/resources/multisig-transactions/erc721/expected-response.json
+++ b/src/routes/transactions/__tests__/resources/multisig-transactions/erc721/expected-response.json
@@ -1,4 +1,6 @@
 {
+  "next": null,
+  "previous": null,
   "results": [
     {
       "type": "TRANSACTION",

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -65,8 +65,8 @@ export class TransactionsService {
     );
 
     return {
-      next: nextURL?.toString(),
-      previous: previousURL?.toString(),
+      next: nextURL?.toString() ?? null,
+      previous: previousURL?.toString() ?? null,
       results,
     };
   }


### PR DESCRIPTION
(Related to https://github.com/5afe/safe-client-gateway-nest/pull/206#discussion_r1056314317)

This PR adds explicit null values when pagination data is empty.
