### PR TITLE
Add get safe creation transaction

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -18,6 +18,7 @@ import { MultisigTransaction } from '../../domain/safe/entities/multisig-transac
 import { Transaction } from '../../domain/safe/entities/transaction.entity';
 import { Token } from '../../domain/tokens/entities/token.entity';
 import { ModuleTransaction } from '../../domain/safe/entities/module-transaction.entity';
+import { CreationTransaction } from '../../domain/safe/entities/creation-transaction.entity';
 
 function balanceCacheKey(chainId: string, safeAddress: string): string {
   return `${chainId}_${safeAddress}_balances`;
@@ -331,6 +332,18 @@ export class TransactionApi implements ITransactionApi {
     try {
       const cacheKey = `${this.chainId}_${safeTransactionHash}_multisig_transaction`;
       const url = `${this.baseUrl}/api/v1/multisig-transactions/${safeTransactionHash}/`;
+      return await this.dataSource.get(cacheKey, '', url);
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  async getCreationTransaction(
+    safeAddress: string,
+  ): Promise<CreationTransaction> {
+    try {
+      const cacheKey = `${this.chainId}_${safeAddress}_creation_transaction`;
+      const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/creation/`;
       return await this.dataSource.get(cacheKey, '', url);
     } catch (error) {
       throw this.httpErrorFactory.from(error);

--- a/src/domain.module.ts
+++ b/src/domain.module.ts
@@ -45,6 +45,7 @@ import { ModuleTransactionValidator } from './domain/safe/module-transaction.val
 import { ITokenRepository } from './domain/tokens/token.repository.interface';
 import { TokenRepository } from './domain/tokens/token.repository';
 import { TokenValidator } from './domain/tokens/token.validator';
+import { CreationTransactionValidator } from './domain/safe/creation-transaction.validator';
 
 @Global()
 @Module({
@@ -67,6 +68,7 @@ import { TokenValidator } from './domain/tokens/token.validator';
     CollectiblesValidator,
     ContractsValidator,
     DataDecodedValidator,
+    CreationTransactionValidator,
     DelegateValidator,
     ExchangeFiatCodesValidator,
     ExchangeRatesValidator,

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -13,6 +13,7 @@ import { Transaction } from '../safe/entities/transaction.entity';
 import { Token } from '../tokens/entities/token.entity';
 import { ModuleTransaction } from '../safe/entities/module-transaction.entity';
 import { SafeList } from '../safe/entities/safe-list.entity';
+import { CreationTransaction } from '../safe/entities/creation-transaction.entity';
 
 export interface ITransactionApi {
   getBalances(
@@ -108,6 +109,8 @@ export interface ITransactionApi {
     limit?: number,
     offset?: number,
   ): Promise<Page<MultisigTransaction>>;
+
+  getCreationTransaction(safeAddress: string): Promise<CreationTransaction>;
 
   getAllTransactions(
     safeAddress: string,

--- a/src/domain/safe/creation-transaction.validator.ts
+++ b/src/domain/safe/creation-transaction.validator.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { ValidateFunction } from 'ajv';
+import { IValidator } from '../interfaces/validator.interface';
+import { JsonSchemaService } from '../schema/json-schema.service';
+import { GenericValidator } from '../schema/generic.validator';
+import { CreationTransaction } from './entities/creation-transaction.entity';
+import { creationTransactionSchema } from './entities/schemas/creation-transaction.schema';
+
+@Injectable()
+export class CreationTransactionValidator
+  implements IValidator<CreationTransaction>
+{
+  private readonly isValidCreationTransaction: ValidateFunction<CreationTransaction>;
+
+  constructor(
+    private readonly genericValidator: GenericValidator,
+    private readonly jsonSchemaService: JsonSchemaService,
+  ) {
+    this.isValidCreationTransaction = this.jsonSchemaService.compile(
+      creationTransactionSchema,
+    ) as ValidateFunction<CreationTransaction>;
+  }
+
+  validate(data: unknown): CreationTransaction {
+    return this.genericValidator.validate(
+      this.isValidCreationTransaction,
+      data,
+    );
+  }
+}

--- a/src/domain/safe/entities/__tests__/creation-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/creation-transaction.builder.ts
@@ -1,0 +1,15 @@
+import { faker } from '@faker-js/faker';
+import { Builder, IBuilder } from '../../../../__tests__/builder';
+import { CreationTransaction } from '../creation-transaction.entity';
+import { dataDecodedBuilder } from '../../../data-decoder/entities/__tests__/data-decoded.builder';
+
+export function creationTransactionBuilder(): IBuilder<CreationTransaction> {
+  return Builder.new<CreationTransaction>()
+    .with('created', faker.date.recent())
+    .with('creator', faker.finance.ethereumAddress())
+    .with('transactionHash', faker.datatype.hexadecimal())
+    .with('factoryAddress', faker.finance.ethereumAddress())
+    .with('masterCopy', faker.finance.ethereumAddress())
+    .with('setupData', faker.datatype.hexadecimal())
+    .with('dataDecoded', dataDecodedBuilder().build());
+}

--- a/src/domain/safe/entities/creation-transaction.entity.ts
+++ b/src/domain/safe/entities/creation-transaction.entity.ts
@@ -4,7 +4,7 @@ export interface CreationTransaction {
   created: Date;
   creator: string;
   transactionHash: string;
-  factoryAddress: string | null;
+  factoryAddress: string;
   masterCopy: string | null;
   setupData: string | null;
   dataDecoded: DataDecoded | null;

--- a/src/domain/safe/entities/creation-transaction.entity.ts
+++ b/src/domain/safe/entities/creation-transaction.entity.ts
@@ -1,0 +1,11 @@
+import { DataDecoded } from '../../data-decoder/entities/data-decoded.entity';
+
+export interface CreationTransaction {
+  created: Date;
+  creator: string;
+  transactionHash: string;
+  factoryAddress: string | null;
+  masterCopy: string | null;
+  setupData: string | null;
+  dataDecoded: DataDecoded | null;
+}

--- a/src/domain/safe/entities/schemas/creation-transaction.schema.ts
+++ b/src/domain/safe/entities/schemas/creation-transaction.schema.ts
@@ -7,7 +7,7 @@ export const creationTransactionSchema: Schema = {
     created: { type: 'string', isDate: true },
     creator: { type: 'string' },
     transactionHash: { type: 'string' },
-    factoryAddress: { type: 'string', nullable: true },
+    factoryAddress: { type: 'string' },
     masterCopy: { type: 'string', nullable: true },
     setupData: { type: 'string', nullable: true },
     dataDecoded: { oneOf: [dataDecodedSchema, { type: 'null' }] },

--- a/src/domain/safe/entities/schemas/creation-transaction.schema.ts
+++ b/src/domain/safe/entities/schemas/creation-transaction.schema.ts
@@ -1,0 +1,16 @@
+import { Schema } from 'ajv';
+import { dataDecodedSchema } from '../../../data-decoder/entities/schemas/data-decoded.schema';
+
+export const creationTransactionSchema: Schema = {
+  type: 'object',
+  properties: {
+    created: { type: 'string', isDate: true },
+    creator: { type: 'string' },
+    transactionHash: { type: 'string' },
+    factoryAddress: { type: 'string', nullable: true },
+    masterCopy: { type: 'string', nullable: true },
+    setupData: { type: 'string', nullable: true },
+    dataDecoded: { oneOf: [dataDecodedSchema, { type: 'null' }] },
+  },
+  required: ['created', 'creator', 'transactionhash'],
+};

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -5,6 +5,7 @@ import { MultisigTransaction } from './entities/multisig-transaction.entity';
 import { Transaction } from './entities/transaction.entity';
 import { ModuleTransaction } from './entities/module-transaction.entity';
 import { SafeList } from './entities/safe-list.entity';
+import { CreationTransaction } from './entities/creation-transaction.entity';
 
 export const ISafeRepository = Symbol('ISafeRepository');
 
@@ -45,6 +46,11 @@ export interface ISafeRepository {
     limit?: number,
     offset?: number,
   ): Promise<Page<MultisigTransaction>>;
+
+  getCreationTransaction(
+    chainId: string,
+    safeAddress: string,
+  ): Promise<CreationTransaction>;
 
   getTransactionHistory(
     chainId: string,

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -14,6 +14,8 @@ import { ModuleTransaction } from './entities/module-transaction.entity';
 import { SafeList } from './entities/safe-list.entity';
 import { SafeListValidator } from './safe-list.validator';
 import { ModuleTransactionValidator } from './module-transaction.validator';
+import { CreationTransaction } from './entities/creation-transaction.entity';
+import { CreationTransactionValidator } from './creation-transaction.validator';
 
 @Injectable()
 export class SafeRepository implements ISafeRepository {
@@ -26,6 +28,7 @@ export class SafeRepository implements ISafeRepository {
     private readonly transactionTypeValidator: TransactionTypeValidator,
     private readonly transferValidator: TransferValidator,
     private readonly moduleTransactionValidator: ModuleTransactionValidator,
+    private readonly creationTransactionValidator: CreationTransactionValidator,
   ) {}
 
   async getSafe(chainId: string, address: string): Promise<Safe> {
@@ -136,6 +139,18 @@ export class SafeRepository implements ISafeRepository {
     );
 
     return page;
+  }
+
+  async getCreationTransaction(
+    chainId: string,
+    safeAddress: string,
+  ): Promise<CreationTransaction> {
+    const transactionService =
+      await this.transactionApiManager.getTransactionApi(chainId);
+    const createTransaction = await transactionService.getCreationTransaction(
+      safeAddress,
+    );
+    return this.creationTransactionValidator.validate(createTransaction);
   }
 
   async getTransactionHistory(


### PR DESCRIPTION
Closes #241 
- Add domain get safe creation transaction

# Additional notes
Couldn't keep alphabetic sort in [domain.module](https://github.com/5afe/safe-client-gateway-nest/compare/add_safe_creation_transaction?expand=1#diff-7d821304f2e0af7a603b971363f1bb70cb50afde8e2254719eb910536255ed27R71) because `creationTransactionValidator` contains a field that needs `dataDecodeValidator`. 

