### PR TITLE
Disable test:e2e:cov task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        task: ['test:cov', 'test:e2e:cov']
+        task: [
+          'test:cov',
+          # 'test:e2e:cov' # Enable this again when we align on the stability of the staging environment
+        ]
     services:
       redis:
         image: redis


### PR DESCRIPTION
- Due to recent ongoing issues in the staging environment, it was decided that E2E tests should be temporarily disabled
- The reason why they are currently being disabled is because of the way we expect coverage to be merged when both Unit and E2E tests complete – by having E2E tests optional this would result in bigger coverage changes (uploaded). Eg.: 75% covered by Unit Tests + 25% covered by E2E tests. PR1 gets merged while E2E tests are not uploaded (~25% decrease in coverage) while PR2 gets merged with both Unit and E2E uploaded (~25% increase in coverage if merged after PR1)