### PR TITLE
Add ConfirmationBuilder

### DIFF
--- a/src/domain/safe/entities/__tests__/multisig-transaction-confirmation.factory.ts
+++ b/src/domain/safe/entities/__tests__/multisig-transaction-confirmation.factory.ts
@@ -1,22 +1,58 @@
-import { Confirmation } from '../multisig-transaction.entity';
 import { faker } from '@faker-js/faker';
+import { Confirmation } from '../multisig-transaction.entity';
+import { Builder } from '../../../common/__tests__/builder';
 
-export default function (
-  owner?: string,
-  signature?: string,
-  signatureType?: string,
-  submissionDate?: Date,
-  transactionHash?: string,
-): Confirmation {
-  return <Confirmation>{
-    owner: owner ?? faker.finance.ethereumAddress(),
-    signature:
-      signature === undefined ? faker.datatype.hexadecimal() : signature,
-    signatureType: signatureType ?? faker.datatype.string(),
-    submissionDate: submissionDate ?? faker.date.recent(),
-    transactionHash:
-      transactionHash === undefined
-        ? faker.datatype.hexadecimal()
-        : transactionHash,
-  };
+export class ConfirmationBuilder implements Builder<Confirmation> {
+  private owner: string = faker.finance.ethereumAddress();
+
+  private signature: string | null = faker.datatype.hexadecimal();
+
+  private signatureType: string = faker.datatype.string();
+
+  private submissionDate: Date = faker.date.recent();
+
+  private transactionHash: string | null = faker.datatype.hexadecimal();
+
+  withOwner(owner: string) {
+    this.owner = owner;
+    return this;
+  }
+
+  withSignature(signature: string | null) {
+    this.signature = signature;
+    return this;
+  }
+
+  withSignatureType(signatureType: string) {
+    this.signatureType = signatureType;
+    return this;
+  }
+
+  withSubmissionDate(submissionDate: Date) {
+    this.submissionDate = submissionDate;
+    return this;
+  }
+
+  withTransactionHash(transactionHash: string | null) {
+    this.transactionHash = transactionHash;
+    return this;
+  }
+
+  build(): Confirmation {
+    return <Confirmation>{
+      owner: this.owner,
+      signature: this.signature,
+      signatureType: this.signatureType,
+      submissionDate: this.submissionDate,
+      transactionHash: this.transactionHash,
+    };
+  }
+
+  toJson(): unknown {
+    const entity = this.build();
+    return {
+      ...entity,
+      submissionDate: entity.submissionDate.toISOString(),
+    };
+  }
 }

--- a/src/domain/safe/entities/__tests__/multisig-transaction.factory.ts
+++ b/src/domain/safe/entities/__tests__/multisig-transaction.factory.ts
@@ -4,8 +4,9 @@ import {
 } from '../multisig-transaction.entity';
 import { Operation } from '../operation.entity';
 import { faker } from '@faker-js/faker';
-import multisigTransactionConfirmationFactory from './multisig-transaction-confirmation.factory';
 import { Builder } from '../../../common/__tests__/builder';
+import { ConfirmationBuilder } from './multisig-transaction-confirmation.factory';
+import dataDecodedFactory from '../../../data-decoder/entities/__tests__/data-decoded.factory';
 
 export class MultisigTransactionBuilder
   implements Builder<MultisigTransaction>
@@ -13,11 +14,11 @@ export class MultisigTransactionBuilder
   private baseGas: number = faker.datatype.number();
   private blockNumber: number = faker.datatype.number();
   private confirmations: Confirmation[] | null = [
-    multisigTransactionConfirmationFactory(),
+    new ConfirmationBuilder().build(),
   ];
   private confirmationsRequired: number = faker.datatype.number();
   private data: string = faker.datatype.hexadecimal();
-  private dataDecoded: any = faker.datatype.json();
+  private dataDecoded: any = dataDecodedFactory();
   private ethGasPrice: string = faker.datatype.hexadecimal();
   private executionDate: Date = faker.date.recent();
   private executor: string = faker.finance.ethereumAddress();
@@ -211,9 +212,17 @@ export class MultisigTransactionBuilder
 
   toJson(): unknown {
     const entity = this.build();
+    // TODO: this is exactly the same as the one in ConfirmationBuilder
+    const confirmations = entity.confirmations?.map((confirmation) => {
+      return {
+        ...confirmation,
+        submissionDate: confirmation.submissionDate.toISOString(),
+      };
+    });
     return {
       ...entity,
       executionDate: entity.executionDate.toISOString(),
+      confirmations: confirmations,
       modified: entity.modified?.toISOString(),
       submissionDate: entity.submissionDate?.toISOString(),
     };

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.spec.ts
@@ -1,11 +1,11 @@
 import { faker } from '@faker-js/faker';
-import multisigTransactionConfirmationFactory from '../../../../domain/safe/entities/__tests__/multisig-transaction-confirmation.factory';
 import { MultisigTransactionBuilder } from '../../../../domain/safe/entities/__tests__/multisig-transaction.factory';
 import safeFactory from '../../../../domain/safe/entities/__tests__/safe.factory';
 import { AddressInfo } from '../../../common/entities/address-info.entity';
 import { MultisigExecutionInfo } from '../../entities/multisig-execution-info.entity';
 import { TransactionStatus } from '../../entities/transaction-status.entity';
 import { MultisigTransactionExecutionInfoMapper } from './multisig-transaction-execution-info.mapper';
+import { ConfirmationBuilder } from '../../../../domain/safe/entities/__tests__/multisig-transaction-confirmation.factory';
 
 describe('Multisig Transaction execution info mapper (Unit)', () => {
   const mapper = new MultisigTransactionExecutionInfoMapper();
@@ -15,8 +15,8 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
     const confirmationsRequired = faker.datatype.number({ min: 0 });
     const txStatus = TransactionStatus.Success;
     const confirmations = [
-      multisigTransactionConfirmationFactory(),
-      multisigTransactionConfirmationFactory(),
+      new ConfirmationBuilder().build(),
+      new ConfirmationBuilder().build(),
     ];
     const safe = safeFactory();
     const transaction = new MultisigTransactionBuilder()
@@ -68,8 +68,8 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
     const confirmationsRequired = faker.datatype.number({ min: 0 });
     const txStatus = TransactionStatus.AwaitingConfirmations;
     const confirmations = [
-      multisigTransactionConfirmationFactory(),
-      multisigTransactionConfirmationFactory(),
+      new ConfirmationBuilder().build(),
+      new ConfirmationBuilder().build(),
     ];
     const safeOwners = [];
     const safe = safeFactory(undefined, undefined, undefined, safeOwners);
@@ -99,8 +99,8 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
     const confirmationsRequired = faker.datatype.number({ min: 0 });
     const txStatus = TransactionStatus.AwaitingConfirmations;
     const confirmations = [
-      multisigTransactionConfirmationFactory(),
-      multisigTransactionConfirmationFactory(),
+      new ConfirmationBuilder().build(),
+      new ConfirmationBuilder().build(),
     ];
     const safeOwners = [
       faker.finance.ethereumAddress(),
@@ -136,8 +136,8 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
     const confirmationsRequired = faker.datatype.number({ min: 0 });
     const txStatus = TransactionStatus.AwaitingConfirmations;
     const confirmations = [
-      multisigTransactionConfirmationFactory(),
-      multisigTransactionConfirmationFactory(),
+      new ConfirmationBuilder().build(),
+      new ConfirmationBuilder().build(),
     ];
     const safeOwners = [
       confirmations[0].owner,

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-status.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-status.mapper.spec.ts
@@ -1,8 +1,8 @@
-import multisigTransactionConfirmationFactory from '../../../../domain/safe/entities/__tests__/multisig-transaction-confirmation.factory';
 import { MultisigTransactionBuilder } from '../../../../domain/safe/entities/__tests__/multisig-transaction.factory';
 import safeFactory from '../../../../domain/safe/entities/__tests__/safe.factory';
 import { TransactionStatus } from '../../entities/transaction-status.entity';
 import { MultisigTransactionStatusMapper } from './multisig-transaction-status.mapper';
+import { ConfirmationBuilder } from '../../../../domain/safe/entities/__tests__/multisig-transaction-confirmation.factory';
 
 describe('Multisig Transaction status mapper (Unit)', () => {
   const mapper = new MultisigTransactionStatusMapper();
@@ -48,8 +48,8 @@ describe('Multisig Transaction status mapper (Unit)', () => {
       .withIsExecuted(false)
       .withNonce(4)
       .withConfirmations([
-        multisigTransactionConfirmationFactory(),
-        multisigTransactionConfirmationFactory(),
+        new ConfirmationBuilder().build(),
+        new ConfirmationBuilder().build(),
       ])
       .withConfirmationsRequired(3)
       .build();
@@ -65,8 +65,8 @@ describe('Multisig Transaction status mapper (Unit)', () => {
       .withIsExecuted(false)
       .withNonce(4)
       .withConfirmations([
-        multisigTransactionConfirmationFactory(),
-        multisigTransactionConfirmationFactory(),
+        new ConfirmationBuilder().build(),
+        new ConfirmationBuilder().build(),
       ])
       .withConfirmationsRequired(1)
       .build();


### PR DESCRIPTION
- Adds a `ConfirmationBuilder` – this builder can be used to create `Confirmation` instances in a testing environment
- Uses the builder as a default value for `MultisigTransactionBuilder.confirmations`
- Uses `dataDecodedFactory` instead of `faker.datatype.json()` in `MultisigTransactionBuilder.dataDecoded`