### PR TITLE
Revert "Disable test:e2e:cov task (#217)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        task: [
-          'test:cov',
-          # 'test:e2e:cov' # Enable this again when we align on the stability of the staging environment
-        ]
+        task: ['test:cov', 'test:e2e:cov']
     services:
       redis:
         image: redis


### PR DESCRIPTION
This reverts commit 6aa81d72e60b3a3183ac4c855b26bb25396d8dd8.

We consider that the E2E tests were fixed so we can reenable the task again.