### PR TITLE
Fix logo URIs in e2e response data

### DIFF
--- a/src/routes/transactions/__tests__/resources/multisig-transactions/e2e/erc721-expected-response.json
+++ b/src/routes/transactions/__tests__/resources/multisig-transactions/e2e/erc721-expected-response.json
@@ -80,7 +80,7 @@
           "to": {
             "value": "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D",
             "name": null,
-            "logoUri": "https://staging-goerli-safe-transaction-web.safe.svc.cluster.local/media/contracts/logos/0x40A2aCCbd92BCA938b02010E17A5b8929b49130D.png"
+            "logoUri": "https://safe-transaction-goerli.staging.5afe.dev/media/contracts/logos/0x40A2aCCbd92BCA938b02010E17A5b8929b49130D.png"
           },
           "dataSize": "12228",
           "value": "0",

--- a/src/routes/transactions/__tests__/resources/multisig-transactions/e2e/native-token-expected-response.json
+++ b/src/routes/transactions/__tests__/resources/multisig-transactions/e2e/native-token-expected-response.json
@@ -204,7 +204,7 @@
         "txInfo": {
           "type": "Custom",
           "to": {
-            "logoUri": "https://staging-goerli-safe-transaction-web.safe.svc.cluster.local/media/contracts/logos/0x40A2aCCbd92BCA938b02010E17A5b8929b49130D.png",
+            "logoUri": "https://safe-transaction-goerli.staging.5afe.dev/media/contracts/logos/0x40A2aCCbd92BCA938b02010E17A5b8929b49130D.png",
             "name": null,
             "value": "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D"
           },
@@ -235,7 +235,7 @@
           "type": "Custom",
           "to": {
             "value": "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D",
-            "logoUri": "https://staging-goerli-safe-transaction-web.safe.svc.cluster.local/media/contracts/logos/0x40A2aCCbd92BCA938b02010E17A5b8929b49130D.png",
+            "logoUri": "https://safe-transaction-goerli.staging.5afe.dev/media/contracts/logos/0x40A2aCCbd92BCA938b02010E17A5b8929b49130D.png",
             "name": null
           },
           "dataSize": "324",
@@ -266,7 +266,7 @@
           "type": "Custom",
           "to": {
             "value": "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D",
-            "logoUri": "https://staging-goerli-safe-transaction-web.safe.svc.cluster.local/media/contracts/logos/0x40A2aCCbd92BCA938b02010E17A5b8929b49130D.png",
+            "logoUri": "https://safe-transaction-goerli.staging.5afe.dev/media/contracts/logos/0x40A2aCCbd92BCA938b02010E17A5b8929b49130D.png",
             "name": null
           },
           "dataSize": "932",
@@ -296,7 +296,7 @@
           "type": "Custom",
           "to": {
             "value": "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D",
-            "logoUri": "https://staging-goerli-safe-transaction-web.safe.svc.cluster.local/media/contracts/logos/0x40A2aCCbd92BCA938b02010E17A5b8929b49130D.png",
+            "logoUri": "https://safe-transaction-goerli.staging.5afe.dev/media/contracts/logos/0x40A2aCCbd92BCA938b02010E17A5b8929b49130D.png",
             "name": null
           },
           "dataSize": "12228",
@@ -326,7 +326,7 @@
           "type": "Custom",
           "to": {
             "value": "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D",
-            "logoUri": "https://staging-goerli-safe-transaction-web.safe.svc.cluster.local/media/contracts/logos/0x40A2aCCbd92BCA938b02010E17A5b8929b49130D.png",
+            "logoUri": "https://safe-transaction-goerli.staging.5afe.dev/media/contracts/logos/0x40A2aCCbd92BCA938b02010E17A5b8929b49130D.png",
             "name": null
           },
           "dataSize": "932",


### PR DESCRIPTION
This PR fixes the expected response for some e2e tests. The incorrect URLs were introduced in the expected test data while a staging database was restoring, so incorrect URIs were picked from the Transaction Service responses at that time.