### PR TITLE
Revert date change for ModuleTransaction

### DIFF
--- a/src/domain/safe/entities/__tests__/module-transaction.factory.ts
+++ b/src/domain/safe/entities/__tests__/module-transaction.factory.ts
@@ -2,14 +2,13 @@ import { DataDecoded } from '../../../data-decoder/entities/data-decoded.entity'
 import { Operation } from '../operation.entity';
 import { faker } from '@faker-js/faker';
 import dataDecodedFactory from '../../../data-decoder/entities/__tests__/data-decoded.factory';
-import { ModuleTransaction } from '../module-transaction.entity';
 
 export default function (
   blockNumber?: number,
-  created?: string,
+  created?: Date,
   data?: string | null,
   dataDecoded?: DataDecoded | null,
-  executionDate?: string,
+  executionDate?: Date,
   isSuccessful?: boolean,
   module?: string,
   operation?: Operation,
@@ -17,13 +16,14 @@ export default function (
   to?: string,
   transactionHash?: string,
   value?: string | null,
-): ModuleTransaction {
+) {
   return {
     blockNumber: blockNumber ?? faker.datatype.number(),
-    created: created ?? faker.date.recent().toISOString(),
+    created: created?.toISOString() ?? faker.date.recent().toISOString(),
     data: data === undefined ? faker.datatype.hexadecimal() : data,
     dataDecoded: dataDecoded === undefined ? dataDecodedFactory() : dataDecoded,
-    executionDate: executionDate ?? faker.date.recent().toISOString(),
+    executionDate:
+      executionDate?.toISOString() ?? faker.date.recent().toISOString(),
     isSuccessful: isSuccessful ?? faker.datatype.boolean(),
     module: module ?? faker.finance.ethereumAddress(),
     operation: operation ?? faker.helpers.arrayElement([0, 1]),

--- a/src/domain/safe/entities/module-transaction.entity.ts
+++ b/src/domain/safe/entities/module-transaction.entity.ts
@@ -3,10 +3,10 @@ import { Operation } from './operation.entity';
 
 export interface ModuleTransaction {
   blockNumber: number;
-  created: string;
+  created: Date;
   data: string | null;
   dataDecoded: DataDecoded | null;
-  executionDate: string;
+  executionDate: Date;
   isSuccessful: boolean;
   module: string;
   operation: Operation;

--- a/src/routes/transactions/mappers/module-transactions/module-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/module-transactions/module-transaction.mapper.ts
@@ -29,10 +29,9 @@ export class ModuleTransactionMapper {
     const executionInfo = new ModuleExecutionInfo(
       await this.addressInfoHelper.getOrDefault(chainId, transaction.module),
     );
-    const timestamp = new Date(transaction.executionDate);
     return new Transaction(
       `module_${transaction.safe}_${transaction.transactionHash}`,
-      timestamp.getTime(),
+      transaction.executionDate.getTime(),
       txStatus,
       txInfo,
       executionInfo,


### PR DESCRIPTION
- Reverts the change from `Date` to `string` made in dbe756d7355c3bbd787934336f6f29a1afc5fc28
- `Date` was introduced on the domain level so that any business logic around dates can use the Date API directly
- See b25d3077686426eb0313cfb18bb800691da541a8 – which introduced support for `Date` on the domain level (AJV support)