### PR TITLE
Add features property to Safe App

### DIFF
--- a/src/domain/safe-apps/entities/__tests__/safe-app.builder.ts
+++ b/src/domain/safe-apps/entities/__tests__/safe-app.builder.ts
@@ -14,5 +14,6 @@ export function safeAppBuilder(): IBuilder<SafeApp> {
     .with('chainIds', [faker.datatype.number(), faker.datatype.number()])
     .with('provider', safeAppProviderBuilder().build())
     .with('accessControl', safeAppAccessControlBuilder().build())
-    .with('tags', [faker.random.word(), faker.random.word()]);
+    .with('tags', [faker.random.word(), faker.random.word()])
+    .with('features', [faker.random.word(), faker.random.word()]);
 }

--- a/src/domain/safe-apps/entities/safe-app.entity.ts
+++ b/src/domain/safe-apps/entities/safe-app.entity.ts
@@ -11,4 +11,5 @@ export interface SafeApp {
   provider: SafeAppProvider | null;
   accessControl: SafeAppAccessControl;
   tags: string[];
+  features: string[];
 }

--- a/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
+++ b/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
@@ -32,6 +32,7 @@ export const safeAppSchema: Schema = {
     provider: { anyOf: [{ type: 'null' }, { $ref: 'safeAppProviderSchema' }] },
     accessControl: { $ref: 'safeAppAccessControlSchema' },
     tags: { type: 'array', items: { type: 'string' } },
+    features: { type: 'array', items: { type: 'string' } },
   },
   required: [
     'id',
@@ -42,6 +43,7 @@ export const safeAppSchema: Schema = {
     'chainIds',
     'accessControl',
     'tags',
+    'features',
   ],
   additionalProperties: false,
 };


### PR DESCRIPTION
- With the recent addition of `SafeApp.features` in the Safe Config Service, and given that the schema has `additionalProperties` set to `false` we need to add `features` to the schema to make it valid again
- Adds the `features` property to the `SafeApp` entity and builder
- See https://github.com/safe-global/safe-config-service/commit/814b8eb5faaabf43809f4852e9cac330e0501335