### PR TITLE
Add ERC20TransferBuilder

### DIFF
--- a/src/domain/safe/entities/__tests__/erc20-transfer.factory.ts
+++ b/src/domain/safe/entities/__tests__/erc20-transfer.factory.ts
@@ -1,25 +1,75 @@
 import { faker } from '@faker-js/faker';
+import { Builder } from '../../../common/__tests__/builder';
+import { ERC20Transfer } from '../transfer.entity';
 
-export default function (
-  blockNumber?: number,
-  executionDate?: Date,
-  from?: string,
-  to?: string,
-  transactionHash?: string,
-  tokenAddress?: string | null,
-  value?: string,
-) {
-  return {
-    type: 'ERC20_TRANSFER',
-    blockNumber: blockNumber ?? faker.datatype.number({ min: 0 }),
-    executionDate: executionDate ?? faker.date.recent(),
-    from: from ?? faker.finance.ethereumAddress(),
-    to: to ?? faker.finance.ethereumAddress(),
-    transactionHash: transactionHash ?? faker.datatype.hexadecimal(),
-    tokenAddress:
-      tokenAddress === undefined
-        ? faker.finance.ethereumAddress()
-        : tokenAddress,
-    value: value ?? faker.datatype.hexadecimal(),
-  };
+export class ERC20TransferBuilder implements Builder<ERC20Transfer> {
+  private blockNumber: number = faker.datatype.number();
+
+  private executionDate: Date = faker.date.recent();
+
+  private from: string = faker.finance.ethereumAddress();
+
+  private to: string = faker.finance.ethereumAddress();
+
+  private transactionHash: string = faker.datatype.string();
+
+  private tokenAddress: string = faker.finance.ethereumAddress();
+
+  private value: string = faker.datatype.hexadecimal();
+
+  withBlockNumber(blockNumber: number) {
+    this.blockNumber = blockNumber;
+    return this;
+  }
+
+  withExecutionDate(executionDate: Date) {
+    this.executionDate = executionDate;
+    return this;
+  }
+
+  withFrom(from: string) {
+    this.from = from;
+    return this;
+  }
+
+  withTo(to: string) {
+    this.to = to;
+    return this;
+  }
+
+  withTransactionHash(transactionHash: string) {
+    this.transactionHash = transactionHash;
+    return this;
+  }
+
+  withTokenAddress(tokenAddress: string) {
+    this.tokenAddress = tokenAddress;
+    return this;
+  }
+
+  withValue(value: string) {
+    this.value = value;
+    return this;
+  }
+
+  build(): ERC20Transfer {
+    return <ERC20Transfer>{
+      blockNumber: this.blockNumber,
+      executionDate: this.executionDate,
+      from: this.from,
+      to: this.to,
+      transactionHash: this.transactionHash,
+      tokenAddress: this.tokenAddress,
+      value: this.value,
+    };
+  }
+
+  toJson(): unknown {
+    const entity = this.build();
+    return {
+      type: 'ERC20_TRANSFER',
+      ...entity,
+      executionDate: this.executionDate.toISOString(),
+    };
+  }
 }

--- a/src/routes/transactions/mappers/transfers/transfer-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-info.mapper.spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import erc20TransferFactory from '../../../../domain/safe/entities/__tests__/erc20-transfer.factory';
 import erc721TransferFactory from '../../../../domain/safe/entities/__tests__/erc721-transfer.factory';
 import nativeTokenTransferFactory from '../../../../domain/safe/entities/__tests__/native-token-transfer.factory';
 import safeFactory from '../../../../domain/safe/entities/__tests__/safe.factory';
@@ -15,6 +14,7 @@ import { Erc20Transfer } from '../../entities/transfers/erc20-transfer.entity';
 import { Erc721Transfer } from '../../entities/transfers/erc721-transfer.entity';
 import { NativeCoinTransfer } from '../../entities/transfers/native-coin-transfer.entity';
 import { TransferInfoMapper } from './transfer-info.mapper';
+import { ERC20TransferBuilder } from '../../../../domain/safe/entities/__tests__/erc20-transfer.factory';
 
 const addressInfoHelper = jest.mocked({
   getOrDefault: jest.fn(),
@@ -33,7 +33,7 @@ describe('Transfer Info mapper (Unit)', () => {
 
   it('should build an ERC20 TransferTransactionInfo', async () => {
     const chainId = faker.random.numeric();
-    const transfer = erc20TransferFactory();
+    const transfer = new ERC20TransferBuilder().build();
     const safe = safeFactory();
     const addressInfo = new AddressInfo(faker.finance.ethereumAddress());
     const token = tokenFactory();
@@ -116,20 +116,5 @@ describe('Transfer Info mapper (Unit)', () => {
         }),
       }),
     );
-  });
-
-  it('should fail if the transfer type is unknown', async () => {
-    const chainId = faker.random.numeric();
-    const transfer = {
-      ...erc20TransferFactory(),
-      tokenAddress: undefined,
-      value: undefined,
-    };
-    transfer.type = faker.random.word();
-    const safe = safeFactory();
-
-    await expect(
-      mapper.mapTransferInfo(chainId, transfer, safe),
-    ).rejects.toThrow('Unknown transfer type');
   });
 });


### PR DESCRIPTION
- Adds a `ERC20TransferBuilder` which can be used to build instances of `ERC20Transfer`
- Removes a `TransferInfoMapper` test that checks the result if the transfer type is unknown – this condition should never happen as the mapper only deals with domain entities which do not contain the type. This validation is done by AJV instead, and it should fail at that level.