### PR TITLE
Update SAFE_CONFIG_BASE_URI default value

### DIFF
--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -11,7 +11,7 @@ export default () => ({
   },
   safeConfig: {
     baseUri:
-      process.env.SAFE_CONFIG_BASE_URI || 'https://safe-config.gnosis.io',
+      process.env.SAFE_CONFIG_BASE_URI || 'https://safe-config.safe.global/',
   },
   redis: {
     host: process.env.REDIS_HOST || 'localhost',


### PR DESCRIPTION
- Use `https://safe-config.safe.global/` instead of `https://safe-config.gnosis.io` as the default value for `SAFE_CONFIG_BASE_URI`