### PR TITLE
Enable AJV removeAdditional option

### DIFF
--- a/src/domain/backbone/entities/schemas/backbone.schema.ts
+++ b/src/domain/backbone/entities/schemas/backbone.schema.ts
@@ -17,5 +17,4 @@ export const backboneSchema: JSONSchemaType<Backbone> = {
     },
   },
   required: ['name', 'version', 'api_version', 'secure', 'host'],
-  additionalProperties: false,
 };

--- a/src/domain/contracts/entities/schemas/contract.schema.ts
+++ b/src/domain/contracts/entities/schemas/contract.schema.ts
@@ -11,5 +11,4 @@ export const contractSchema: Schema = {
     trustedForDelegateCall: { type: 'boolean' },
   },
   required: ['address', 'name', 'displayName', 'trustedForDelegateCall'],
-  additionalProperties: false,
 };

--- a/src/domain/data-decoder/entities/schemas/data-decoded.schema.ts
+++ b/src/domain/data-decoder/entities/schemas/data-decoded.schema.ts
@@ -9,7 +9,6 @@ export const dataDecodedParameterSchema: Schema = {
     valueDecoded: { type: ['object', 'array', 'null'] },
   },
   required: ['name', 'type', 'value'],
-  additionalProperties: true,
 };
 
 export const dataDecodedSchema: Schema = {

--- a/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
+++ b/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
@@ -45,5 +45,4 @@ export const safeAppSchema: Schema = {
     'tags',
     'features',
   ],
-  additionalProperties: false,
 };

--- a/src/domain/schema/json-schema.service.ts
+++ b/src/domain/schema/json-schema.service.ts
@@ -12,6 +12,7 @@ export class JsonSchemaService {
       allowUnionTypes: true,
       useDefaults: true,
       discriminator: true,
+      removeAdditional: 'all',
     });
 
     addIsDate(this.ajv);


### PR DESCRIPTION
- The schema of other services that this service depends on can change in a non-breaking way (e.g. adding a new property).
- By having `additionalProperties` set to `false`, the routes that depend on schemas with this option could fail completely just because a new property was added.
- Since we don't want to break current live instances when a property gets added to a new schema, this change removes that requirement.
- Additionally, we set `removeAdditional` to `all` – this means that all additional properties (not set in the schema) will be removed. This forces us to implement and handle additional properties on a case by case only if needed. See https://ajv.js.org/options.html#removeadditional