### PR TITLE
Add toJson function to Builder

### DIFF
--- a/src/domain/chains/entities/__tests__/chain.factory.ts
+++ b/src/domain/chains/entities/__tests__/chain.factory.ts
@@ -164,4 +164,8 @@ export class ChainBuilder implements Builder<Chain> {
       features: this.features,
     };
   }
+
+  toJson(): unknown {
+    return this.build();
+  }
 }

--- a/src/domain/common/__tests__/builder.ts
+++ b/src/domain/common/__tests__/builder.ts
@@ -1,3 +1,12 @@
 export interface Builder<T> {
+  /**
+   * Returns the concrete class T using the internal Builder state
+   */
   build(): T;
+
+  /**
+   * Returns the JSON-like implementation for the concrete class T using the
+   * internal Builder state
+   */
+  toJson(): unknown;
 }

--- a/src/domain/safe/entities/__tests__/multisig-transaction.factory.ts
+++ b/src/domain/safe/entities/__tests__/multisig-transaction.factory.ts
@@ -208,4 +208,14 @@ export class MultisigTransactionBuilder
       value: this.value,
     };
   }
+
+  toJson(): unknown {
+    const entity = this.build();
+    return {
+      ...entity,
+      executionDate: entity.executionDate.toISOString(),
+      modified: entity.modified?.toISOString(),
+      submissionDate: entity.submissionDate?.toISOString(),
+    };
+  }
 }


### PR DESCRIPTION
- Adds a `toJson` function to `Builder`
- This function should be used whenever in a testing scenario a JSON payload is required for `T`
- The result of `build()` can, in some cases, be the same result as `toJson`. However, `toJson` can be used to convert types that are serialised to `Date` back to a `string`