### PR TITLE
Use dataDecoded schema for MultisigTransaction

### DIFF
--- a/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
@@ -6,6 +6,7 @@ import {
   confirmationBuilder,
   toJson as confirmationToJson,
 } from './multisig-transaction-confirmation.builder';
+import { dataDecodedBuilder } from '../../../data-decoder/entities/__tests__/data-decoded.builder';
 
 export function multisigTransactionBuilder(): IBuilder<MultisigTransaction> {
   return Builder.new<MultisigTransaction>()
@@ -14,7 +15,7 @@ export function multisigTransactionBuilder(): IBuilder<MultisigTransaction> {
     .with('confirmations', [confirmationBuilder().build()])
     .with('confirmationsRequired', faker.datatype.number())
     .with('data', faker.datatype.hexadecimal())
-    .with('dataDecoded', faker.datatype.json())
+    .with('dataDecoded', dataDecodedBuilder().build())
     .with('ethGasPrice', faker.datatype.hexadecimal())
     .with('executor', faker.finance.ethereumAddress())
     .with('executionDate', faker.date.recent())

--- a/src/domain/safe/entities/multisig-transaction.entity.ts
+++ b/src/domain/safe/entities/multisig-transaction.entity.ts
@@ -1,4 +1,5 @@
 import { Operation } from './operation.entity';
+import { DataDecoded } from '../../data-decoder/entities/data-decoded.entity';
 
 export interface Confirmation {
   owner: string;
@@ -14,7 +15,7 @@ export type MultisigTransaction = {
   confirmations: Confirmation[] | null;
   confirmationsRequired: number;
   data: string | null; // TODO will be added under https://github.com/5afe/safe-client-gateway-nest/pull/132
-  dataDecoded: any | null;
+  dataDecoded: DataDecoded | null;
   ethGasPrice: string | null;
   executionDate: Date;
   executor: string | null;

--- a/src/domain/safe/entities/schemas/multisig-transaction.schema.ts
+++ b/src/domain/safe/entities/schemas/multisig-transaction.schema.ts
@@ -19,7 +19,10 @@ export const multisigTransactionSchema: Schema = {
     to: { type: 'string' },
     value: { type: 'string', nullable: true, default: null },
     data: { type: 'string', nullable: true, default: null },
-    dataDecoded: { type: 'object', nullable: true, default: null },
+    dataDecoded: {
+      anyOf: [{ type: 'null' }, { $ref: 'dataDecodedSchema' }],
+      default: null,
+    },
     operation: { type: 'number', enum: [0, 1] },
     gasToken: { type: 'string', nullable: true, default: null },
     safeTxGas: { type: 'number', nullable: true, default: null },

--- a/src/domain/safe/multisig-transaction.validator.ts
+++ b/src/domain/safe/multisig-transaction.validator.ts
@@ -5,6 +5,7 @@ import { JsonSchemaService } from '../schema/json-schema.service';
 import { GenericValidator } from '../schema/generic.validator';
 import { multisigTransactionSchema } from './entities/schemas/multisig-transaction.schema';
 import { MultisigTransaction } from './entities/multisig-transaction.entity';
+import { dataDecodedSchema } from '../data-decoder/entities/schemas/data-decoded.schema';
 
 @Injectable()
 export class MultisigTransactionValidator
@@ -16,6 +17,7 @@ export class MultisigTransactionValidator
     private readonly genericValidator: GenericValidator,
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
+    this.jsonSchemaService.addSchema(dataDecodedSchema, 'dataDecodedSchema');
     this.isValidMultisigTransaction = this.jsonSchemaService.compile(
       multisigTransactionSchema,
     ) as ValidateFunction<MultisigTransaction>;

--- a/src/routes/transactions/entities/custom-transaction.entity.ts
+++ b/src/routes/transactions/entities/custom-transaction.entity.ts
@@ -4,7 +4,7 @@ import { TransactionInfo } from './transaction-info.entity';
 
 export class CustomTransactionInfo extends TransactionInfo {
   @ApiProperty()
-  to: AddressInfo | null;
+  to: AddressInfo;
   @ApiProperty()
   dataSize: string;
   @ApiProperty()
@@ -17,10 +17,10 @@ export class CustomTransactionInfo extends TransactionInfo {
   actionCount: number | null;
 
   constructor(
-    to: AddressInfo | null,
+    to: AddressInfo,
     dataSize: string,
     value: string,
-    methodName: string,
+    methodName: string | null,
     actionCount: number | null,
     isCancellation: boolean,
   ) {

--- a/src/routes/transactions/entities/settings-change-transaction.entity.ts
+++ b/src/routes/transactions/entities/settings-change-transaction.entity.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { DataDecoded } from '../../data-decode/entities/data-decoded.entity';
 import { SettingsChange } from './settings-changes/settings-change.entity';
 import { TransactionInfo } from './transaction-info.entity';
@@ -6,10 +6,10 @@ import { TransactionInfo } from './transaction-info.entity';
 export class SettingsChangeTransaction extends TransactionInfo {
   @ApiProperty()
   dataDecoded: DataDecoded;
-  @ApiProperty()
-  settingsInfo: SettingsChange;
+  @ApiPropertyOptional()
+  settingsInfo: SettingsChange | null;
 
-  constructor(dataDecoded: DataDecoded, settingsInfo: SettingsChange) {
+  constructor(dataDecoded: DataDecoded, settingsInfo: SettingsChange | null) {
     super('SettingsChange');
     this.dataDecoded = dataDecoded;
     this.settingsInfo = settingsInfo;

--- a/src/routes/transactions/mappers/common/custom-transaction.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/custom-transaction.mapper.spec.ts
@@ -5,6 +5,10 @@ import { CustomTransactionInfo } from '../../entities/custom-transaction.entity'
 import { CustomTransactionMapper } from './custom-transaction.mapper';
 import { multisigTransactionBuilder } from '../../../../domain/safe/entities/__tests__/multisig-transaction.builder';
 import { NULL_ADDRESS } from '../../../common/constants';
+import {
+  dataDecodedBuilder,
+  dataDecodedParameterBuilder,
+} from '../../../../domain/data-decoder/entities/__tests__/data-decoded.builder';
 
 const addressInfoHelper = jest.mocked({
   getOrDefault: jest.fn(),
@@ -16,12 +20,11 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
   it('should build a CustomTransactionInfo with null actionCount', async () => {
     const toAddress = new AddressInfo(faker.finance.ethereumAddress());
     addressInfoHelper.getOrDefault.mockResolvedValueOnce(toAddress);
-    const method = faker.random.word();
     const value = faker.datatype.number();
     const dataSize = faker.datatype.number();
     const chainId = faker.random.numeric();
     const transaction = multisigTransactionBuilder()
-      .with('dataDecoded', { method })
+      .with('dataDecoded', dataDecodedBuilder().build())
       .build();
 
     const customTransaction = await mapper.mapCustomTransaction(
@@ -36,7 +39,7 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
       to: toAddress,
       dataSize: dataSize.toString(),
       value: value.toString(),
-      methodName: method,
+      methodName: transaction.dataDecoded?.method,
       actionCount: null,
       isCancellation: false,
     });
@@ -50,7 +53,7 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     const dataSize = faker.datatype.number();
     const chainId = faker.random.numeric();
     const transaction = multisigTransactionBuilder()
-      .with('dataDecoded', { method })
+      .with('dataDecoded', dataDecodedBuilder().with('method', method).build())
       .build();
 
     const customTransaction = await mapper.mapCustomTransaction(
@@ -79,10 +82,18 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     const dataSize = faker.datatype.number();
     const chainId = faker.random.numeric();
     const transaction = multisigTransactionBuilder()
-      .with('dataDecoded', {
-        method,
-        parameters: [{ name: 'transactions', valueDecoded: [1, 2, 3] }],
-      })
+      .with(
+        'dataDecoded',
+        dataDecodedBuilder()
+          .with('method', method)
+          .with('parameters', [
+            dataDecodedParameterBuilder()
+              .with('name', 'transactions')
+              .with('valueDecoded', [1, 2, 3])
+              .build(),
+          ])
+          .build(),
+      )
       .build();
 
     const customTransaction = await mapper.mapCustomTransaction(
@@ -120,7 +131,7 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
       .with('gasToken', NULL_ADDRESS)
       .with('refundReceiver', NULL_ADDRESS)
       .with('safeTxGas', 0)
-      .with('dataDecoded', { method })
+      .with('dataDecoded', dataDecodedBuilder().with('method', method).build())
       .build();
 
     const customTransaction = await mapper.mapCustomTransaction(

--- a/src/routes/transactions/mappers/common/data-decoded-param.helper.spec.ts
+++ b/src/routes/transactions/mappers/common/data-decoded-param.helper.spec.ts
@@ -1,223 +1,312 @@
 import { faker } from '@faker-js/faker';
-import { DataDecoded } from '../../../data-decode/entities/data-decoded.entity';
 import { DataDecodedParamHelper } from './data-decoded-param.helper';
+import {
+  DataDecoded,
+  DataDecodedParameter,
+} from '../../../../domain/data-decoder/entities/data-decoded.entity';
 
 describe('DataDecoded param helper (Unit)', () => {
   const helper = new DataDecodedParamHelper();
 
   describe('getFromParam function tests', () => {
     it('should return the fallback value if null parameters in DataDecoded', () => {
-      const dataDecoded = new DataDecoded('transferFrom', null);
+      const dataDecoded = <DataDecoded>{
+        method: 'transferFrom',
+        parameters: null,
+      };
+
       const fromParam = helper.getFromParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('fallback');
     });
 
     it('should return the fallback value if empty parameters in DataDecoded', () => {
-      const dataDecoded = new DataDecoded('transferFrom', []);
+      const dataDecoded = <DataDecoded>{
+        method: 'transferFrom',
+        parameters: [],
+      };
+
       const fromParam = helper.getFromParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('fallback');
     });
 
     it('should return the fallback value if non-string parameters in DataDecoded', () => {
-      const firstParam = {
+      const firstParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 0,
       };
-      const dataDecoded = new DataDecoded('transferFrom', [firstParam]);
+      const dataDecoded = <DataDecoded>{
+        method: 'transferFrom',
+        parameters: [firstParam],
+      };
+
       const fromParam = helper.getFromParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('fallback');
     });
 
     it('should get the DataDecoded "from" param for a transfer method', () => {
-      const firstParam = {
+      const firstParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 'value',
       };
-      const dataDecoded = new DataDecoded('transfer', [firstParam]);
+      const dataDecoded = <DataDecoded>{
+        method: 'transfer',
+        parameters: [firstParam],
+      };
+
       const fromParam = helper.getFromParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('fallback');
     });
 
     it('should get the DataDecoded "from" param for a transferFrom method', () => {
-      const firstParam = {
+      const firstParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 'value',
       };
-      const dataDecoded = new DataDecoded('transferFrom', [firstParam]);
+      const dataDecoded = <DataDecoded>{
+        method: 'transferFrom',
+        parameters: [firstParam],
+      };
+
       const fromParam = helper.getFromParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('value');
     });
 
     it('should get the DataDecoded "from" param for a safeTransferFrom method', () => {
-      const firstParam = {
+      const firstParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 'value',
       };
-      const dataDecoded = new DataDecoded('safeTransferFrom', [firstParam]);
+      const dataDecoded = <DataDecoded>{
+        method: 'safeTransferFrom',
+        parameters: [firstParam],
+      };
+
       const fromParam = helper.getFromParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('value');
     });
 
     it('should return the fallback value if method is not "transferFrom"', () => {
-      const firstParam = {
+      const firstParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 'value',
       };
-      const dataDecoded = new DataDecoded(faker.random.word(), [firstParam]);
+      const dataDecoded = <DataDecoded>{
+        method: faker.random.word(),
+        parameters: [firstParam],
+      };
+
       const fromParam = helper.getFromParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('fallback');
     });
   });
 
   describe('getToParam function tests', () => {
     it('should return the fallback value if null parameters in DataDecoded', () => {
-      const dataDecoded = new DataDecoded('transferFrom', null);
+      const dataDecoded = <DataDecoded>{
+        method: 'transferFrom',
+        parameters: null,
+      };
+
       const fromParam = helper.getToParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('fallback');
     });
 
     it('should return the fallback value if empty parameters in DataDecoded', () => {
-      const dataDecoded = new DataDecoded('transferFrom', []);
+      const dataDecoded = <DataDecoded>{
+        method: 'transferFrom',
+        parameters: [],
+      };
+
       const fromParam = helper.getToParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('fallback');
     });
 
     it('should return the fallback value if non-string parameters in DataDecoded', () => {
-      const firstParam = {
+      const firstParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 0,
       };
-      const dataDecoded = new DataDecoded('transferFrom', [firstParam]);
+      const dataDecoded = <DataDecoded>{
+        method: 'transferFrom',
+        parameters: [firstParam],
+      };
+
       const fromParam = helper.getToParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('fallback');
     });
 
     it('should get the DataDecoded "to" param for a transfer method', () => {
-      const firstParam = {
+      const firstParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 'firstValue',
       };
-      const secondParam = {
+      const secondParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 'secondValue',
       };
-      const dataDecoded = new DataDecoded('transfer', [
-        firstParam,
-        secondParam,
-      ]);
+
+      const dataDecoded = <DataDecoded>{
+        method: 'transfer',
+        parameters: [firstParam, secondParam],
+      };
+
       const fromParam = helper.getToParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('firstValue');
     });
 
     it('should get the DataDecoded fallback for a non-string param', () => {
-      const firstParam = {
+      const firstParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: faker.datatype.number(),
       };
-      const dataDecoded = new DataDecoded('transfer', [firstParam]);
+      const dataDecoded = <DataDecoded>{
+        method: 'transfer',
+        parameters: [firstParam, [firstParam]],
+      };
+
       const fromParam = helper.getToParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('fallback');
     });
 
     it('should get the DataDecoded "to" param for a transferFrom method', () => {
-      const firstParam = {
+      const firstParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 'firstValue',
       };
-      const secondParam = {
+      const secondParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 'secondValue',
       };
-      const dataDecoded = new DataDecoded('transferFrom', [
-        firstParam,
-        secondParam,
-      ]);
+
+      const dataDecoded = <DataDecoded>{
+        method: 'transferFrom',
+        parameters: [firstParam, secondParam],
+      };
+
       const fromParam = helper.getToParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('secondValue');
     });
 
     it('should get the DataDecoded "to" param for a safeTransferFrom method', () => {
-      const firstParam = {
+      const firstParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 'firstValue',
       };
-      const secondParam = {
+      const secondParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 'secondValue',
       };
-      const dataDecoded = new DataDecoded('transferFrom', [
-        firstParam,
-        secondParam,
-      ]);
+      const dataDecoded = <DataDecoded>{
+        method: 'transferFrom',
+        parameters: [firstParam, secondParam],
+      };
+
       const fromParam = helper.getToParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('secondValue');
     });
 
     it('should return the fallback value if method is not "transferFrom"', () => {
-      const firstParam = {
+      const firstParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 'value',
       };
-      const dataDecoded = new DataDecoded(faker.random.word(), [firstParam]);
+      const dataDecoded = <DataDecoded>{
+        method: faker.random.word(),
+        parameters: [firstParam],
+      };
+
       const fromParam = helper.getToParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('fallback');
     });
   });
 
   describe('getValueParam function tests', () => {
     it('should return the fallback value if null parameters in DataDecoded', () => {
-      const dataDecoded = new DataDecoded('transferFrom', null);
+      const dataDecoded = <DataDecoded>{
+        method: 'transferFrom',
+        parameters: null,
+      };
+
       const fromParam = helper.getValueParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('fallback');
     });
 
     it('should return the fallback value if empty parameters in DataDecoded', () => {
-      const dataDecoded = new DataDecoded('transferFrom', []);
+      const dataDecoded = <DataDecoded>{
+        method: 'transferFrom',
+        parameters: [],
+      };
+
       const fromParam = helper.getValueParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('fallback');
     });
 
     it('should return the fallback value if non-string parameters in DataDecoded', () => {
-      const firstParam = {
+      const firstParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: faker.datatype.number(),
       };
-      const dataDecoded = new DataDecoded('transferFrom', [firstParam]);
+      const dataDecoded = <DataDecoded>{
+        method: 'transferFrom',
+        parameters: [firstParam],
+      };
+
       const fromParam = helper.getValueParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('fallback');
     });
 
     it('should get the DataDecoded "value" param for a transfer method', () => {
-      const firstParam = {
+      const firstParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 'firstValue',
       };
-      const secondParam = {
+      const secondParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 'secondValue',
       };
-      const dataDecoded = new DataDecoded('transfer', [
-        firstParam,
-        secondParam,
-      ]);
+
+      const dataDecoded = <DataDecoded>{
+        method: 'transfer',
+        parameters: [firstParam, secondParam],
+      };
+
       const fromParam = helper.getValueParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('secondValue');
     });
 
@@ -232,72 +321,82 @@ describe('DataDecoded param helper (Unit)', () => {
         type: faker.random.word(),
         value: faker.datatype.number(),
       };
-      const dataDecoded = new DataDecoded('transfer', [
-        firstParam,
-        secondParam,
-      ]);
+
+      const dataDecoded = <DataDecoded>{
+        method: 'transfer',
+        parameters: [firstParam, secondParam],
+      };
+
       const fromParam = helper.getValueParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('fallback');
     });
 
     it('should get the DataDecoded "value" param for a transferFrom method', () => {
-      const firstParam = {
+      const firstParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 'firstValue',
       };
-      const secondParam = {
+      const secondParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 'secondValue',
       };
-      const thirdParam = {
+      const thirdParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 'thirdValue',
       };
-      const dataDecoded = new DataDecoded('transferFrom', [
-        firstParam,
-        secondParam,
-        thirdParam,
-      ]);
+      const dataDecoded = <DataDecoded>{
+        method: 'transferFrom',
+        parameters: [firstParam, secondParam, thirdParam],
+      };
+
       const fromParam = helper.getValueParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('thirdValue');
     });
 
     it('should get the DataDecoded "value" param for a safeTransferFrom method', () => {
-      const firstParam = {
+      const firstParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 'firstValue',
       };
-      const secondParam = {
+      const secondParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 'secondValue',
       };
-      const thirdParam = {
+      const thirdParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 'thirdValue',
       };
-      const dataDecoded = new DataDecoded('transferFrom', [
-        firstParam,
-        secondParam,
-        thirdParam,
-      ]);
+      const dataDecoded = <DataDecoded>{
+        method: 'transferFrom',
+        parameters: [firstParam, secondParam, thirdParam],
+      };
+
       const fromParam = helper.getValueParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('thirdValue');
     });
 
     it('should return the fallback value if method is not "transferFrom"', () => {
-      const firstParam = {
+      const firstParam = <DataDecodedParameter>{
         name: faker.random.word(),
         type: faker.random.word(),
         value: 'value',
       };
-      const dataDecoded = new DataDecoded(faker.random.word(), [firstParam]);
+      const dataDecoded = <DataDecoded>{
+        method: faker.random.word(),
+        parameters: [firstParam],
+      };
+
       const fromParam = helper.getValueParam(dataDecoded, 'fallback');
+
       expect(fromParam).toBe('fallback');
     });
   });

--- a/src/routes/transactions/mappers/common/data-decoded-param.helper.ts
+++ b/src/routes/transactions/mappers/common/data-decoded-param.helper.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { DataDecoded } from '../../../data-decode/entities/data-decoded.entity';
+import { DataDecoded } from '../../../../domain/data-decoder/entities/data-decoded.entity';
 
 @Injectable()
 export class DataDecodedParamHelper {
@@ -7,10 +7,8 @@ export class DataDecodedParamHelper {
   private readonly TRANSFER_FROM_METHOD = 'transferFrom';
   private readonly SAFE_TRANSFER_FROM_METHOD = 'safeTransferFrom';
 
-  getFromParam(dataDecoded: DataDecoded, fallback: string): string {
-    if (!dataDecoded.parameters) {
-      return fallback;
-    }
+  getFromParam(dataDecoded: DataDecoded | null, fallback: string): string {
+    if (!dataDecoded || !dataDecoded.parameters) return fallback;
 
     switch (dataDecoded.method) {
       case this.TRANSFER_FROM_METHOD:
@@ -24,10 +22,8 @@ export class DataDecodedParamHelper {
     }
   }
 
-  getToParam(dataDecoded: DataDecoded, fallback: string): string {
-    if (!dataDecoded.parameters) {
-      return fallback;
-    }
+  getToParam(dataDecoded: DataDecoded | null, fallback: string): string {
+    if (!dataDecoded || !dataDecoded.parameters) return fallback;
 
     switch (dataDecoded.method) {
       case this.TRANSFER_METHOD: {
@@ -44,10 +40,8 @@ export class DataDecodedParamHelper {
     }
   }
 
-  getValueParam(dataDecoded: DataDecoded, fallback: string): string {
-    if (!dataDecoded.parameters) {
-      return fallback;
-    }
+  getValueParam(dataDecoded: DataDecoded | null, fallback: string): string {
+    if (!dataDecoded || !dataDecoded.parameters) return fallback;
 
     switch (dataDecoded.method) {
       case this.TRANSFER_METHOD: {
@@ -64,8 +58,11 @@ export class DataDecodedParamHelper {
     }
   }
 
-  getValueAtPosition(dataDecoded: any | null, position: number) {
-    if (!dataDecoded.parameters?.length) return null;
+  getValueAtPosition(
+    dataDecoded: DataDecoded | null,
+    position: number,
+  ): unknown {
+    if (!dataDecoded || !dataDecoded.parameters?.length) return null;
     return dataDecoded.parameters[position]?.value ?? null;
   }
 }

--- a/src/routes/transactions/mappers/common/settings-change.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/settings-change.mapper.spec.ts
@@ -14,7 +14,10 @@ import { SwapOwner } from '../../entities/settings-changes/swap-owner.entity';
 import { DataDecodedParamHelper } from './data-decoded-param.helper';
 import { SettingsChangeMapper } from './settings-change.mapper';
 import { multisigTransactionBuilder } from '../../../../domain/safe/entities/__tests__/multisig-transaction.builder';
-import { safeBuilder } from '../../../../domain/safe/entities/__tests__/safe.builder';
+import {
+  dataDecodedBuilder,
+  dataDecodedParameterBuilder,
+} from '../../../../domain/data-decoder/entities/__tests__/data-decoded.builder';
 
 const addressInfoHelper = jest.mocked({
   getOrDefault: jest.fn(),
@@ -27,252 +30,313 @@ describe('Multisig Settings Change Transaction mapper (Unit)', () => {
   );
 
   it('should build a SetFallbackHandler setting', async () => {
-    const safe = safeBuilder().build();
-    const handlerValue = faker.random.numeric();
+    const handlerValue = faker.finance.ethereumAddress();
+    addressInfoHelper.getOrDefault.mockResolvedValueOnce(
+      new AddressInfo(handlerValue),
+    );
     const transaction = multisigTransactionBuilder()
-      .with('dataDecoded', {
-        method: 'setFallbackHandler',
-        parameters: [{ value: handlerValue }],
-      })
+      .with(
+        'dataDecoded',
+        dataDecodedBuilder()
+          .with('method', 'setFallbackHandler')
+          .with('parameters', [
+            dataDecodedParameterBuilder().with('value', handlerValue).build(),
+          ])
+          .build(),
+      )
       .build();
 
-    const settingChange = await mapper.mapSettingsChange(
+    const actual = await mapper.mapSettingsChange(
       faker.random.numeric(),
       transaction,
-      safe,
     );
 
-    expect(settingChange).toBeInstanceOf(SetFallbackHandler);
-    expect(settingChange).toHaveProperty('handler', handlerValue);
+    const expected = new SetFallbackHandler(new AddressInfo(handlerValue));
+    expect(actual).toEqual(expected);
   });
 
   it('should build a SetFallbackHandler setting with a null handler', async () => {
-    const safe = safeBuilder().build();
     const transaction = multisigTransactionBuilder()
-      .with('dataDecoded', {
-        method: 'setFallbackHandler',
-      })
+      .with(
+        'dataDecoded',
+        dataDecodedBuilder()
+          .with('method', 'setFallbackHandler')
+          .with('parameters', [])
+          .build(),
+      )
       .build();
 
-    const settingChange = await mapper.mapSettingsChange(
+    const actual = await mapper.mapSettingsChange(
       faker.random.numeric(),
       transaction,
-      safe,
     );
 
-    expect(settingChange).toBeInstanceOf(SetFallbackHandler);
-    expect(settingChange).toHaveProperty('handler', null);
+    expect(actual).toBeNull();
   });
 
   it('should build a AddOwner setting', async () => {
-    const safe = safeBuilder().build();
     const ownerValue = faker.random.numeric();
     const thresholdValue = faker.random.numeric();
     const transaction = multisigTransactionBuilder()
-      .with('dataDecoded', {
-        method: 'addOwnerWithThreshold',
-        parameters: [{ value: ownerValue }, { value: thresholdValue }],
-      })
+      .with(
+        'dataDecoded',
+        dataDecodedBuilder()
+          .with('method', 'addOwnerWithThreshold')
+          .with('parameters', [
+            dataDecodedParameterBuilder().with('value', ownerValue).build(),
+            dataDecodedParameterBuilder().with('value', thresholdValue).build(),
+          ])
+          .build(),
+      )
       .build();
 
-    const settingChange = await mapper.mapSettingsChange(
+    const actual = await mapper.mapSettingsChange(
       faker.random.numeric(),
       transaction,
-      safe,
     );
 
-    expect(settingChange).toBeInstanceOf(AddOwner);
-    expect(settingChange).toHaveProperty('owner', new AddressInfo(ownerValue));
-    expect(settingChange).toHaveProperty('threshold', Number(thresholdValue));
+    const expected = new AddOwner(
+      new AddressInfo(ownerValue),
+      Number(thresholdValue),
+    );
+    expect(actual).toEqual(expected);
   });
 
   it('should build a RemoveOwner setting', async () => {
-    const safe = safeBuilder().build();
-    const ownerValue = faker.random.numeric();
+    const ownerValue = faker.finance.ethereumAddress();
     const thresholdValue = faker.random.numeric();
     const transaction = multisigTransactionBuilder()
-      .with('dataDecoded', {
-        method: 'removeOwner',
-        parameters: [
-          { value: faker.random.numeric() },
-          { value: ownerValue },
-          { value: thresholdValue },
-        ],
-      })
+      .with(
+        'dataDecoded',
+        dataDecodedBuilder()
+          .with('method', 'removeOwner')
+          .with('parameters', [
+            dataDecodedParameterBuilder()
+              .with('value', faker.random.numeric())
+              .build(),
+            dataDecodedParameterBuilder().with('value', ownerValue).build(),
+            dataDecodedParameterBuilder().with('value', thresholdValue).build(),
+          ])
+          .build(),
+      )
       .build();
 
-    const settingChange = await mapper.mapSettingsChange(
+    const actual = await mapper.mapSettingsChange(
       faker.random.numeric(),
       transaction,
-      safe,
     );
 
-    expect(settingChange).toBeInstanceOf(RemoveOwner);
-    expect(settingChange).toHaveProperty('owner', new AddressInfo(ownerValue));
-    expect(settingChange).toHaveProperty('threshold', Number(thresholdValue));
+    const expected = new RemoveOwner(
+      new AddressInfo(ownerValue),
+      Number(thresholdValue),
+    );
+    expect(actual).toEqual(expected);
   });
 
   it('should build a SwapOwner setting', async () => {
-    const safe = safeBuilder().build();
     const oldOwner = faker.random.numeric();
     const newOwner = faker.random.numeric();
     const transaction = multisigTransactionBuilder()
-      .with('dataDecoded', {
-        method: 'swapOwner',
-        parameters: [
-          { value: faker.random.numeric() },
-          { value: oldOwner },
-          { value: newOwner },
-        ],
-      })
+      .with(
+        'dataDecoded',
+        dataDecodedBuilder()
+          .with('method', 'swapOwner')
+          .with('parameters', [
+            dataDecodedParameterBuilder()
+              .with('value', faker.random.numeric())
+              .build(),
+            dataDecodedParameterBuilder().with('value', oldOwner).build(),
+            dataDecodedParameterBuilder().with('value', newOwner).build(),
+          ])
+          .build(),
+      )
       .build();
 
-    const settingChange = await mapper.mapSettingsChange(
+    const actual = await mapper.mapSettingsChange(
       faker.random.numeric(),
       transaction,
-      safe,
     );
 
-    expect(settingChange).toBeInstanceOf(SwapOwner);
-    expect(settingChange).toHaveProperty('oldOwner', new AddressInfo(oldOwner));
-    expect(settingChange).toHaveProperty('newOwner', new AddressInfo(newOwner));
+    const expected = new SwapOwner(
+      new AddressInfo(oldOwner),
+      new AddressInfo(newOwner),
+    );
+    expect(actual).toEqual(expected);
   });
 
   it('should build a ChangeMasterCopy setting', async () => {
-    const safe = safeBuilder().build();
-    const masterCopyAddress = new AddressInfo(faker.finance.ethereumAddress());
-    addressInfoHelper.getOrDefault.mockResolvedValueOnce(masterCopyAddress);
+    const newMasterCopy = faker.finance.ethereumAddress();
+    addressInfoHelper.getOrDefault.mockResolvedValueOnce(
+      new AddressInfo(newMasterCopy),
+    );
     const transaction = multisigTransactionBuilder()
-      .with('dataDecoded', {
-        method: 'changeMasterCopy',
-        parameters: [],
-      })
+      .with(
+        'dataDecoded',
+        dataDecodedBuilder()
+          .with('method', 'changeMasterCopy')
+          .with('parameters', [
+            dataDecodedParameterBuilder().with('value', newMasterCopy).build(),
+          ])
+          .build(),
+      )
       .build();
 
-    const settingChange = await mapper.mapSettingsChange(
+    const actual = await mapper.mapSettingsChange(
       faker.random.numeric(),
       transaction,
-      safe,
     );
 
-    expect(settingChange).toBeInstanceOf(ChangeMasterCopy);
-    expect(settingChange).toHaveProperty('implementation', masterCopyAddress);
+    const expected = new ChangeMasterCopy(new AddressInfo(newMasterCopy));
+    expect(actual).toEqual(expected);
   });
 
   it('should build a EnableModule setting', async () => {
-    const safe = safeBuilder().build();
-    const moduleAddress = new AddressInfo(faker.finance.ethereumAddress());
-    addressInfoHelper.getOrDefault.mockResolvedValueOnce(moduleAddress);
+    const moduleAddress = faker.finance.ethereumAddress();
+    addressInfoHelper.getOrDefault.mockResolvedValueOnce(
+      new AddressInfo(moduleAddress),
+    );
     const transaction = multisigTransactionBuilder()
-      .with('dataDecoded', {
-        method: 'enableModule',
-        parameters: [{ value: faker.random.numeric() }],
-      })
+      .with(
+        'dataDecoded',
+        dataDecodedBuilder()
+          .with('method', 'enableModule')
+          .with('parameters', [
+            dataDecodedParameterBuilder()
+              .with('value', faker.random.numeric())
+              .build(),
+          ])
+          .build(),
+      )
       .build();
 
-    const settingChange = await mapper.mapSettingsChange(
+    const actual = await mapper.mapSettingsChange(
       faker.random.numeric(),
       transaction,
-      safe,
     );
 
-    expect(settingChange).toBeInstanceOf(EnableModule);
-    expect(settingChange).toHaveProperty('module', moduleAddress);
+    const expected = new EnableModule(new AddressInfo(moduleAddress));
+    expect(actual).toEqual(expected);
   });
 
   it('should build a DisableModule setting', async () => {
-    const safe = safeBuilder().build();
-    const moduleAddress = new AddressInfo(faker.finance.ethereumAddress());
-    addressInfoHelper.getOrDefault.mockResolvedValueOnce(moduleAddress);
+    const moduleAddress = faker.finance.ethereumAddress();
+    addressInfoHelper.getOrDefault.mockResolvedValueOnce(
+      new AddressInfo(moduleAddress),
+    );
     const transaction = multisigTransactionBuilder()
-      .with('dataDecoded', {
-        method: 'disableModule',
-        parameters: [{ value: faker.random.numeric() }],
-      })
+      .with(
+        'dataDecoded',
+        dataDecodedBuilder()
+          .with('method', 'disableModule')
+          .with('parameters', [
+            dataDecodedParameterBuilder()
+              .with('value', faker.random.numeric())
+              .build(),
+            dataDecodedParameterBuilder().with('value', moduleAddress).build(),
+          ])
+          .build(),
+      )
       .build();
 
-    const settingChange = await mapper.mapSettingsChange(
+    const actual = await mapper.mapSettingsChange(
       faker.random.numeric(),
       transaction,
-      safe,
     );
 
-    expect(settingChange).toBeInstanceOf(DisableModule);
-    expect(settingChange).toHaveProperty('module', moduleAddress);
+    const expected = new DisableModule(new AddressInfo(moduleAddress));
+    expect(actual).toEqual(expected);
   });
 
   it('should build a ChangeThreshold setting', async () => {
-    const safe = safeBuilder().build();
     const thresholdValue = faker.random.numeric();
     const transaction = multisigTransactionBuilder()
-      .with('dataDecoded', {
-        method: 'changeThreshold',
-        parameters: [{ value: thresholdValue }],
-      })
+      .with(
+        'dataDecoded',
+        dataDecodedBuilder()
+          .with('method', 'changeThreshold')
+          .with('parameters', [
+            dataDecodedParameterBuilder().with('value', thresholdValue).build(),
+          ])
+          .build(),
+      )
       .build();
 
-    const settingChange = await mapper.mapSettingsChange(
+    const actual = await mapper.mapSettingsChange(
       faker.random.numeric(),
       transaction,
-      safe,
     );
 
-    expect(settingChange).toBeInstanceOf(ChangeThreshold);
-    expect(settingChange).toHaveProperty('threshold', thresholdValue);
+    const expected = new ChangeThreshold(Number(thresholdValue));
+    expect(actual).toEqual(expected);
   });
 
   it('should build a SetGuard setting', async () => {
-    const safe = safeBuilder().build();
-    const guardValue = faker.finance.ethereumAddress();
-    const guardAddress = new AddressInfo(guardValue);
-    addressInfoHelper.getOrDefault.mockResolvedValueOnce(guardAddress);
+    const guardAddress = faker.finance.ethereumAddress();
+    const guardAddressInfo = new AddressInfo(guardAddress);
+    addressInfoHelper.getOrDefault.mockResolvedValueOnce(guardAddressInfo);
     const transaction = multisigTransactionBuilder()
-      .with('dataDecoded', {
-        method: 'setGuard',
-        parameters: [{ value: guardValue }],
-      })
+      .with(
+        'dataDecoded',
+        dataDecodedBuilder()
+          .with('method', 'setGuard')
+          .with('parameters', [
+            dataDecodedParameterBuilder().with('value', guardAddress).build(),
+          ])
+          .build(),
+      )
       .build();
 
-    const settingChange = await mapper.mapSettingsChange(
+    const actual = await mapper.mapSettingsChange(
       faker.random.numeric(),
       transaction,
-      safe,
     );
 
-    expect(settingChange).toBeInstanceOf(SetGuard);
-    expect(settingChange).toHaveProperty('guard', guardAddress);
+    const expected = new SetGuard(new AddressInfo(guardAddress));
+    expect(actual).toEqual(expected);
   });
 
   it('should build a DeleteGuard setting', async () => {
-    const safe = safeBuilder().build();
     const guardValue = '0x0000000000000000000000000000000000000000';
     const transaction = multisigTransactionBuilder()
-      .with('dataDecoded', {
-        method: 'setGuard',
-        parameters: [{ value: guardValue }],
-      })
+      .with(
+        'dataDecoded',
+        dataDecodedBuilder()
+          .with('method', 'setGuard')
+          .with('parameters', [
+            dataDecodedParameterBuilder().with('value', guardValue).build(),
+          ])
+          .build(),
+      )
       .build();
 
-    const settingChange = await mapper.mapSettingsChange(
+    const actual = await mapper.mapSettingsChange(
       faker.random.numeric(),
       transaction,
-      safe,
     );
 
-    expect(settingChange).toBeInstanceOf(DeleteGuard);
+    expect(actual).toEqual(new DeleteGuard());
   });
 
-  it('should throw an error on a unknown setting', async () => {
-    const safe = safeBuilder().build();
+  it('should return null on a unknown setting', async () => {
     const transaction = multisigTransactionBuilder()
       .with('dataDecoded', {
         method: 'unknownMethod',
         parameters: [],
       })
+      .with(
+        'dataDecoded',
+        dataDecodedBuilder()
+          .with('method', 'unknownMethod')
+          .with('parameters', [])
+          .build(),
+      )
       .build();
 
-    await expect(
-      mapper.mapSettingsChange(faker.random.numeric(), transaction, safe),
-    ).rejects.toThrow();
+    const actual = await mapper.mapSettingsChange(
+      faker.random.numeric(),
+      transaction,
+    );
+
+    expect(actual).toBeNull();
   });
 });

--- a/src/routes/transactions/mappers/common/settings-change.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/settings-change.mapper.spec.ts
@@ -317,12 +317,8 @@ describe('Multisig Settings Change Transaction mapper (Unit)', () => {
     expect(actual).toEqual(new DeleteGuard());
   });
 
-  it('should return null on a unknown setting', async () => {
+  it('should throw an error on a unknown setting', async () => {
     const transaction = multisigTransactionBuilder()
-      .with('dataDecoded', {
-        method: 'unknownMethod',
-        parameters: [],
-      })
       .with(
         'dataDecoded',
         dataDecodedBuilder()
@@ -332,11 +328,8 @@ describe('Multisig Settings Change Transaction mapper (Unit)', () => {
       )
       .build();
 
-    const actual = await mapper.mapSettingsChange(
-      faker.random.numeric(),
-      transaction,
-    );
-
-    expect(actual).toBeNull();
+    await expect(
+      mapper.mapSettingsChange(faker.random.numeric(), transaction),
+    ).rejects.toThrow();
   });
 });

--- a/src/routes/transactions/mappers/common/settings-change.mapper.ts
+++ b/src/routes/transactions/mappers/common/settings-change.mapper.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { ModuleTransaction } from '../../../../domain/safe/entities/module-transaction.entity';
 import { MultisigTransaction } from '../../../../domain/safe/entities/multisig-transaction.entity';
-import { Safe } from '../../../../domain/safe/entities/safe.entity';
 import { AddressInfoHelper } from '../../../common/address-info/address-info.helper';
 import { NULL_ADDRESS } from '../../../common/constants';
 import { AddressInfo } from '../../../common/entities/address-info.entity';
@@ -9,7 +8,6 @@ import { AddOwner } from '../../entities/settings-changes/add-owner.entity';
 import { ChangeMasterCopy } from '../../entities/settings-changes/change-master-copy.entity';
 import { ChangeThreshold } from '../../entities/settings-changes/change-threshold.entity';
 import { DeleteGuard } from '../../entities/settings-changes/delete-guard';
-import { DisableModule } from '../../entities/settings-changes/disable-module.entity';
 import { EnableModule } from '../../entities/settings-changes/enable-module.entity';
 import { RemoveOwner } from '../../entities/settings-changes/remove-owner.entity';
 import { SetFallbackHandler } from '../../entities/settings-changes/set-fallback-handler.entity';
@@ -17,6 +15,8 @@ import { SetGuard } from '../../entities/settings-changes/set-guard.entity';
 import { SettingsChange } from '../../entities/settings-changes/settings-change.entity';
 import { SwapOwner } from '../../entities/settings-changes/swap-owner.entity';
 import { DataDecodedParamHelper } from './data-decoded-param.helper';
+import { DataDecoded } from '../../../../domain/data-decoder/entities/data-decoded.entity';
+import { DisableModule } from '../../entities/settings-changes/disable-module.entity';
 
 @Injectable()
 export class SettingsChangeMapper {
@@ -47,86 +47,183 @@ export class SettingsChangeMapper {
     private readonly dataDecodedParamHelper: DataDecodedParamHelper,
   ) {}
 
+  private async handleFallbackHandler(
+    chainId: string,
+    dataDecoded: DataDecoded,
+  ): Promise<SetFallbackHandler | null> {
+    const handler: unknown = this.dataDecodedParamHelper.getValueAtPosition(
+      dataDecoded,
+      0,
+    );
+    if (typeof handler !== 'string') return null;
+    const addressInfo = await this.addressInfoHelper.getOrDefault(
+      chainId,
+      handler,
+    );
+    return new SetFallbackHandler(addressInfo);
+  }
+
+  private handleAddOwnerWithThreshold(
+    dataDecoded: DataDecoded,
+  ): AddOwner | null {
+    const owner: unknown = this.dataDecodedParamHelper.getValueAtPosition(
+      dataDecoded,
+      0,
+    );
+    const threshold = Number(
+      this.dataDecodedParamHelper.getValueAtPosition(dataDecoded, 1),
+    );
+
+    if (typeof owner !== 'string') return null;
+    if (isNaN(threshold)) return null;
+
+    return new AddOwner(new AddressInfo(owner), threshold);
+  }
+
+  private handleRemoveOwner(dataDecoded: DataDecoded): RemoveOwner | null {
+    const owner: unknown = this.dataDecodedParamHelper.getValueAtPosition(
+      dataDecoded,
+      1,
+    );
+    const threshold = Number(
+      this.dataDecodedParamHelper.getValueAtPosition(dataDecoded, 2),
+    );
+
+    if (typeof owner !== 'string') return null;
+    if (isNaN(threshold)) return null;
+
+    return new RemoveOwner(new AddressInfo(owner), threshold);
+  }
+
+  private handleSwapOwner(dataDecoded: DataDecoded): SwapOwner | null {
+    const oldOwner: unknown = this.dataDecodedParamHelper.getValueAtPosition(
+      dataDecoded,
+      1,
+    );
+    const newOwner: unknown = this.dataDecodedParamHelper.getValueAtPosition(
+      dataDecoded,
+      2,
+    );
+
+    if (typeof oldOwner !== 'string') return null;
+    if (typeof newOwner !== 'string') return null;
+
+    return new SwapOwner(new AddressInfo(oldOwner), new AddressInfo(newOwner));
+  }
+
+  private async handleChangeMasterCopy(
+    chainId: string,
+    dataDecoded: DataDecoded,
+  ): Promise<ChangeMasterCopy | null> {
+    const implementation: unknown =
+      this.dataDecodedParamHelper.getValueAtPosition(dataDecoded, 0);
+
+    if (typeof implementation !== 'string') return null;
+
+    const implementationInfo = await this.addressInfoHelper.getOrDefault(
+      chainId,
+      implementation,
+    );
+    return new ChangeMasterCopy(implementationInfo);
+  }
+
+  private async handleEnableModule(
+    chainId: string,
+    dataDecoded: DataDecoded,
+  ): Promise<EnableModule | null> {
+    const module: unknown = this.dataDecodedParamHelper.getValueAtPosition(
+      dataDecoded,
+      0,
+    );
+
+    if (typeof module !== 'string') return null;
+
+    const moduleInfo = await this.addressInfoHelper.getOrDefault(
+      chainId,
+      module,
+    );
+    return new EnableModule(moduleInfo);
+  }
+
+  private async handleDisableModule(
+    chainId: string,
+    dataDecoded: DataDecoded,
+  ): Promise<DisableModule | null> {
+    const module: unknown = this.dataDecodedParamHelper.getValueAtPosition(
+      dataDecoded,
+      1,
+    );
+
+    if (typeof module !== 'string') return null;
+
+    const moduleInfo = await this.addressInfoHelper.getOrDefault(
+      chainId,
+      module,
+    );
+    return new DisableModule(moduleInfo);
+  }
+
+  private handleChangeThreshold(
+    dataDecoded: DataDecoded,
+  ): ChangeThreshold | null {
+    const threshold = Number(
+      this.dataDecodedParamHelper.getValueAtPosition(dataDecoded, 0),
+    );
+
+    if (isNaN(threshold)) return null;
+
+    return new ChangeThreshold(threshold);
+  }
+
+  private async handleSetGuard(
+    chainId: string,
+    dataDecoded: DataDecoded,
+  ): Promise<DeleteGuard | SetGuard | null> {
+    const guardValue: unknown = this.dataDecodedParamHelper.getValueAtPosition(
+      dataDecoded,
+      0,
+    );
+
+    if (typeof guardValue !== 'string') return null;
+
+    if (guardValue !== NULL_ADDRESS) {
+      const guardAddressInfo = await this.addressInfoHelper.getOrDefault(
+        chainId,
+        guardValue,
+      );
+      return new SetGuard(guardAddressInfo);
+    } else {
+      return new DeleteGuard();
+    }
+  }
+
   async mapSettingsChange(
     chainId: string,
     transaction: MultisigTransaction | ModuleTransaction,
-    safe: Safe,
-  ): Promise<SettingsChange> {
+  ): Promise<SettingsChange | null> {
     const { dataDecoded } = transaction;
-    switch (transaction.dataDecoded.method) {
-      case SettingsChangeMapper.SET_FALLBACK_HANDLER:
-        return new SetFallbackHandler(
-          this.dataDecodedParamHelper.getValueAtPosition(dataDecoded, 0),
-        );
-      case SettingsChangeMapper.ADD_OWNER_WITH_THRESHOLD:
-        return new AddOwner(
-          new AddressInfo(
-            this.dataDecodedParamHelper.getValueAtPosition(dataDecoded, 0),
-          ),
-          Number(
-            this.dataDecodedParamHelper.getValueAtPosition(dataDecoded, 1),
-          ),
-        );
-      case SettingsChangeMapper.REMOVE_OWNER:
-        return new RemoveOwner(
-          new AddressInfo(
-            this.dataDecodedParamHelper.getValueAtPosition(dataDecoded, 1),
-          ),
-          Number(
-            this.dataDecodedParamHelper.getValueAtPosition(dataDecoded, 2),
-          ),
-        );
 
+    switch (dataDecoded?.method) {
+      case SettingsChangeMapper.SET_FALLBACK_HANDLER:
+        return this.handleFallbackHandler(chainId, dataDecoded);
+      case SettingsChangeMapper.ADD_OWNER_WITH_THRESHOLD:
+        return this.handleAddOwnerWithThreshold(dataDecoded);
+      case SettingsChangeMapper.REMOVE_OWNER:
+        return this.handleRemoveOwner(dataDecoded);
       case SettingsChangeMapper.SWAP_OWNER:
-        return new SwapOwner(
-          new AddressInfo(
-            this.dataDecodedParamHelper.getValueAtPosition(dataDecoded, 1),
-          ),
-          new AddressInfo(
-            this.dataDecodedParamHelper.getValueAtPosition(dataDecoded, 2),
-          ),
-        );
-      case SettingsChangeMapper.CHANGE_MASTER_COPY: {
-        const masterCopy = await this.addressInfoHelper.getOrDefault(
-          chainId,
-          safe.address,
-        );
-        return new ChangeMasterCopy(masterCopy);
-      }
-      case SettingsChangeMapper.ENABLE_MODULE: {
-        const module = await this.addressInfoHelper.getOrDefault(
-          chainId,
-          this.dataDecodedParamHelper.getValueAtPosition(dataDecoded, 0),
-        );
-        return new EnableModule(module);
-      }
-      case SettingsChangeMapper.DISABLE_MODULE: {
-        const module = await this.addressInfoHelper.getOrDefault(
-          chainId,
-          this.dataDecodedParamHelper.getValueAtPosition(dataDecoded, 1),
-        );
-        return new DisableModule(module);
-      }
+        return this.handleSwapOwner(dataDecoded);
+      case SettingsChangeMapper.CHANGE_MASTER_COPY:
+        return this.handleChangeMasterCopy(chainId, dataDecoded);
+      case SettingsChangeMapper.ENABLE_MODULE:
+        return this.handleEnableModule(chainId, dataDecoded);
+      case SettingsChangeMapper.DISABLE_MODULE:
+        return this.handleDisableModule(chainId, dataDecoded);
       case SettingsChangeMapper.CHANGE_THRESHOLD:
-        return new ChangeThreshold(
-          this.dataDecodedParamHelper.getValueAtPosition(dataDecoded, 0),
-        );
-      case SettingsChangeMapper.SET_GUARD: {
-        const guardValue = this.dataDecodedParamHelper.getValueAtPosition(
-          dataDecoded,
-          0,
-        );
-        if (guardValue !== NULL_ADDRESS) {
-          const guardAddressInfo = await this.addressInfoHelper.getOrDefault(
-            chainId,
-            guardValue,
-          );
-          return new SetGuard(guardAddressInfo);
-        } else {
-          return new DeleteGuard();
-        }
-      }
+        return this.handleChangeThreshold(dataDecoded);
+      case SettingsChangeMapper.SET_GUARD:
+        return this.handleSetGuard(chainId, dataDecoded);
     }
-    throw new Error('Unknown setting');
+
+    return null;
   }
 }

--- a/src/routes/transactions/mappers/common/settings-change.mapper.ts
+++ b/src/routes/transactions/mappers/common/settings-change.mapper.ts
@@ -224,6 +224,6 @@ export class SettingsChangeMapper {
         return this.handleSetGuard(chainId, dataDecoded);
     }
 
-    return null;
+    throw new Error(`Unknown setting method: ${dataDecoded?.method}`);
   }
 }

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -151,7 +151,7 @@ export class MultisigTransactionInfoMapper {
     value: number,
     dataSize: number,
   ): boolean {
-    const isSettingsChange: boolean = transaction.dataDecoded
+    const isSettingsChangeMethod: boolean = transaction.dataDecoded
       ? SettingsChangeMapper.SETTINGS_CHANGE_METHODS.includes(
           transaction.dataDecoded.method,
         )
@@ -161,7 +161,7 @@ export class MultisigTransactionInfoMapper {
       value === 0 &&
       dataSize > 0 &&
       transaction.safe === transaction.to &&
-      isSettingsChange
+      isSettingsChangeMethod
     );
   }
 

--- a/src/routes/transactions/transactions.controller.spec.ts
+++ b/src/routes/transactions/transactions.controller.spec.ts
@@ -351,7 +351,7 @@ describe('Transactions Controller (Unit)', () => {
                     },
                     dataSize: '16',
                     value: domainTransaction.value,
-                    methodName: domainTransaction.dataDecoded.method,
+                    methodName: domainTransaction.dataDecoded?.method ?? null,
                     actionCount: 3,
                     isCancellation: false,
                   },


### PR DESCRIPTION
- `MultisigTransaction` now uses `DataDecoded` in its schema validation instead of `any`
- `SettingsChangeMapper` now uses the respective `DataDecoded` domain entities (instead of the route ones)
- `SettingsChangeMapper` now returns `null` instead of raising an error – this matches with the expected outcome of the mapper in the current Safe Client Gateway
- Fix `SettingsChangeMapper` issue where a `CHANGE_MASTER_COPY` would always return the value of the safe address as the master copy – consequentially, `safe` is no longer required as an argument for `mapSettingsChange`
- Sets the `SettingsChangeTransaction.settingsInfo` as an optional property (it can be `null`)
- Sets `CustomTransactionInfo.to` as required
- Adds support for nullable `DataDecoded` in `DataDecodedParamHelper`