### PR TITLE
Add autodeploy CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        task: ['test:cov', 'test:e2e:cov']
+        task: [ 'test:cov', 'test:e2e:cov' ]
     services:
       redis:
         image: redis
@@ -95,3 +95,15 @@ jobs:
           # Use inline cache storage https://docs.docker.com/build/cache/backends/inline/
           cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_TAG }}
           cache-to: type=inline
+
+  autodeploy:
+    runs-on: ubuntu-latest
+    needs: [ docker-publish ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy Staging
+        run: bash scripts/autodeploy.sh
+        env:
+          AUTODEPLOY_URL: ${{ secrets.AUTODEPLOY_URL }}
+          AUTODEPLOY_TOKEN: ${{ secrets.AUTODEPLOY_TOKEN }}
+          TARGET_ENV: "staging"

--- a/scripts/autodeploy.sh
+++ b/scripts/autodeploy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ev
+
+curl -s --output /dev/null --write-out "%{http_code}" \
+    -H "Content-Type: application/json" \
+    -X POST \
+    -u "$AUTODEPLOY_TOKEN" \
+    -d '{"push_data": {"tag": "'$TARGET_ENV'" }}' \
+    $AUTODEPLOY_URL


### PR DESCRIPTION
- Adds `autodeploy` step to Github Actions
- This step depends on `docker-publish` which means that it will only be triggered once a new Docker image is published to DockerHub
- This step executes autodeploy.sh which notifies `AUTODEPLOY_URL` that a new image is available