### PR TITLE
Add web and nginx images to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,5 +2,27 @@ services:
   redis:
     image: redis/redis-stack:7.0.2-RC1
     ports:
-      - "${REDIS_PORT-6379}:${REDIS_PORT-6379}"
+      - ${REDIS_PORT-6379}:${REDIS_PORT-6379}
       - 8001:8001
+
+  web:
+    build: .
+    tty: true
+    environment:
+      REDIS_HOST: redis
+      EXCHANGE_API_KEY: ${EXCHANGE_API_KEY-example_api_key}
+      APPLICATION_PORT: ${APPLICATION_PORT-3000}
+    depends_on:
+      - redis
+
+  nginx:
+    image: nginx:1.23-alpine
+    ports:
+      - ${NGINX_HOST_PORT:-8080}:80
+    volumes:
+      - ./nginx/templates:/etc/nginx/templates
+    environment:
+      NGINX_ENVSUBST_OUTPUT_DIR: /etc/nginx/
+      APPLICATION_PORT: ${APPLICATION_PORT-3000}
+    depends_on:
+      - web

--- a/nginx/templates/nginx.conf.template
+++ b/nginx/templates/nginx.conf.template
@@ -1,0 +1,61 @@
+worker_processes auto;
+
+events {
+}
+
+http {
+  include mime.types;
+  # fallback in case we can't determine a type
+  default_type application/octet-stream;
+  sendfile on;
+
+  upstream app_server {
+    ip_hash;  # For load-balancing
+    server web:${APPLICATION_PORT} fail_timeout=0;
+    keepalive 32;
+  }
+
+  server {
+    access_log off;
+    listen 80;
+    charset utf-8;
+
+    keepalive_timeout 75s;
+    keepalive_requests 100000;
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+
+    gzip             on;
+    gzip_min_length 10000;
+    gzip_comp_level  6;
+
+    # text/html is always included by default
+    gzip_types text/plain text/css application/json application/javascript application/x-javascript text/javascript text/xml application/xml application/rss+xml application/atom+xml application/rdf+xml;
+    gzip_disable "MSIE [1-6]\.";
+
+    # allow the server to close connection on non responding client, this will free up memory
+    reset_timedout_connection on;
+
+    # Redirect http to https
+    if ($http_x_forwarded_proto = 'http') {
+      return 301 https://$host$request_uri;
+    }
+
+    location / {
+          proxy_pass http://app_server/;
+          proxy_set_header Host $host;
+          proxy_set_header X-Forwarded-Host $server_name;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header        X-Forwarded-Proto $http_x_forwarded_proto;
+          add_header              Front-End-Https   on;
+          # we don't want nginx trying to do something clever with
+          # redirects, we set the Host: header above already.
+          proxy_redirect off;
+          # They default to 60s. Increase to avoid WORKER TIMEOUT in web container
+          proxy_connect_timeout 60s;
+          proxy_read_timeout 60s;
+    }
+  }
+}


### PR DESCRIPTION
- Adds a `web` image (the NestJS service) to docker compose
  * This web image reads the `APPLICATION_PORT` and the `EXCHANGE_API_KEY` from the local environment and uses these values for configuring the service
  * This is mostly to showcase how the web image works behind the Nginx reverse proxy (no other environment variables/configuration will be read)
- Adds a Nginx image as a reverse proxy in docker compose
  * The container behind this image is accessible to the host via `NGINX_HOST_PORT` (defaults to `8080`)
  * This container is responsible to redirect the incoming requests to the underlying web application