### PR TITLE
Fix ERC721 logoUri value (E2E test)

### DIFF
--- a/src/routes/transactions/__tests__/resources/incoming-transfers/e2e/erc721-expected-response.json
+++ b/src/routes/transactions/__tests__/resources/incoming-transfers/e2e/erc721-expected-response.json
@@ -58,7 +58,7 @@
             "tokenId": "110380171670080793190909999014722746036502744273864122623133899039475607835745",
             "tokenName": "Ethereum Name Service",
             "tokenSymbol": "ENS",
-            "logoUri": "/media/tokens/logos/ENS.png"
+            "logoUri": "/media/tokens/logos/0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85.png"
           }
         }
       },


### PR DESCRIPTION
- Changes the expected `logoUri` from `/media/tokens/logos/ENS.png` to `/media/tokens/logos/0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85.png`
- The Safe Transaction Service ignores the uploaded file name and, when saving the uploaded image, save the resource with the address (see https://github.com/safe-global/safe-transaction-service/blob/a0864385d4d0bf4adef49067b81acb3ce9e1fd3d/safe_transaction_service/tokens/models.py#L32-L35)