### PR TITLE
Improve MultisigTransactionBuilder

### DIFF
--- a/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
@@ -1,7 +1,8 @@
+import { faker } from '@faker-js/faker';
+import { random, range } from 'lodash';
+import { Builder, IBuilder } from '../../../../__tests__/builder';
 import { MultisigTransaction } from '../multisig-transaction.entity';
 import { Operation } from '../operation.entity';
-import { faker } from '@faker-js/faker';
-import { Builder, IBuilder } from '../../../../__tests__/builder';
 import {
   confirmationBuilder,
   toJson as confirmationToJson,
@@ -11,7 +12,10 @@ export function multisigTransactionBuilder(): IBuilder<MultisigTransaction> {
   return Builder.new<MultisigTransaction>()
     .with('baseGas', faker.datatype.number())
     .with('blockNumber', faker.datatype.number())
-    .with('confirmations', [confirmationBuilder().build()])
+    .with(
+      'confirmations',
+      range(random(5)).map(() => confirmationBuilder().build()),
+    )
     .with('confirmationsRequired', faker.datatype.number())
     .with('data', faker.datatype.hexadecimal())
     .with('dataDecoded', faker.datatype.json())
@@ -27,7 +31,10 @@ export function multisigTransactionBuilder(): IBuilder<MultisigTransaction> {
     .with('modified', faker.date.recent())
     .with('nonce', faker.datatype.number())
     .with('operation', faker.helpers.arrayElement([0, 1]) as Operation)
-    .with('origin', faker.internet.url())
+    .with(
+      'origin',
+      `{"url": "${faker.internet.url()}", "name": "${faker.random.words()}"}`,
+    )
     .with('refundReceiver', faker.finance.ethereumAddress())
     .with('safe', faker.finance.ethereumAddress())
     .with('safeTxGas', faker.datatype.number())

--- a/src/routes/transactions/mappers/common/safe-app-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/safe-app-info.mapper.spec.ts
@@ -49,12 +49,7 @@ describe('SafeAppInfo mapper (Unit)', () => {
   it('should return null if no SafeApp is found and origin is not null', async () => {
     const chainId = faker.random.numeric();
     const safeApps = [];
-    const transaction = multisigTransactionBuilder()
-      .with(
-        'origin',
-        `{\"url\": \"${faker.internet.url()}\", \"name\": \"$SAFE Claiming App\"}`,
-      )
-      .build();
+    const transaction = multisigTransactionBuilder().build();
     safeAppsRepositoryMock.getSafeApps.mockResolvedValue(safeApps);
 
     const actual = await mapper.mapSafeAppInfo(chainId, transaction);
@@ -67,12 +62,7 @@ describe('SafeAppInfo mapper (Unit)', () => {
     const safeApp = safeAppBuilder().build();
     const anotherSafeApp = safeAppBuilder().build();
     const safeApps = [safeApp, anotherSafeApp];
-    const transaction = multisigTransactionBuilder()
-      .with(
-        'origin',
-        `{\"url\": \"${safeApp.url}\", \"name\": \"$SAFE Claiming App\"}`,
-      )
-      .build();
+    const transaction = multisigTransactionBuilder().build();
     safeAppsRepositoryMock.getSafeApps.mockResolvedValue(safeApps);
     const expected = new SafeAppInfo(
       safeApp.name,
@@ -91,12 +81,7 @@ describe('SafeAppInfo mapper (Unit)', () => {
     const safeApp = safeAppBuilder().with('url', originUrl).build();
     const safeApps = [safeApp];
     const expectedUrl = 'https://cloudflare-ipfs.com/test';
-    const transaction = multisigTransactionBuilder()
-      .with(
-        'origin',
-        `{\"url\": \"${originUrl}\", \"name\": \"$SAFE Claiming App\"}`,
-      )
-      .build();
+    const transaction = multisigTransactionBuilder().build();
     safeAppsRepositoryMock.getSafeApps.mockResolvedValue(safeApps);
     const expected = new SafeAppInfo(
       safeApp.name,

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.spec.ts
@@ -1,169 +1,140 @@
 import { faker } from '@faker-js/faker';
+import { confirmationBuilder } from '../../../../domain/safe/entities/__tests__/multisig-transaction-confirmation.builder';
+import { multisigTransactionBuilder } from '../../../../domain/safe/entities/__tests__/multisig-transaction.builder';
+import { safeBuilder } from '../../../../domain/safe/entities/__tests__/safe.builder';
 import { AddressInfo } from '../../../common/entities/address-info.entity';
 import { MultisigExecutionInfo } from '../../entities/multisig-execution-info.entity';
 import { TransactionStatus } from '../../entities/transaction-status.entity';
 import { MultisigTransactionExecutionInfoMapper } from './multisig-transaction-execution-info.mapper';
-import { multisigTransactionBuilder } from '../../../../domain/safe/entities/__tests__/multisig-transaction.builder';
-import { confirmationBuilder } from '../../../../domain/safe/entities/__tests__/multisig-transaction-confirmation.builder';
-import { safeBuilder } from '../../../../domain/safe/entities/__tests__/safe.builder';
 
 describe('Multisig Transaction execution info mapper (Unit)', () => {
   const mapper = new MultisigTransactionExecutionInfoMapper();
 
   it('should return a MultiSigExecutionInfo with no missing signers', () => {
-    const nonce = faker.datatype.number({ min: 0 });
-    const confirmationsRequired = faker.datatype.number({ min: 0 });
-    const txStatus = TransactionStatus.Success;
-    const confirmations = [
-      confirmationBuilder().build(),
-      confirmationBuilder().build(),
-    ];
     const safe = safeBuilder().build();
-    const transaction = multisigTransactionBuilder()
-      .with('nonce', nonce)
-      .with('confirmations', confirmations)
-      .with('confirmationsRequired', confirmationsRequired)
-      .build();
-
-    const executionInfo = mapper.mapExecutionInfo(transaction, safe, txStatus);
+    const transaction = multisigTransactionBuilder().build();
+    const executionInfo = mapper.mapExecutionInfo(
+      transaction,
+      safe,
+      TransactionStatus.Success,
+    );
 
     expect(executionInfo).toBeInstanceOf(MultisigExecutionInfo);
-    expect(executionInfo).toHaveProperty('nonce', nonce);
+    expect(executionInfo).toHaveProperty('nonce', transaction.nonce);
     expect(executionInfo).toHaveProperty(
       'confirmationsRequired',
-      confirmationsRequired,
+      transaction.confirmationsRequired,
     );
     expect(executionInfo).toHaveProperty(
       'confirmationsSubmitted',
-      confirmations.length,
+      transaction.confirmations?.length,
     );
     expect(executionInfo).toHaveProperty('missingSigners', null);
   });
 
   it('should return a MultiSigExecutionInfo with no missing signers and zero confirmations', () => {
-    const nonce = faker.datatype.number({ min: 0 });
-    const confirmationsRequired = faker.datatype.number({ min: 0 });
-    const txStatus = TransactionStatus.Success;
     const safe = safeBuilder().build();
     const transaction = multisigTransactionBuilder()
-      .with('nonce', nonce)
       .with('confirmations', null)
-      .with('confirmationsRequired', confirmationsRequired)
       .build();
-
-    const executionInfo = mapper.mapExecutionInfo(transaction, safe, txStatus);
+    const executionInfo = mapper.mapExecutionInfo(
+      transaction,
+      safe,
+      TransactionStatus.Success,
+    );
 
     expect(executionInfo).toBeInstanceOf(MultisigExecutionInfo);
-    expect(executionInfo).toHaveProperty('nonce', nonce);
+    expect(executionInfo).toHaveProperty('nonce', transaction.nonce);
     expect(executionInfo).toHaveProperty(
       'confirmationsRequired',
-      confirmationsRequired,
+      transaction.confirmationsRequired,
     );
     expect(executionInfo).toHaveProperty('confirmationsSubmitted', 0);
     expect(executionInfo).toHaveProperty('missingSigners', null);
   });
 
   it('should return a MultiSigExecutionInfo with empty missing signers', () => {
-    const nonce = faker.datatype.number({ min: 0 });
-    const confirmationsRequired = faker.datatype.number({ min: 0 });
-    const txStatus = TransactionStatus.AwaitingConfirmations;
-    const confirmations = [
-      confirmationBuilder().build(),
-      confirmationBuilder().build(),
-    ];
-    const safeOwners = [];
-    const safe = safeBuilder().with('owners', safeOwners).build();
-    const transaction = multisigTransactionBuilder()
-      .with('nonce', nonce)
-      .with('confirmations', confirmations)
-      .with('confirmationsRequired', confirmationsRequired)
-      .build();
-
-    const executionInfo = mapper.mapExecutionInfo(transaction, safe, txStatus);
+    const safe = safeBuilder().with('owners', []).build();
+    const transaction = multisigTransactionBuilder().build();
+    const executionInfo = mapper.mapExecutionInfo(
+      transaction,
+      safe,
+      TransactionStatus.AwaitingConfirmations,
+    );
 
     expect(executionInfo).toBeInstanceOf(MultisigExecutionInfo);
-    expect(executionInfo).toHaveProperty('nonce', nonce);
+    expect(executionInfo).toHaveProperty('nonce', transaction.nonce);
     expect(executionInfo).toHaveProperty(
       'confirmationsRequired',
-      confirmationsRequired,
+      transaction.confirmationsRequired,
     );
     expect(executionInfo).toHaveProperty(
       'confirmationsSubmitted',
-      confirmations.length,
+      transaction.confirmations?.length,
     );
     expect(executionInfo).toHaveProperty('missingSigners', []);
   });
 
   it('should return a MultiSigExecutionInfo with all safe owners as missing signers', () => {
-    const nonce = faker.datatype.number({ min: 0 });
-    const confirmationsRequired = faker.datatype.number({ min: 0 });
-    const txStatus = TransactionStatus.AwaitingConfirmations;
-    const confirmations = [
-      confirmationBuilder().build(),
-      confirmationBuilder().build(),
-    ];
-    const safeOwners = [
-      faker.finance.ethereumAddress(),
-      faker.finance.ethereumAddress(),
-    ];
-    const safe = safeBuilder().with('owners', safeOwners).build();
-    const transaction = multisigTransactionBuilder()
-      .with('nonce', nonce)
-      .with('confirmations', confirmations)
-      .with('confirmationsRequired', confirmationsRequired)
+    const transaction = multisigTransactionBuilder().build();
+    const safe = safeBuilder()
+      .with('owners', [
+        faker.finance.ethereumAddress(),
+        faker.finance.ethereumAddress(),
+      ])
       .build();
-
-    const executionInfo = mapper.mapExecutionInfo(transaction, safe, txStatus);
+    const executionInfo = mapper.mapExecutionInfo(
+      transaction,
+      safe,
+      TransactionStatus.AwaitingConfirmations,
+    );
 
     expect(executionInfo).toBeInstanceOf(MultisigExecutionInfo);
-    expect(executionInfo).toHaveProperty('nonce', nonce);
+    expect(executionInfo).toHaveProperty('nonce', transaction.nonce);
     expect(executionInfo).toHaveProperty(
       'confirmationsRequired',
-      confirmationsRequired,
+      transaction.confirmationsRequired,
     );
     expect(executionInfo).toHaveProperty(
       'confirmationsSubmitted',
-      confirmations.length,
+      transaction.confirmations?.length,
     );
     expect(executionInfo).toHaveProperty(
       'missingSigners',
-      safeOwners.map((address) => new AddressInfo(address)),
+      safe.owners.map((address) => new AddressInfo(address)),
     );
   });
 
   it('should return a MultiSigExecutionInfo with some safe owners as missing signers', () => {
-    const nonce = faker.datatype.number({ min: 0 });
-    const confirmationsRequired = faker.datatype.number({ min: 0 });
-    const txStatus = TransactionStatus.AwaitingConfirmations;
     const confirmations = [
       confirmationBuilder().build(),
       confirmationBuilder().build(),
     ];
-    const safeOwners = [
-      confirmations[0].owner,
-      faker.finance.ethereumAddress(),
-    ];
-    const safe = safeBuilder().with('owners', safeOwners).build();
     const transaction = multisigTransactionBuilder()
-      .with('nonce', nonce)
       .with('confirmations', confirmations)
-      .with('confirmationsRequired', confirmationsRequired)
+      .build();
+    const safe = safeBuilder()
+      .with('owners', [confirmations[0].owner, faker.finance.ethereumAddress()])
       .build();
 
-    const executionInfo = mapper.mapExecutionInfo(transaction, safe, txStatus);
+    const executionInfo = mapper.mapExecutionInfo(
+      transaction,
+      safe,
+      TransactionStatus.AwaitingConfirmations,
+    );
 
     expect(executionInfo).toBeInstanceOf(MultisigExecutionInfo);
-    expect(executionInfo).toHaveProperty('nonce', nonce);
+    expect(executionInfo).toHaveProperty('nonce', transaction.nonce);
     expect(executionInfo).toHaveProperty(
       'confirmationsRequired',
-      confirmationsRequired,
+      transaction.confirmationsRequired,
     );
     expect(executionInfo).toHaveProperty(
       'confirmationsSubmitted',
       confirmations.length,
     );
     expect(executionInfo).toHaveProperty('missingSigners', [
-      new AddressInfo(safeOwners[1]),
+      new AddressInfo(safe.owners[1]),
     ]);
   });
 });

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.spec.ts
@@ -19,17 +19,14 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
       TransactionStatus.Success,
     );
 
-    expect(executionInfo).toBeInstanceOf(MultisigExecutionInfo);
-    expect(executionInfo).toHaveProperty('nonce', transaction.nonce);
-    expect(executionInfo).toHaveProperty(
-      'confirmationsRequired',
-      transaction.confirmationsRequired,
+    expect(executionInfo).toEqual(
+      new MultisigExecutionInfo(
+        transaction.nonce,
+        transaction.confirmationsRequired,
+        Number(transaction.confirmations?.length),
+        null,
+      ),
     );
-    expect(executionInfo).toHaveProperty(
-      'confirmationsSubmitted',
-      transaction.confirmations?.length,
-    );
-    expect(executionInfo).toHaveProperty('missingSigners', null);
   });
 
   it('should return a MultiSigExecutionInfo with no missing signers and zero confirmations', () => {
@@ -43,14 +40,14 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
       TransactionStatus.Success,
     );
 
-    expect(executionInfo).toBeInstanceOf(MultisigExecutionInfo);
-    expect(executionInfo).toHaveProperty('nonce', transaction.nonce);
-    expect(executionInfo).toHaveProperty(
-      'confirmationsRequired',
-      transaction.confirmationsRequired,
+    expect(executionInfo).toEqual(
+      new MultisigExecutionInfo(
+        transaction.nonce,
+        transaction.confirmationsRequired,
+        0,
+        null,
+      ),
     );
-    expect(executionInfo).toHaveProperty('confirmationsSubmitted', 0);
-    expect(executionInfo).toHaveProperty('missingSigners', null);
   });
 
   it('should return a MultiSigExecutionInfo with empty missing signers', () => {
@@ -62,17 +59,14 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
       TransactionStatus.AwaitingConfirmations,
     );
 
-    expect(executionInfo).toBeInstanceOf(MultisigExecutionInfo);
-    expect(executionInfo).toHaveProperty('nonce', transaction.nonce);
-    expect(executionInfo).toHaveProperty(
-      'confirmationsRequired',
-      transaction.confirmationsRequired,
+    expect(executionInfo).toEqual(
+      new MultisigExecutionInfo(
+        transaction.nonce,
+        transaction.confirmationsRequired,
+        Number(transaction.confirmations?.length),
+        [],
+      ),
     );
-    expect(executionInfo).toHaveProperty(
-      'confirmationsSubmitted',
-      transaction.confirmations?.length,
-    );
-    expect(executionInfo).toHaveProperty('missingSigners', []);
   });
 
   it('should return a MultiSigExecutionInfo with all safe owners as missing signers', () => {
@@ -89,19 +83,13 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
       TransactionStatus.AwaitingConfirmations,
     );
 
-    expect(executionInfo).toBeInstanceOf(MultisigExecutionInfo);
-    expect(executionInfo).toHaveProperty('nonce', transaction.nonce);
-    expect(executionInfo).toHaveProperty(
-      'confirmationsRequired',
-      transaction.confirmationsRequired,
-    );
-    expect(executionInfo).toHaveProperty(
-      'confirmationsSubmitted',
-      transaction.confirmations?.length,
-    );
-    expect(executionInfo).toHaveProperty(
-      'missingSigners',
-      safe.owners.map((address) => new AddressInfo(address)),
+    expect(executionInfo).toEqual(
+      new MultisigExecutionInfo(
+        transaction.nonce,
+        transaction.confirmationsRequired,
+        Number(transaction.confirmations?.length),
+        safe.owners.map((address) => new AddressInfo(address)),
+      ),
     );
   });
 
@@ -123,18 +111,13 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
       TransactionStatus.AwaitingConfirmations,
     );
 
-    expect(executionInfo).toBeInstanceOf(MultisigExecutionInfo);
-    expect(executionInfo).toHaveProperty('nonce', transaction.nonce);
-    expect(executionInfo).toHaveProperty(
-      'confirmationsRequired',
-      transaction.confirmationsRequired,
+    expect(executionInfo).toEqual(
+      new MultisigExecutionInfo(
+        transaction.nonce,
+        transaction.confirmationsRequired,
+        Number(transaction.confirmations?.length),
+        [new AddressInfo(safe.owners[1])],
+      ),
     );
-    expect(executionInfo).toHaveProperty(
-      'confirmationsSubmitted',
-      confirmations.length,
-    );
-    expect(executionInfo).toHaveProperty('missingSigners', [
-      new AddressInfo(safe.owners[1]),
-    ]);
   });
 });

--- a/src/routes/transactions/transactions.controller.spec.ts
+++ b/src/routes/transactions/transactions.controller.spec.ts
@@ -259,20 +259,17 @@ describe('Transactions Controller (Unit)', () => {
     it('Should get a Custom transaction mapped to the expected format', async () => {
       const chainId = faker.random.numeric();
       const chainResponse = chainBuilder().build();
-      const safeAppUrl = faker.internet.url();
-      const contractDisplayName = faker.random.words();
-      const contractLogoUri = faker.internet.url();
       const safeAppsResponse = [
         safeAppBuilder()
-          .with('url', safeAppUrl)
+          .with('url', faker.internet.url())
           .with('iconUrl', faker.internet.url())
           .with('name', faker.random.words())
           .build(),
       ];
       const contractResponse = contractBuilder()
         .with('address', faker.finance.ethereumAddress())
-        .with('displayName', contractDisplayName)
-        .with('logoUri', contractLogoUri)
+        .with('displayName', faker.random.words())
+        .with('logoUri', faker.internet.url())
         .build();
       const domainTransaction = multisigTransactionBuilder()
         .with('value', '0')
@@ -291,7 +288,6 @@ describe('Transactions Controller (Unit)', () => {
             ])
             .build(),
         )
-        .with('origin', `{\"url\": \"${safeAppUrl}\"}`)
         .build();
       mockNetworkService.get.mockImplementation((url) => {
         const getChainUrl = `${safeConfigApiUrl}/api/v1/chains/${chainId}`;
@@ -346,8 +342,8 @@ describe('Transactions Controller (Unit)', () => {
                     type: 'Custom',
                     to: {
                       value: contractResponse.address,
-                      name: contractDisplayName,
-                      logoUri: contractLogoUri,
+                      name: contractResponse.displayName,
+                      logoUri: contractResponse.logoUri,
                     },
                     dataSize: '16',
                     value: domainTransaction.value,
@@ -367,7 +363,7 @@ describe('Transactions Controller (Unit)', () => {
                   safeAppInfo: {
                     logo_uri: safeAppsResponse[0].iconUrl,
                     name: safeAppsResponse[0].name,
-                    url: safeAppUrl,
+                    url: safeAppsResponse[0].url,
                   },
                 },
                 conflictType: 'None',


### PR DESCRIPTION
This PR aims to improve `MultisigTransactionBuilder`, specifically:
- Change `origin` field return to a string containing a JSON with `url` and `name`.
- Return a random number of `Confirmation` instead just 1.
- Related changes were made to some test classes to use the builder directly with random data instead of custom properties. Some refactors were made as well to simplify the code taking advantage of the builder changes.

More context for this change on [this previous discussion](https://github.com/5afe/safe-client-gateway-nest/pull/236#discussion_r1085112938).