### PR TITLE
Bugfix: add fallback if no executionDate on transaction

### DIFF
--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper.ts
@@ -30,10 +30,11 @@ export class MultisigTransactionMapper {
       safe,
       txStatus,
     );
+    const timestamp = transaction.executionDate ?? transaction.submissionDate;
 
     return new Transaction(
       `multisig_${transaction.safe}_${transaction.safeTxHash}`,
-      transaction.executionDate.getTime(),
+      timestamp?.getTime() ?? null,
       txStatus,
       txInfo,
       executionInfo,


### PR DESCRIPTION
This prevents `undefined` values from being returned when a transaction has no `executionDate` value.
This fallback was missing in the code.See the Rust implementation of this logic here: https://github.com/safe-global/safe-client-gateway/blob/ad6e9f132e804fbacbbecbc878cb8b7efe4d2dc1/src/routes/transactions/converters/summary.rs#L53