### PR TITLE
Implement GET /chains/:chain_id/about

### DIFF
--- a/src/routes/chains/chains.controller.spec.ts
+++ b/src/routes/chains/chains.controller.spec.ts
@@ -405,8 +405,7 @@ describe('Chains Controller (Unit)', () => {
 
   describe('GET /:chainId/about', () => {
     it('Success', async () => {
-      const chainId = faker.random.numeric();
-      const chainDomain = chainBuilder().with('chainId', chainId).build();
+      const chainDomain = chainBuilder().build();
       const name = faker.random.words();
       const version = faker.system.semver();
       const buildNumber = faker.random.numeric();
@@ -422,7 +421,7 @@ describe('Chains Controller (Unit)', () => {
       mockNetworkService.get.mockResolvedValueOnce({ data: chainDomain });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/about`)
+        .get(`/chains/${chainDomain.chainId}/about`)
         .expect(200)
         .expect(expectedResult);
     });

--- a/src/routes/chains/chains.controller.ts
+++ b/src/routes/chains/chains.controller.ts
@@ -10,6 +10,7 @@ import { MasterCopy } from './entities/master-copy.entity';
 import { ApiImplicitQuery } from '@nestjs/swagger/dist/decorators/api-implicit-query.decorator';
 import { Page } from '../common/entities/page.entity';
 import { Chain } from './entities/chain.entity';
+import { AboutChain } from './entities/about-chain.entity';
 
 @ApiTags('chains')
 @Controller({
@@ -37,6 +38,12 @@ export class ChainsController {
   @Get('/:chainId')
   async getChain(@Param('chainId') chainId: string): Promise<Chain> {
     return this.chainsService.getChain(chainId);
+  }
+
+  @ApiOkResponse({ type: AboutChain })
+  @Get('/:chainId/about')
+  async getAboutChain(@Param('chainId') chainId: string): Promise<AboutChain> {
+    return this.chainsService.getAboutChain(chainId);
   }
 
   @ApiOkResponse({ type: ApiBackbone })

--- a/src/routes/chains/chains.service.spec.ts
+++ b/src/routes/chains/chains.service.spec.ts
@@ -1,9 +1,10 @@
-import { ChainsService } from './chains.service';
-import { IChainsRepository } from '../../domain/chains/chains.repository.interface';
+import { FakeConfigurationService } from '../../config/__tests__/fake.configuration.service';
 import { IBackboneRepository } from '../../domain/backbone/backbone.repository.interface';
-import { MasterCopy } from './entities/master-copy.entity';
-import { masterCopyBuilder } from '../../domain/chains/entities/__tests__/master-copy.builder';
 import { backboneBuilder } from '../../domain/backbone/entities/__tests__/backbone.builder';
+import { IChainsRepository } from '../../domain/chains/chains.repository.interface';
+import { masterCopyBuilder } from '../../domain/chains/entities/__tests__/master-copy.builder';
+import { ChainsService } from './chains.service';
+import { MasterCopy } from './entities/master-copy.entity';
 
 const chainsRepository = {
   getChains: jest.fn(),
@@ -20,6 +21,7 @@ const backboneRepositoryMock = jest.mocked(backboneRepository);
 
 describe('ChainsService', () => {
   const service: ChainsService = new ChainsService(
+    new FakeConfigurationService(),
     chainsRepositoryMock,
     backboneRepositoryMock,
   );

--- a/src/routes/chains/chains.service.ts
+++ b/src/routes/chains/chains.service.ts
@@ -1,18 +1,22 @@
 import { Inject, Injectable } from '@nestjs/common';
+import { IConfigurationService } from '../../config/configuration.service.interface';
+import { IBackboneRepository } from '../../domain/backbone/backbone.repository.interface';
+import { Backbone } from '../../domain/backbone/entities/backbone.entity';
+import { IChainsRepository } from '../../domain/chains/chains.repository.interface';
+import { MasterCopy } from '../../domain/chains/entities/master-copies.entity';
+import { Page } from '../../domain/entities/page.entity';
 import {
   cursorUrlFromLimitAndOffset,
   PaginationData,
 } from '../common/pagination/pagination.data';
-import { IChainsRepository } from '../../domain/chains/chains.repository.interface';
-import { IBackboneRepository } from '../../domain/backbone/backbone.repository.interface';
-import { Backbone } from '../../domain/backbone/entities/backbone.entity';
-import { Page } from '../../domain/entities/page.entity';
-import { MasterCopy } from '../../domain/chains/entities/master-copies.entity';
+import { AboutChain } from './entities/about-chain.entity';
 import { Chain } from './entities/chain.entity';
 
 @Injectable()
 export class ChainsService {
   constructor(
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
     @Inject(IChainsRepository)
     private readonly chainsRepository: IChainsRepository,
     @Inject(IBackboneRepository)
@@ -80,6 +84,17 @@ export class ChainsService {
       result.shortName,
       result.theme,
       result.ensRegistryAddress,
+    );
+  }
+
+  async getAboutChain(chainId: string): Promise<AboutChain> {
+    const chain = await this.chainsRepository.getChain(chainId);
+
+    return new AboutChain(
+      chain.transactionService,
+      this.configurationService.getOrThrow<string>('about.name'),
+      this.configurationService.getOrThrow<string>('about.version'),
+      this.configurationService.getOrThrow<string>('about.buildNumber'),
     );
   }
 

--- a/src/routes/chains/entities/about-chain.entity.ts
+++ b/src/routes/chains/entities/about-chain.entity.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AboutChain {
+  @ApiProperty()
+  transactionServiceBaseUri: string;
+  @ApiProperty()
+  name: string;
+  @ApiProperty()
+  version: string;
+  @ApiProperty()
+  buildNumber: string;
+
+  constructor(
+    transactionServiceBaseUri: string,
+    name: string,
+    version: string,
+    buildNumber: string,
+  ) {
+    this.transactionServiceBaseUri = transactionServiceBaseUri;
+    this.name = name;
+    this.version = version;
+    this.buildNumber = buildNumber;
+  }
+}


### PR DESCRIPTION
- Adds `/v1/chains/:chain_id/about` route to the service.
- The payload returned is formed by aggregating Config Service data (`transactionServiceBaseUri`) and some of the service's internal configuration data (`name`, `version`, `buildNumber`).
- Controller tests and OpenAPI specifications are included.
- No E2E was included since the expected data for this endpoint is volatile.