### PR TITLE
Avoid floating point numbers for transactions dataSize value

### DIFF
--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -52,7 +52,8 @@ export class MultisigTransactionInfoMapper {
       ? Buffer.byteLength(transaction.data)
       : 0;
 
-    const dataSize = dataByteLength >= 2 ? (dataByteLength - 2) / 2 : 0;
+    const dataSize =
+      dataByteLength >= 2 ? Math.floor((dataByteLength - 2) / 2) : 0;
 
     if (this.isCustomTransaction(value, dataSize, transaction.operation)) {
       return await this.customTransactionMapper.mapCustomTransaction(


### PR DESCRIPTION
`dataSize` should be an integer value, (see [the Rust implementation of the function](https://github.com/safe-global/safe-client-gateway/blob/501371f64c13ee0a0585eaf5a0909ded7299ad7f/src/routes/transactions/converters/mod.rs#L295) which calculates the `dataSize` value) the current implementation was returning floating-point numbers.