### PR TITLE
Fix PaginationDataDecorator return type

### DIFF
--- a/src/routes/chains/chains.controller.ts
+++ b/src/routes/chains/chains.controller.ts
@@ -28,7 +28,7 @@ export class ChainsController {
   @Get()
   async getChains(
     @RouteUrlDecorator() routeUrl: URL,
-    @PaginationDataDecorator() paginationData?: PaginationData,
+    @PaginationDataDecorator() paginationData: PaginationData,
   ): Promise<Page<Chain>> {
     return this.chainsService.getChains(routeUrl, paginationData);
   }

--- a/src/routes/chains/chains.service.ts
+++ b/src/routes/chains/chains.service.ts
@@ -21,11 +21,11 @@ export class ChainsService {
 
   async getChains(
     routeUrl: Readonly<URL>,
-    paginationData?: PaginationData,
+    paginationData: PaginationData,
   ): Promise<Page<Chain>> {
     const result = await this.chainsRepository.getChains(
-      paginationData?.limit,
-      paginationData?.offset,
+      paginationData.limit,
+      paginationData.offset,
     );
 
     const nextURL = cursorUrlFromLimitAndOffset(routeUrl, result.next);

--- a/src/routes/collectibles/collectibles.controller.ts
+++ b/src/routes/collectibles/collectibles.controller.ts
@@ -37,7 +37,7 @@ export class CollectiblesController {
     @Param('chainId') chainId: string,
     @Param('safeAddress') safeAddress: string,
     @RouteUrlDecorator() routeUrl: URL,
-    @PaginationDataDecorator() paginationData?: PaginationData,
+    @PaginationDataDecorator() paginationData: PaginationData,
     @Query('trusted') trusted?: boolean,
     @Query('exclude_spam') excludeSpam?: boolean,
   ): Promise<Page<Collectible>> {

--- a/src/routes/collectibles/collectibles.service.ts
+++ b/src/routes/collectibles/collectibles.service.ts
@@ -18,15 +18,15 @@ export class CollectiblesService {
     chainId: string,
     safeAddress: string,
     routeUrl: Readonly<URL>,
-    paginationData?: PaginationData,
+    paginationData: PaginationData,
     trusted?: boolean,
     excludeSpam?: boolean,
   ): Promise<Page<Collectible>> {
     const collectibles = await this.repository.getCollectibles(
       chainId,
       safeAddress,
-      paginationData?.limit,
-      paginationData?.offset,
+      paginationData.limit,
+      paginationData.offset,
       trusted,
       excludeSpam,
     );

--- a/src/routes/common/decorators/pagination.data.decorator.spec.ts
+++ b/src/routes/common/decorators/pagination.data.decorator.spec.ts
@@ -12,7 +12,7 @@ describe('PaginationDataDecorator', () => {
   @Controller()
   class TestController {
     @Get()
-    route(@PaginationDataDecorator() data?: PaginationData) {
+    route(@PaginationDataDecorator() data: PaginationData) {
       paginationData = data;
       return;
     }

--- a/src/routes/common/decorators/pagination.data.decorator.ts
+++ b/src/routes/common/decorators/pagination.data.decorator.ts
@@ -6,10 +6,10 @@ import { getRouteUrl } from './utils';
  * Route decorator which parses {@link PaginationData} from a
  * cursor query.
  *
- * If the cursor does not exist or is invalid null is returned instead
+ * If the cursor does not exist or is invalid a default one is returned instead
  */
 export const PaginationDataDecorator = createParamDecorator(
-  (data: unknown, ctx: ExecutionContext): PaginationData | null => {
+  (data: unknown, ctx: ExecutionContext): PaginationData => {
     const request = ctx.switchToHttp().getRequest();
     return PaginationData.fromCursor(getRouteUrl(request));
   },

--- a/src/routes/delegates/delegates.controller.ts
+++ b/src/routes/delegates/delegates.controller.ts
@@ -59,7 +59,7 @@ export class DelegatesController {
     @Param('chainId') chainId: string,
     @RouteUrlDecorator() routeUrl: URL,
     @Query() delegateParamsDto: DelegateParamsDto,
-    @PaginationDataDecorator() paginationData?: PaginationData,
+    @PaginationDataDecorator() paginationData: PaginationData,
   ): Promise<Page<Delegate>> {
     return this.service.getDelegates(
       chainId,

--- a/src/routes/delegates/delegates.service.spec.ts
+++ b/src/routes/delegates/delegates.service.spec.ts
@@ -5,6 +5,7 @@ import delegateFactory from '../../domain/delegate/entities/__tests__/delegate.f
 import { faker } from '@faker-js/faker';
 import { Page } from '../common/entities/page.entity';
 import { DelegateParamsDto } from './entities/delegate-params.entity';
+import { PaginationData } from '../common/pagination/pagination.data';
 
 const delegateRepository = {
   getDelegates: jest.fn(),
@@ -26,6 +27,7 @@ describe('DelegatesService', () => {
     const safe = faker.finance.ethereumAddress();
     const url = faker.internet.url();
     const routeUrl: Readonly<URL> = new URL(url);
+    const paginationData = PaginationData.fromCursor(routeUrl);
     const delegates = <Page<Delegate>>{
       count: 2,
       next: null,
@@ -35,7 +37,12 @@ describe('DelegatesService', () => {
     delegateRepositoryMock.getDelegates.mockResolvedValueOnce(delegates);
 
     const params = new DelegateParamsDto(safe);
-    const actual = await service.getDelegates(chainId, routeUrl, params);
+    const actual = await service.getDelegates(
+      chainId,
+      routeUrl,
+      params,
+      paginationData,
+    );
 
     expect(actual).toEqual(delegates);
     expect(delegateRepositoryMock.getDelegates).toBeCalledTimes(1);

--- a/src/routes/delegates/delegates.service.ts
+++ b/src/routes/delegates/delegates.service.ts
@@ -21,7 +21,7 @@ export class DelegatesService {
     chainId: string,
     routeUrl: Readonly<URL>,
     delegateParams: DelegateParamsDto,
-    paginationData?: PaginationData,
+    paginationData: PaginationData,
   ): Promise<Page<Delegate>> {
     if (
       !(
@@ -43,8 +43,8 @@ export class DelegatesService {
       delegateParams.delegate,
       delegateParams.delegator,
       delegateParams.label,
-      paginationData?.limit,
-      paginationData?.offset,
+      paginationData.limit,
+      paginationData.offset,
     );
 
     const nextURL = cursorUrlFromLimitAndOffset(routeUrl, delegates.next);

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -32,6 +32,7 @@ export class TransactionsController {
   async getMultisigTransactions(
     @Param('chainId') chainId: string,
     @RouteUrlDecorator() routeUrl: URL,
+    @PaginationDataDecorator() paginationData: PaginationData,
     @Param('safeAddress') safeAddress: string,
     @Query('execution_date__gte') executionDateGte?: string,
     @Query('execution_date__lte') executionDateLte?: string,
@@ -39,11 +40,11 @@ export class TransactionsController {
     @Query('value') value?: string,
     @Query('nonce') nonce?: string,
     @Query('executed') executed?: boolean,
-    @PaginationDataDecorator() paginationData?: PaginationData,
   ): Promise<Partial<Page<MultisigTransaction>>> {
     return this.transactionsService.getMultisigTransactions(
       chainId,
       routeUrl,
+      paginationData,
       safeAddress,
       executionDateGte,
       executionDateLte,
@@ -51,7 +52,6 @@ export class TransactionsController {
       value,
       nonce,
       executed,
-      paginationData,
     );
   }
 
@@ -63,10 +63,10 @@ export class TransactionsController {
   async getModuleTransactions(
     @Param('chainId') chainId: string,
     @RouteUrlDecorator() routeUrl: URL,
+    @PaginationDataDecorator() paginationData: PaginationData,
     @Param('safeAddress') safeAddress: string,
     @Query('to') to?: string,
     @Query('module') module?: string,
-    @PaginationDataDecorator() paginationData?: PaginationData,
   ): Promise<Page<ModuleTransaction>> {
     return this.transactionsService.getModuleTransactions(
       chainId,
@@ -90,12 +90,12 @@ export class TransactionsController {
     @Param('chainId') chainId: string,
     @RouteUrlDecorator() routeUrl: URL,
     @Param('safeAddress') safeAddress: string,
+    @PaginationDataDecorator() paginationData: PaginationData,
     @Query('execution_date__gte') executionDateGte?: string,
     @Query('execution_date__lte') executionDateLte?: string,
     @Query('to') to?: string,
     @Query('value') value?: string,
     @Query('token_address') tokenAddress?: string,
-    @PaginationDataDecorator() paginationData?: PaginationData,
   ): Promise<Partial<Page<IncomingTransfer>>> {
     return this.transactionsService.getIncomingTransfers(
       chainId,

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -25,6 +25,7 @@ export class TransactionsService {
   async getMultisigTransactions(
     chainId: string,
     routeUrl: Readonly<URL>,
+    paginationData: PaginationData,
     safeAddress: string,
     executionDateGte?: string,
     executionDateLte?: string,
@@ -32,7 +33,6 @@ export class TransactionsService {
     value?: string,
     nonce?: string,
     executed?: boolean,
-    paginationData?: PaginationData,
   ): Promise<Partial<Page<MultisigTransaction>>> {
     const domainTransactions =
       await this.safeRepository.getMultisigTransactions(
@@ -44,8 +44,8 @@ export class TransactionsService {
         to,
         value,
         nonce,
-        paginationData?.limit,
-        paginationData?.offset,
+        paginationData.limit,
+        paginationData.offset,
       );
 
     const safeInfo = await this.safeRepository.getSafe(chainId, safeAddress);


### PR DESCRIPTION
- `PaginationData.fromCursor` should always return a `PaginationData` even if the necessary data to create one is not provided
- Changes the routes which used `@PaginationDataDecorator()` – the respective parameters are now non-undefined/non-null
- The domain interfaces were not changed – `offset` and `limit` can still be undefined – this allows the route layer to still request the specified data while ignoring pagination parameters