### PR TITLE
Add  missing pagination parameters on getTransactionHistory

### DIFF
--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -46,9 +46,11 @@ export interface ISafeRepository {
     offset?: number,
   ): Promise<Page<MultisigTransaction>>;
 
-  getTransactionHistory(
+  getHistoryTransactions(
     chainId: string,
     safeAddress: string,
+    limit?: number,
+    offset?: number,
   ): Promise<Page<Transaction>>;
 
   getMultiSigTransaction(

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -138,14 +138,21 @@ export class SafeRepository implements ISafeRepository {
     return page;
   }
 
-  async getTransactionHistory(
+  async getHistoryTransactions(
     chainId: string,
     safeAddress: string,
+    limit?: number,
+    offset?: number,
   ): Promise<Page<Transaction>> {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(chainId);
     const page: Page<Transaction> = await transactionService.getAllTransactions(
       safeAddress,
+      undefined,
+      true,
+      false,
+      limit,
+      offset,
     );
 
     page.results.map((transaction) =>


### PR DESCRIPTION
- Add missing limit and offset to `getTransactionHistory`
- Set queued to false and executed to true.
- Change the function name to `getHistoryTransactions` to be aligned with the rest of function names. 
