### PR TITLE
Add GET /safes/{safe_address} route

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "redis": "^4.2.0",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
-    "rxjs": "^7.2.0"
+    "rxjs": "^7.2.0",
+    "semver": "^7.3.7"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.4.0",
@@ -65,6 +66,7 @@
     "@types/express": "^4.17.13",
     "@types/jest": "28.1.4",
     "@types/node": "^16.0.0",
+    "@types/semver": "^7.3.12",
     "@types/supertest": "^2.0.11",
     "@typescript-eslint/eslint-plugin": "^5.32.0",
     "@typescript-eslint/parser": "^5.32.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,6 +22,7 @@ import { HealthModule } from './routes/health/health.module';
 import { OwnersModule } from './routes/owners/owners.module';
 import { AboutModule } from './routes/about/about.module';
 import { TransactionsModule } from './routes/transactions/transactions.module';
+import { SafesModule } from './routes/safes/safes.module';
 
 @Module({
   imports: [
@@ -37,6 +38,7 @@ import { TransactionsModule } from './routes/transactions/transactions.module';
     HealthModule,
     OwnersModule,
     SafeAppsModule,
+    SafesModule,
     TransactionsModule,
     // common
     CacheModule,

--- a/src/domain/chains/entities/__tests__/chain.builder.ts
+++ b/src/domain/chains/entities/__tests__/chain.builder.ts
@@ -10,7 +10,7 @@ import { rpcUriBuilder } from './rpc-uri.builder';
 
 export function chainBuilder(): IBuilder<Chain> {
   return Builder.new<Chain>()
-    .with('chainId', faker.datatype.number.toString())
+    .with('chainId', faker.random.numeric())
     .with('chainName', faker.company.name())
     .with('description', faker.random.words())
     .with('l2', faker.datatype.boolean())
@@ -29,5 +29,6 @@ export function chainBuilder(): IBuilder<Chain> {
     ])
     .with('ensRegistryAddress', faker.finance.ethereumAddress())
     .with('disabledWallets', [faker.random.word(), faker.random.word()])
-    .with('features', [faker.random.word(), faker.random.word()]);
+    .with('features', [faker.random.word(), faker.random.word()])
+    .with('recommendedMasterCopyVersion', faker.system.semver());
 }

--- a/src/domain/chains/entities/chain.entity.ts
+++ b/src/domain/chains/entities/chain.entity.ts
@@ -23,4 +23,5 @@ export interface Chain {
   ensRegistryAddress: string | null;
   disabledWallets: string[];
   features: string[];
+  recommendedMasterCopyVersion: string;
 }

--- a/src/domain/chains/entities/schemas/chain.schema.ts
+++ b/src/domain/chains/entities/schemas/chain.schema.ts
@@ -100,6 +100,7 @@ export const chainSchema: JSONSchemaType<Chain> = {
     ensRegistryAddress: { type: 'string', nullable: true, default: null },
     disabledWallets: { type: 'array', items: { type: 'string' } },
     features: { type: 'array', items: { type: 'string' } },
+    recommendedMasterCopyVersion: { type: 'string' },
   },
   required: [
     'chainId',
@@ -118,5 +119,6 @@ export const chainSchema: JSONSchemaType<Chain> = {
     'gasPrice',
     'disabledWallets',
     'features',
+    'recommendedMasterCopyVersion',
   ],
 };

--- a/src/domain/safe/entities/__tests__/erc721-transfer.builder.ts
+++ b/src/domain/safe/entities/__tests__/erc721-transfer.builder.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import { Builder, IBuilder } from '../../../../__tests__/builder';
 import { ERC721Transfer } from '../transfer.entity';
 
-export function erc721TransferTransferBuilder(): IBuilder<ERC721Transfer> {
+export function erc721TransferBuilder(): IBuilder<ERC721Transfer> {
   return Builder.new<ERC721Transfer>()
     .with('blockNumber', faker.datatype.number())
     .with('executionDate', faker.date.recent())

--- a/src/domain/safe/entities/__tests__/ethereum-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/ethereum-transaction.builder.ts
@@ -11,3 +11,11 @@ export function ethereumTransactionBuilder(): IBuilder<EthereumTransaction> {
     .with('transfers', [])
     .with('txHash', faker.datatype.hexadecimal());
 }
+
+export function toJson(ethereumTransaction: EthereumTransaction): unknown {
+  return {
+    ...ethereumTransaction,
+    txType: 'ETHEREUM_TRANSACTION',
+    executionDate: ethereumTransaction.executionDate.toISOString(),
+  };
+}

--- a/src/domain/safe/entities/__tests__/module-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/module-transaction.builder.ts
@@ -22,6 +22,7 @@ export function moduleTransactionBuilder(): IBuilder<ModuleTransaction> {
 export function toJson(moduleTransaction: ModuleTransaction): unknown {
   return {
     ...moduleTransaction,
+    txType: 'MODULE_TRANSACTION',
     created: moduleTransaction.created.toISOString(),
     executionDate: moduleTransaction.executionDate.toISOString(),
   };

--- a/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
@@ -53,6 +53,7 @@ export function toJson(multisigTransaction: MultisigTransaction): unknown {
     confirmations: multisigTransaction.confirmations?.map((confirmation) =>
       confirmationToJson(confirmation),
     ),
+    txType: 'MULTISIG_TRANSACTION',
     executionDate: multisigTransaction.executionDate.toISOString(),
     modified: multisigTransaction.modified?.toISOString(),
     submissionDate: multisigTransaction.submissionDate?.toISOString(),

--- a/src/domain/safe/entities/transaction.entity.ts
+++ b/src/domain/safe/entities/transaction.entity.ts
@@ -6,3 +6,21 @@ export type Transaction =
   | MultisigTransaction
   | EthereumTransaction
   | ModuleTransaction;
+
+export function isMultisigTransaction(
+  transaction: Transaction,
+): transaction is MultisigTransaction {
+  return (transaction as MultisigTransaction).safeTxHash !== undefined;
+}
+
+export function isEthereumTransaction(
+  transaction: Transaction,
+): transaction is EthereumTransaction {
+  return (transaction as EthereumTransaction).from !== undefined;
+}
+
+export function isModuleTransaction(
+  transaction: Transaction,
+): transaction is ModuleTransaction {
+  return (transaction as ModuleTransaction).module !== undefined;
+}

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -47,6 +47,13 @@ export interface ISafeRepository {
     offset?: number,
   ): Promise<Page<MultisigTransaction>>;
 
+  getTransactionHistoryByExecutionDate(
+    chainId: string,
+    safeAddress: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<Page<Transaction>>;
+
   getCreationTransaction(
     chainId: string,
     safeAddress: string,

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -153,9 +153,40 @@ export class SafeRepository implements ISafeRepository {
     return this.creationTransactionValidator.validate(createTransaction);
   }
 
+  async getTransactionHistoryByExecutionDate(
+    chainId: string,
+    safeAddress: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<Page<Transaction>> {
+    return this.getAllExecutedTransactions(
+      chainId,
+      safeAddress,
+      'executionDate',
+      limit,
+      offset,
+    );
+  }
+
   async getTransactionHistory(
     chainId: string,
     safeAddress: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<Page<Transaction>> {
+    return this.getAllExecutedTransactions(
+      chainId,
+      safeAddress,
+      undefined,
+      limit,
+      offset,
+    );
+  }
+
+  private async getAllExecutedTransactions(
+    chainId: string,
+    safeAddress: string,
+    ordering?: string,
     limit?: number,
     offset?: number,
   ): Promise<Page<Transaction>> {
@@ -163,7 +194,7 @@ export class SafeRepository implements ISafeRepository {
       await this.transactionApiManager.getTransactionApi(chainId);
     const page: Page<Transaction> = await transactionService.getAllTransactions(
       safeAddress,
-      undefined,
+      ordering,
       true,
       false,
       limit,

--- a/src/routes/safes/entities/safe-info.entity.ts
+++ b/src/routes/safes/entities/safe-info.entity.ts
@@ -1,0 +1,71 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { AddressInfo } from '../../common/entities/address-info.entity';
+
+export enum MasterCopyVersionState {
+  UP_TO_DATE = 'UP_TO_DATE',
+  OUTDATED = 'OUTDATED',
+  UNKNOWN = 'UNKNOWN',
+}
+
+export class SafeState {
+  @ApiProperty()
+  readonly address: AddressInfo;
+  @ApiProperty()
+  readonly chainId: string;
+  @ApiProperty()
+  readonly nonce: number;
+  @ApiProperty()
+  readonly threshold: number;
+  @ApiProperty()
+  readonly owners: AddressInfo[];
+  @ApiProperty()
+  readonly implementation: AddressInfo;
+  @ApiPropertyOptional()
+  readonly modules: AddressInfo[] | null;
+  @ApiPropertyOptional()
+  readonly fallbackHandler: AddressInfo | null;
+  @ApiPropertyOptional()
+  readonly guard: AddressInfo | null;
+  @ApiPropertyOptional()
+  readonly version: string | null;
+  @ApiProperty({ enum: Object.values(MasterCopyVersionState) })
+  readonly implementationVersionState: MasterCopyVersionState;
+  @ApiProperty()
+  readonly collectiblesTag: string;
+  @ApiProperty()
+  readonly txQueuedTag: string;
+  @ApiProperty()
+  readonly txHistoryTag: string;
+
+  constructor(
+    address: AddressInfo,
+    chainId: string,
+    nonce: number,
+    threshold: number,
+    owners: AddressInfo[],
+    implementation: AddressInfo,
+    implementationVersionState: MasterCopyVersionState,
+    collectiblesTag: string,
+    txQueuedTag: string,
+    txHistoryTag: string,
+    modules: AddressInfo[] | null,
+    fallbackHandler: AddressInfo | null,
+    guard: AddressInfo | null,
+    version: string | null,
+  ) {
+    this.address = address;
+    this.chainId = chainId;
+    this.nonce = nonce;
+    this.threshold = threshold;
+    this.owners = owners;
+    this.implementation = implementation;
+    this.implementationVersionState = implementationVersionState;
+    this.collectiblesTag = collectiblesTag;
+    this.txQueuedTag = txQueuedTag;
+    this.txHistoryTag = txHistoryTag;
+    this.modules = modules;
+    this.fallbackHandler = fallbackHandler;
+    this.guard = guard;
+    this.version = version;
+  }
+}

--- a/src/routes/safes/safes.controller.spec.ts
+++ b/src/routes/safes/safes.controller.spec.ts
@@ -42,18 +42,15 @@ import {
 describe('Safes Controller (Unit)', () => {
   let app: INestApplication;
 
+  const safeConfigUri = faker.internet.url();
+
   beforeAll(async () => {
+    fakeConfigurationService.set('safeConfig.baseUri', safeConfigUri);
+    fakeConfigurationService.set('exchange.baseUri', faker.internet.url());
     fakeConfigurationService.set(
-      'safeConfig.baseUri',
-      'https://test.safe.config',
+      'exchange.apiKey',
+      faker.random.alphaNumeric(),
     );
-
-    fakeConfigurationService.set(
-      'exchange.baseUri',
-      'https://test.exchange.service',
-    );
-
-    fakeConfigurationService.set('exchange.apiKey', 'https://test.api.key');
   });
 
   beforeEach(async () => {
@@ -79,18 +76,21 @@ describe('Safes Controller (Unit)', () => {
   });
 
   it('safe info is correctly serialised', async () => {
+    const masterCopyVersion = faker.system.semver();
     const chain = chainBuilder()
-      .with('recommendedMasterCopyVersion', '5.0.0')
+      .with('recommendedMasterCopyVersion', masterCopyVersion)
       .build();
     const owner = faker.finance.ethereumAddress();
-    const masterCopies = [masterCopyBuilder().with('version', '5.0.0').build()];
+    const masterCopies = [
+      masterCopyBuilder().with('version', masterCopyVersion).build(),
+    ];
     const masterCopyInfo = contractBuilder()
       .with('address', masterCopies[0].address)
       .build();
     const safeInfo = safeBuilder()
       .with('owners', [owner])
       .with('masterCopy', masterCopies[0].address)
-      .with('version', '5.0.0')
+      .with('version', masterCopyVersion)
       .build();
     const fallbackHandlerInfo = contractBuilder()
       .with('address', safeInfo.fallbackHandler)
@@ -126,20 +126,29 @@ describe('Safes Controller (Unit)', () => {
         ),
       ])
       .build();
-
-    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
-    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: collectibleTransfers,
+    mockNetworkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUri}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
+          return Promise.resolve({ data: safeInfo });
+        case `${chain.transactionService}/api/v1/about/master-copies/`:
+          return Promise.resolve({ data: masterCopies });
+        case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
+          return Promise.resolve({ data: masterCopyInfo });
+        case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
+          return Promise.resolve({ data: fallbackHandlerInfo });
+        case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
+          return Promise.resolve({ data: guardInfo });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
+          return Promise.resolve({ data: collectibleTransfers });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
+          return Promise.resolve({ data: queuedTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
+          return Promise.resolve({ data: allTransactions });
+      }
+      return Promise.reject(`No matching rule for url: ${url}`);
     });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: queuedTransactions,
-    });
-    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
 
     await request(app.getHttpServer())
       .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
@@ -188,25 +197,40 @@ describe('Safes Controller (Unit)', () => {
     const chain = chainBuilder().build();
     const masterCopies = [masterCopyBuilder().build()];
     const masterCopyInfo = contractBuilder().build();
-    const safeInfo = safeBuilder().with('version', 'vI.N.V.A.L.I.D').build();
-    const fallbackHandlerInfo = contractBuilder().build();
-    const guardInfo = contractBuilder().build();
+    const safeInfo = safeBuilder()
+      .with('masterCopy', masterCopyInfo.address)
+      .with('version', 'vI.N.V.A.L.I.D')
+      .build();
+    const fallbackHandlerInfo = contractBuilder()
+      .with('address', safeInfo.fallbackHandler)
+      .build();
+    const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
     const allTransactions = pageBuilder().build();
-    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
-    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: collectibleTransfers,
+    mockNetworkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUri}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
+          return Promise.resolve({ data: safeInfo });
+        case `${chain.transactionService}/api/v1/about/master-copies/`:
+          return Promise.resolve({ data: masterCopies });
+        case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
+          return Promise.resolve({ data: masterCopyInfo });
+        case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
+          return Promise.resolve({ data: fallbackHandlerInfo });
+        case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
+          return Promise.resolve({ data: guardInfo });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
+          return Promise.resolve({ data: collectibleTransfers });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
+          return Promise.resolve({ data: queuedTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
+          return Promise.resolve({ data: allTransactions });
+      }
+      return Promise.reject(`No matching rule for url: ${url}`);
     });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: queuedTransactions,
-    });
-    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
 
     await request(app.getHttpServer())
       .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
@@ -224,25 +248,39 @@ describe('Safes Controller (Unit)', () => {
       .build();
     const masterCopies = [masterCopyBuilder().build()];
     const masterCopyInfo = contractBuilder().build();
-    const safeInfo = safeBuilder().build();
-    const fallbackHandlerInfo = contractBuilder().build();
-    const guardInfo = contractBuilder().build();
+    const safeInfo = safeBuilder()
+      .with('masterCopy', masterCopyInfo.address)
+      .build();
+    const fallbackHandlerInfo = contractBuilder()
+      .with('address', safeInfo.fallbackHandler)
+      .build();
+    const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
     const allTransactions = pageBuilder().build();
-    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
-    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: collectibleTransfers,
+    mockNetworkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUri}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
+          return Promise.resolve({ data: safeInfo });
+        case `${chain.transactionService}/api/v1/about/master-copies/`:
+          return Promise.resolve({ data: masterCopies });
+        case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
+          return Promise.resolve({ data: masterCopyInfo });
+        case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
+          return Promise.resolve({ data: fallbackHandlerInfo });
+        case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
+          return Promise.resolve({ data: guardInfo });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
+          return Promise.resolve({ data: collectibleTransfers });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
+          return Promise.resolve({ data: queuedTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
+          return Promise.resolve({ data: allTransactions });
+      }
+      return Promise.reject(`No matching rule for url: ${url}`);
     });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: queuedTransactions,
-    });
-    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
 
     await request(app.getHttpServer())
       .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
@@ -261,25 +299,39 @@ describe('Safes Controller (Unit)', () => {
       masterCopyBuilder().with('address', supportedMasterCopy).build(),
     ];
     const masterCopyInfo = contractBuilder().build();
-    const safeInfo = safeBuilder().build();
-    const fallbackHandlerInfo = contractBuilder().build();
-    const guardInfo = contractBuilder().build();
+    const safeInfo = safeBuilder()
+      .with('masterCopy', masterCopyInfo.address)
+      .build();
+    const fallbackHandlerInfo = contractBuilder()
+      .with('address', safeInfo.fallbackHandler)
+      .build();
+    const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
     const allTransactions = pageBuilder().build();
-    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
-    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: collectibleTransfers,
+    mockNetworkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUri}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
+          return Promise.resolve({ data: safeInfo });
+        case `${chain.transactionService}/api/v1/about/master-copies/`:
+          return Promise.resolve({ data: masterCopies });
+        case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
+          return Promise.resolve({ data: masterCopyInfo });
+        case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
+          return Promise.resolve({ data: fallbackHandlerInfo });
+        case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
+          return Promise.resolve({ data: guardInfo });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
+          return Promise.resolve({ data: collectibleTransfers });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
+          return Promise.resolve({ data: queuedTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
+          return Promise.resolve({ data: allTransactions });
+      }
+      return Promise.reject(`No matching rule for url: ${url}`);
     });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: queuedTransactions,
-    });
-    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
 
     await request(app.getHttpServer())
       .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
@@ -304,24 +356,36 @@ describe('Safes Controller (Unit)', () => {
       .with('masterCopy', supportedMasterCopy)
       .with('version', '4.0.0')
       .build();
-    const fallbackHandlerInfo = contractBuilder().build();
-    const guardInfo = contractBuilder().build();
+    const fallbackHandlerInfo = contractBuilder()
+      .with('address', safeInfo.fallbackHandler)
+      .build();
+    const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
     const allTransactions = pageBuilder().build();
-    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
-    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: collectibleTransfers,
+    mockNetworkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUri}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
+          return Promise.resolve({ data: safeInfo });
+        case `${chain.transactionService}/api/v1/about/master-copies/`:
+          return Promise.resolve({ data: masterCopies });
+        case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
+          return Promise.resolve({ data: masterCopyInfo });
+        case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
+          return Promise.resolve({ data: fallbackHandlerInfo });
+        case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
+          return Promise.resolve({ data: guardInfo });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
+          return Promise.resolve({ data: collectibleTransfers });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
+          return Promise.resolve({ data: queuedTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
+          return Promise.resolve({ data: allTransactions });
+      }
+      return Promise.reject(`No matching rule for url: ${url}`);
     });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: queuedTransactions,
-    });
-    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
 
     await request(app.getHttpServer())
       .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
@@ -337,9 +401,13 @@ describe('Safes Controller (Unit)', () => {
     const chain = chainBuilder().build();
     const masterCopies = [masterCopyBuilder().build()];
     const masterCopyInfo = contractBuilder().build();
-    const safeInfo = safeBuilder().build();
-    const fallbackHandlerInfo = contractBuilder().build();
-    const guardInfo = contractBuilder().build();
+    const safeInfo = safeBuilder()
+      .with('masterCopy', masterCopyInfo.address)
+      .build();
+    const fallbackHandlerInfo = contractBuilder()
+      .with('address', safeInfo.fallbackHandler)
+      .build();
+    const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
     const allTransactions = pageBuilder()
@@ -361,19 +429,29 @@ describe('Safes Controller (Unit)', () => {
         ),
       ])
       .build();
-    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
-    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: collectibleTransfers,
+    mockNetworkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUri}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
+          return Promise.resolve({ data: safeInfo });
+        case `${chain.transactionService}/api/v1/about/master-copies/`:
+          return Promise.resolve({ data: masterCopies });
+        case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
+          return Promise.resolve({ data: masterCopyInfo });
+        case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
+          return Promise.resolve({ data: fallbackHandlerInfo });
+        case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
+          return Promise.resolve({ data: guardInfo });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
+          return Promise.resolve({ data: collectibleTransfers });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
+          return Promise.resolve({ data: queuedTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
+          return Promise.resolve({ data: allTransactions });
+      }
+      return Promise.reject(`No matching rule for url: ${url}`);
     });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: queuedTransactions,
-    });
-    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
 
     await request(app.getHttpServer())
       .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
@@ -389,9 +467,13 @@ describe('Safes Controller (Unit)', () => {
     const chain = chainBuilder().build();
     const masterCopies = [masterCopyBuilder().build()];
     const masterCopyInfo = contractBuilder().build();
-    const safeInfo = safeBuilder().build();
-    const fallbackHandlerInfo = contractBuilder().build();
-    const guardInfo = contractBuilder().build();
+    const safeInfo = safeBuilder()
+      .with('masterCopy', masterCopyInfo.address)
+      .build();
+    const fallbackHandlerInfo = contractBuilder()
+      .with('address', safeInfo.fallbackHandler)
+      .build();
+    const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
     const allTransactions = pageBuilder()
@@ -416,19 +498,29 @@ describe('Safes Controller (Unit)', () => {
         ),
       ])
       .build();
-    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
-    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: collectibleTransfers,
+    mockNetworkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUri}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
+          return Promise.resolve({ data: safeInfo });
+        case `${chain.transactionService}/api/v1/about/master-copies/`:
+          return Promise.resolve({ data: masterCopies });
+        case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
+          return Promise.resolve({ data: masterCopyInfo });
+        case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
+          return Promise.resolve({ data: fallbackHandlerInfo });
+        case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
+          return Promise.resolve({ data: guardInfo });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
+          return Promise.resolve({ data: collectibleTransfers });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
+          return Promise.resolve({ data: queuedTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
+          return Promise.resolve({ data: allTransactions });
+      }
+      return Promise.reject(`No matching rule for url: ${url}`);
     });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: queuedTransactions,
-    });
-    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
 
     await request(app.getHttpServer())
       .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
@@ -444,9 +536,13 @@ describe('Safes Controller (Unit)', () => {
     const chain = chainBuilder().build();
     const masterCopies = [masterCopyBuilder().build()];
     const masterCopyInfo = contractBuilder().build();
-    const safeInfo = safeBuilder().build();
-    const fallbackHandlerInfo = contractBuilder().build();
-    const guardInfo = contractBuilder().build();
+    const safeInfo = safeBuilder()
+      .with('masterCopy', masterCopyInfo.address)
+      .build();
+    const fallbackHandlerInfo = contractBuilder()
+      .with('address', safeInfo.fallbackHandler)
+      .build();
+    const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
     const allTransactions = pageBuilder()
@@ -470,19 +566,29 @@ describe('Safes Controller (Unit)', () => {
         ),
       ])
       .build();
-    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
-    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: collectibleTransfers,
+    mockNetworkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUri}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
+          return Promise.resolve({ data: safeInfo });
+        case `${chain.transactionService}/api/v1/about/master-copies/`:
+          return Promise.resolve({ data: masterCopies });
+        case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
+          return Promise.resolve({ data: masterCopyInfo });
+        case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
+          return Promise.resolve({ data: fallbackHandlerInfo });
+        case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
+          return Promise.resolve({ data: guardInfo });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
+          return Promise.resolve({ data: collectibleTransfers });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
+          return Promise.resolve({ data: queuedTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
+          return Promise.resolve({ data: allTransactions });
+      }
+      return Promise.reject(`No matching rule for url: ${url}`);
     });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: queuedTransactions,
-    });
-    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
 
     await request(app.getHttpServer())
       .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
@@ -498,9 +604,13 @@ describe('Safes Controller (Unit)', () => {
     const chain = chainBuilder().build();
     const masterCopies = [masterCopyBuilder().build()];
     const masterCopyInfo = contractBuilder().build();
-    const safeInfo = safeBuilder().build();
-    const fallbackHandlerInfo = contractBuilder().build();
-    const guardInfo = contractBuilder().build();
+    const safeInfo = safeBuilder()
+      .with('masterCopy', masterCopyInfo.address)
+      .build();
+    const fallbackHandlerInfo = contractBuilder()
+      .with('address', safeInfo.fallbackHandler)
+      .build();
+    const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
     const allTransactions = pageBuilder()
@@ -524,19 +634,29 @@ describe('Safes Controller (Unit)', () => {
         ),
       ])
       .build();
-    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
-    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: collectibleTransfers,
+    mockNetworkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUri}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
+          return Promise.resolve({ data: safeInfo });
+        case `${chain.transactionService}/api/v1/about/master-copies/`:
+          return Promise.resolve({ data: masterCopies });
+        case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
+          return Promise.resolve({ data: masterCopyInfo });
+        case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
+          return Promise.resolve({ data: fallbackHandlerInfo });
+        case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
+          return Promise.resolve({ data: guardInfo });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
+          return Promise.resolve({ data: collectibleTransfers });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
+          return Promise.resolve({ data: queuedTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
+          return Promise.resolve({ data: allTransactions });
+      }
+      return Promise.reject(`No matching rule for url: ${url}`);
     });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: queuedTransactions,
-    });
-    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
 
     await request(app.getHttpServer())
       .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
@@ -556,32 +676,48 @@ describe('Safes Controller (Unit)', () => {
     const module2 = faker.finance.ethereumAddress();
     const module3 = faker.finance.ethereumAddress();
     const safeInfo = safeBuilder()
+      .with('masterCopy', masterCopyInfo.address)
       .with('modules', [module1, module2, module3])
       .build();
     const moduleInfo1 = contractBuilder().with('address', module1).build();
     const moduleInfo2 = contractBuilder().with('address', module2).build();
     const moduleInfo3 = contractBuilder().with('address', module3).build();
-    const fallbackHandlerInfo = contractBuilder().build();
-    const guardInfo = contractBuilder().build();
+    const fallbackHandlerInfo = contractBuilder()
+      .with('address', safeInfo.fallbackHandler)
+      .build();
+    const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
     const allTransactions = pageBuilder().build();
-    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
-    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: moduleInfo1 });
-    mockNetworkService.get.mockResolvedValueOnce({ data: moduleInfo2 });
-    mockNetworkService.get.mockResolvedValueOnce({ data: moduleInfo3 });
-    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: collectibleTransfers,
+    mockNetworkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUri}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
+          return Promise.resolve({ data: safeInfo });
+        case `${chain.transactionService}/api/v1/about/master-copies/`:
+          return Promise.resolve({ data: masterCopies });
+        case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
+          return Promise.resolve({ data: masterCopyInfo });
+        case `${chain.transactionService}/api/v1/contracts/${module1}`:
+          return Promise.resolve({ data: moduleInfo1 });
+        case `${chain.transactionService}/api/v1/contracts/${module2}`:
+          return Promise.resolve({ data: moduleInfo2 });
+        case `${chain.transactionService}/api/v1/contracts/${module3}`:
+          return Promise.resolve({ data: moduleInfo3 });
+        case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
+          return Promise.resolve({ data: fallbackHandlerInfo });
+        case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
+          return Promise.resolve({ data: guardInfo });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
+          return Promise.resolve({ data: collectibleTransfers });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
+          return Promise.resolve({ data: queuedTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
+          return Promise.resolve({ data: allTransactions });
+      }
+      return Promise.reject(`No matching rule for url: ${url}`);
     });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: queuedTransactions,
-    });
-    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
 
     await request(app.getHttpServer())
       .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
@@ -613,26 +749,40 @@ describe('Safes Controller (Unit)', () => {
     const chain = chainBuilder().build();
     const masterCopies = [masterCopyBuilder().build()];
     const masterCopyInfo = contractBuilder().build();
-    const safeInfo = safeBuilder().with('modules', []).build();
-
-    const fallbackHandlerInfo = contractBuilder().build();
-    const guardInfo = contractBuilder().build();
+    const safeInfo = safeBuilder()
+      .with('modules', [])
+      .with('masterCopy', masterCopyInfo.address)
+      .build();
+    const fallbackHandlerInfo = contractBuilder()
+      .with('address', safeInfo.fallbackHandler)
+      .build();
+    const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
     const allTransactions = pageBuilder().build();
-    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
-    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
-    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
-    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: collectibleTransfers,
+    mockNetworkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUri}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
+          return Promise.resolve({ data: safeInfo });
+        case `${chain.transactionService}/api/v1/about/master-copies/`:
+          return Promise.resolve({ data: masterCopies });
+        case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
+          return Promise.resolve({ data: masterCopyInfo });
+        case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
+          return Promise.resolve({ data: fallbackHandlerInfo });
+        case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
+          return Promise.resolve({ data: guardInfo });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
+          return Promise.resolve({ data: collectibleTransfers });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
+          return Promise.resolve({ data: queuedTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
+          return Promise.resolve({ data: allTransactions });
+      }
+      return Promise.reject(`No matching rule for url: ${url}`);
     });
-    mockNetworkService.get.mockResolvedValueOnce({
-      data: queuedTransactions,
-    });
-    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
 
     await request(app.getHttpServer())
       .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)

--- a/src/routes/safes/safes.controller.spec.ts
+++ b/src/routes/safes/safes.controller.spec.ts
@@ -1,0 +1,646 @@
+import { INestApplication } from '@nestjs/common';
+import {
+  fakeConfigurationService,
+  TestConfigurationModule,
+} from '../../config/__tests__/test.configuration.module';
+import {
+  fakeCacheService,
+  TestCacheModule,
+} from '../../datasources/cache/__tests__/test.cache.module';
+import { Test, TestingModule } from '@nestjs/testing';
+import { DomainModule } from '../../domain.module';
+import {
+  mockNetworkService,
+  TestNetworkModule,
+} from '../../datasources/network/__tests__/test.network.module';
+import { DataSourceErrorFilter } from '../common/filters/data-source-error.filter';
+import { SafesModule } from './safes.module';
+import * as request from 'supertest';
+import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
+import { safeBuilder } from '../../domain/safe/entities/__tests__/safe.builder';
+import { masterCopyBuilder } from '../../domain/chains/entities/__tests__/master-copy.builder';
+import { contractBuilder } from '../../domain/contracts/entities/__tests__/contract.builder';
+import { pageBuilder } from '../../domain/entities/__tests__/page.builder';
+import {
+  multisigTransactionBuilder,
+  toJson as multisigTransactionToJson,
+} from '../../domain/safe/entities/__tests__/multisig-transaction.builder';
+import {
+  ethereumTransactionBuilder,
+  toJson as ethereumTransactionToJson,
+} from '../../domain/safe/entities/__tests__/ethereum-transaction.builder';
+import { faker } from '@faker-js/faker';
+import {
+  erc721TransferBuilder,
+  toJson as erc721TransferToJson,
+} from '../../domain/safe/entities/__tests__/erc721-transfer.builder';
+import {
+  moduleTransactionBuilder,
+  toJson as moduleTransactionToJson,
+} from '../../domain/safe/entities/__tests__/module-transaction.builder';
+
+describe('Safes Controller (Unit)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    fakeConfigurationService.set(
+      'safeConfig.baseUri',
+      'https://test.safe.config',
+    );
+
+    fakeConfigurationService.set(
+      'exchange.baseUri',
+      'https://test.exchange.service',
+    );
+
+    fakeConfigurationService.set('exchange.apiKey', 'https://test.api.key');
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    fakeCacheService.clear();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        // feature
+        SafesModule,
+        // common
+        DomainModule,
+        TestCacheModule,
+        TestConfigurationModule,
+        TestNetworkModule,
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalFilters(new DataSourceErrorFilter());
+
+    await app.init();
+  });
+
+  it('safe info is correctly serialised', async () => {
+    const chain = chainBuilder()
+      .with('recommendedMasterCopyVersion', '5.0.0')
+      .build();
+    const owner = faker.finance.ethereumAddress();
+    const masterCopies = [masterCopyBuilder().with('version', '5.0.0').build()];
+    const masterCopyInfo = contractBuilder()
+      .with('address', masterCopies[0].address)
+      .build();
+    const safeInfo = safeBuilder()
+      .with('owners', [owner])
+      .with('masterCopy', masterCopies[0].address)
+      .with('version', '5.0.0')
+      .build();
+    const fallbackHandlerInfo = contractBuilder()
+      .with('address', safeInfo.fallbackHandler)
+      .build();
+    const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
+
+    const collectibleTransfers = pageBuilder()
+      .with('results', [
+        erc721TransferToJson(
+          erc721TransferBuilder()
+            .with('executionDate', new Date('2016-09-19T02:55:04+0000'))
+            .build(),
+        ),
+      ])
+      .build();
+
+    const queuedTransactions = pageBuilder()
+      .with('results', [
+        multisigTransactionToJson(
+          multisigTransactionBuilder()
+            .with('modified', new Date('2049-01-30T14:23:07Z'))
+            .build(),
+        ),
+      ])
+      .build();
+
+    const allTransactions = pageBuilder()
+      .with('results', [
+        ethereumTransactionToJson(
+          ethereumTransactionBuilder()
+            .with('executionDate', new Date('2073-03-12T12:29:06Z'))
+            .build(),
+        ),
+      ])
+      .build();
+
+    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
+    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: collectibleTransfers,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: queuedTransactions,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
+
+    await request(app.getHttpServer())
+      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .expect(200)
+      .expect({
+        address: {
+          value: safeInfo.address,
+          name: null,
+          logoUri: null,
+        },
+        chainId: chain.chainId,
+        nonce: safeInfo.nonce,
+        threshold: safeInfo.threshold,
+        owners: [
+          {
+            value: owner,
+            name: null,
+            logoUri: null,
+          },
+        ],
+        implementation: {
+          value: masterCopyInfo.address,
+          name: masterCopyInfo.displayName,
+          logoUri: masterCopyInfo.logoUri,
+        },
+        implementationVersionState: 'UP_TO_DATE',
+        collectiblesTag: '1474253704',
+        txQueuedTag: '2495629387',
+        txHistoryTag: '3256547346',
+        modules: null,
+        fallbackHandler: {
+          value: fallbackHandlerInfo.address,
+          name: fallbackHandlerInfo.displayName,
+          logoUri: fallbackHandlerInfo.logoUri,
+        },
+        guard: {
+          value: guardInfo.address,
+          name: guardInfo.displayName,
+          logoUri: guardInfo.logoUri,
+        },
+        version: safeInfo.version,
+      });
+  });
+
+  it('Version State is UNKNOWN when safe has an invalid safe version', async () => {
+    const chain = chainBuilder().build();
+    const masterCopies = [masterCopyBuilder().build()];
+    const masterCopyInfo = contractBuilder().build();
+    const safeInfo = safeBuilder().with('version', 'vI.N.V.A.L.I.D').build();
+    const fallbackHandlerInfo = contractBuilder().build();
+    const guardInfo = contractBuilder().build();
+    const collectibleTransfers = pageBuilder().build();
+    const queuedTransactions = pageBuilder().build();
+    const allTransactions = pageBuilder().build();
+    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
+    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: collectibleTransfers,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: queuedTransactions,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
+
+    await request(app.getHttpServer())
+      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .expect(200)
+      .expect((response) =>
+        expect(response.body).toMatchObject({
+          implementationVersionState: 'UNKNOWN',
+        }),
+      );
+  });
+
+  it('Version State is UNKNOWN when chain has an invalid recommended safe version', async () => {
+    const chain = chainBuilder()
+      .with('recommendedMasterCopyVersion', 'vI.N.V.A.L.I.D')
+      .build();
+    const masterCopies = [masterCopyBuilder().build()];
+    const masterCopyInfo = contractBuilder().build();
+    const safeInfo = safeBuilder().build();
+    const fallbackHandlerInfo = contractBuilder().build();
+    const guardInfo = contractBuilder().build();
+    const collectibleTransfers = pageBuilder().build();
+    const queuedTransactions = pageBuilder().build();
+    const allTransactions = pageBuilder().build();
+    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
+    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: collectibleTransfers,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: queuedTransactions,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
+
+    await request(app.getHttpServer())
+      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .expect(200)
+      .expect((response) =>
+        expect(response.body).toMatchObject({
+          implementationVersionState: 'UNKNOWN',
+        }),
+      );
+  });
+
+  it('Version State is UNKNOWN if master copy is not supported', async () => {
+    const chain = chainBuilder().build();
+    const supportedMasterCopy = faker.finance.ethereumAddress();
+    const masterCopies = [
+      masterCopyBuilder().with('address', supportedMasterCopy).build(),
+    ];
+    const masterCopyInfo = contractBuilder().build();
+    const safeInfo = safeBuilder().build();
+    const fallbackHandlerInfo = contractBuilder().build();
+    const guardInfo = contractBuilder().build();
+    const collectibleTransfers = pageBuilder().build();
+    const queuedTransactions = pageBuilder().build();
+    const allTransactions = pageBuilder().build();
+    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
+    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: collectibleTransfers,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: queuedTransactions,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
+
+    await request(app.getHttpServer())
+      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .expect(200)
+      .expect((response) =>
+        expect(response.body).toMatchObject({
+          implementationVersionState: 'UNKNOWN',
+        }),
+      );
+  });
+
+  it('Version State is OUTDATED if safe version is not recommended', async () => {
+    const chain = chainBuilder()
+      .with('recommendedMasterCopyVersion', '5.0.0')
+      .build();
+    const supportedMasterCopy = faker.finance.ethereumAddress();
+    const masterCopies = [
+      masterCopyBuilder().with('address', supportedMasterCopy).build(),
+    ];
+    const masterCopyInfo = contractBuilder().build();
+    const safeInfo = safeBuilder()
+      .with('masterCopy', supportedMasterCopy)
+      .with('version', '4.0.0')
+      .build();
+    const fallbackHandlerInfo = contractBuilder().build();
+    const guardInfo = contractBuilder().build();
+    const collectibleTransfers = pageBuilder().build();
+    const queuedTransactions = pageBuilder().build();
+    const allTransactions = pageBuilder().build();
+    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
+    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: collectibleTransfers,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: queuedTransactions,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
+
+    await request(app.getHttpServer())
+      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .expect(200)
+      .expect((response) =>
+        expect(response.body).toMatchObject({
+          implementationVersionState: 'OUTDATED',
+        }),
+      );
+  });
+
+  it('txHistoryTag is computed from Multisig transaction with modified date', async () => {
+    const chain = chainBuilder().build();
+    const masterCopies = [masterCopyBuilder().build()];
+    const masterCopyInfo = contractBuilder().build();
+    const safeInfo = safeBuilder().build();
+    const fallbackHandlerInfo = contractBuilder().build();
+    const guardInfo = contractBuilder().build();
+    const collectibleTransfers = pageBuilder().build();
+    const queuedTransactions = pageBuilder().build();
+    const allTransactions = pageBuilder()
+      .with('results', [
+        multisigTransactionToJson(
+          multisigTransactionBuilder()
+            .with('modified', new Date('2020-09-18T03:52:02Z'))
+            .build(),
+        ),
+        multisigTransactionToJson(
+          multisigTransactionBuilder()
+            .with('modified', new Date('2020-09-16T03:52:02Z'))
+            .build(),
+        ),
+        multisigTransactionToJson(
+          multisigTransactionBuilder()
+            .with('modified', new Date('2020-09-14T03:52:02Z'))
+            .build(),
+        ),
+      ])
+      .build();
+    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
+    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: collectibleTransfers,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: queuedTransactions,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
+
+    await request(app.getHttpServer())
+      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .expect(200)
+      .expect((response) =>
+        expect(response.body).toMatchObject({
+          txHistoryTag: '1600401122',
+        }),
+      );
+  });
+
+  it('txHistoryTag is computed from Multisig transaction without modified date', async () => {
+    const chain = chainBuilder().build();
+    const masterCopies = [masterCopyBuilder().build()];
+    const masterCopyInfo = contractBuilder().build();
+    const safeInfo = safeBuilder().build();
+    const fallbackHandlerInfo = contractBuilder().build();
+    const guardInfo = contractBuilder().build();
+    const collectibleTransfers = pageBuilder().build();
+    const queuedTransactions = pageBuilder().build();
+    const allTransactions = pageBuilder()
+      .with('results', [
+        multisigTransactionToJson(
+          multisigTransactionBuilder()
+            .with('modified', null)
+            .with('submissionDate', new Date('2020-09-17T03:52:02Z'))
+            .build(),
+        ),
+        multisigTransactionToJson(
+          multisigTransactionBuilder()
+            .with('modified', new Date('2020-09-16T03:52:02Z'))
+            .with('submissionDate', new Date('2020-09-16T03:52:02Z'))
+            .build(),
+        ),
+        multisigTransactionToJson(
+          multisigTransactionBuilder()
+            .with('modified', new Date('2020-09-14T03:52:02Z'))
+            .with('submissionDate', new Date('2020-09-14T03:52:02Z'))
+            .build(),
+        ),
+      ])
+      .build();
+    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
+    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: collectibleTransfers,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: queuedTransactions,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
+
+    await request(app.getHttpServer())
+      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .expect(200)
+      .expect((response) =>
+        expect(response.body).toMatchObject({
+          txHistoryTag: '1600314722',
+        }),
+      );
+  });
+
+  it('txHistoryTag is computed from Ethereum transaction', async () => {
+    const chain = chainBuilder().build();
+    const masterCopies = [masterCopyBuilder().build()];
+    const masterCopyInfo = contractBuilder().build();
+    const safeInfo = safeBuilder().build();
+    const fallbackHandlerInfo = contractBuilder().build();
+    const guardInfo = contractBuilder().build();
+    const collectibleTransfers = pageBuilder().build();
+    const queuedTransactions = pageBuilder().build();
+    const allTransactions = pageBuilder()
+      .with('results', [
+        ethereumTransactionToJson(
+          ethereumTransactionBuilder()
+            .with('executionDate', new Date('2020-09-17T03:52:02Z'))
+            .build(),
+        ),
+        multisigTransactionToJson(
+          multisigTransactionBuilder()
+            .with('modified', new Date('2020-09-16T03:52:02Z'))
+            .with('submissionDate', new Date('2020-09-16T03:52:02Z'))
+            .build(),
+        ),
+        multisigTransactionToJson(
+          multisigTransactionBuilder()
+            .with('modified', new Date('2020-09-14T03:52:02Z'))
+            .with('submissionDate', new Date('2020-09-14T03:52:02Z'))
+            .build(),
+        ),
+      ])
+      .build();
+    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
+    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: collectibleTransfers,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: queuedTransactions,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
+
+    await request(app.getHttpServer())
+      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .expect(200)
+      .expect((response) =>
+        expect(response.body).toMatchObject({
+          txHistoryTag: '1600314722',
+        }),
+      );
+  });
+
+  it('txHistoryTag is computed from Module transaction', async () => {
+    const chain = chainBuilder().build();
+    const masterCopies = [masterCopyBuilder().build()];
+    const masterCopyInfo = contractBuilder().build();
+    const safeInfo = safeBuilder().build();
+    const fallbackHandlerInfo = contractBuilder().build();
+    const guardInfo = contractBuilder().build();
+    const collectibleTransfers = pageBuilder().build();
+    const queuedTransactions = pageBuilder().build();
+    const allTransactions = pageBuilder()
+      .with('results', [
+        moduleTransactionToJson(
+          moduleTransactionBuilder()
+            .with('executionDate', new Date('2020-09-17T03:52:02Z'))
+            .build(),
+        ),
+        multisigTransactionToJson(
+          multisigTransactionBuilder()
+            .with('modified', new Date('2020-09-16T03:52:02Z'))
+            .with('submissionDate', new Date('2020-09-16T03:52:02Z'))
+            .build(),
+        ),
+        multisigTransactionToJson(
+          multisigTransactionBuilder()
+            .with('modified', new Date('2020-09-14T03:52:02Z'))
+            .with('submissionDate', new Date('2020-09-14T03:52:02Z'))
+            .build(),
+        ),
+      ])
+      .build();
+    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
+    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: collectibleTransfers,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: queuedTransactions,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
+
+    await request(app.getHttpServer())
+      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .expect(200)
+      .expect((response) =>
+        expect(response.body).toMatchObject({
+          txHistoryTag: '1600314722',
+        }),
+      );
+  });
+
+  it('modules are computed with the respective address info', async () => {
+    const chain = chainBuilder().build();
+    const masterCopies = [masterCopyBuilder().build()];
+    const masterCopyInfo = contractBuilder().build();
+    const module1 = faker.finance.ethereumAddress();
+    const module2 = faker.finance.ethereumAddress();
+    const module3 = faker.finance.ethereumAddress();
+    const safeInfo = safeBuilder()
+      .with('modules', [module1, module2, module3])
+      .build();
+    const moduleInfo1 = contractBuilder().with('address', module1).build();
+    const moduleInfo2 = contractBuilder().with('address', module2).build();
+    const moduleInfo3 = contractBuilder().with('address', module3).build();
+    const fallbackHandlerInfo = contractBuilder().build();
+    const guardInfo = contractBuilder().build();
+    const collectibleTransfers = pageBuilder().build();
+    const queuedTransactions = pageBuilder().build();
+    const allTransactions = pageBuilder().build();
+    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
+    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: moduleInfo1 });
+    mockNetworkService.get.mockResolvedValueOnce({ data: moduleInfo2 });
+    mockNetworkService.get.mockResolvedValueOnce({ data: moduleInfo3 });
+    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: collectibleTransfers,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: queuedTransactions,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
+
+    await request(app.getHttpServer())
+      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .expect(200)
+      .expect((response) =>
+        expect(response.body).toMatchObject({
+          modules: [
+            {
+              logoUri: moduleInfo1.logoUri,
+              name: moduleInfo1.displayName,
+              value: moduleInfo1.address,
+            },
+            {
+              logoUri: moduleInfo2.logoUri,
+              name: moduleInfo2.displayName,
+              value: moduleInfo2.address,
+            },
+            {
+              logoUri: moduleInfo3.logoUri,
+              name: moduleInfo3.displayName,
+              value: moduleInfo3.address,
+            },
+          ],
+        }),
+      );
+  });
+
+  it('modules are null when module collection is empty', async () => {
+    const chain = chainBuilder().build();
+    const masterCopies = [masterCopyBuilder().build()];
+    const masterCopyInfo = contractBuilder().build();
+    const safeInfo = safeBuilder().with('modules', []).build();
+
+    const fallbackHandlerInfo = contractBuilder().build();
+    const guardInfo = contractBuilder().build();
+    const collectibleTransfers = pageBuilder().build();
+    const queuedTransactions = pageBuilder().build();
+    const allTransactions = pageBuilder().build();
+    mockNetworkService.get.mockResolvedValueOnce({ data: chain });
+    mockNetworkService.get.mockResolvedValueOnce({ data: safeInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopies });
+    mockNetworkService.get.mockResolvedValueOnce({ data: masterCopyInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: fallbackHandlerInfo });
+    mockNetworkService.get.mockResolvedValueOnce({ data: guardInfo });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: collectibleTransfers,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({
+      data: queuedTransactions,
+    });
+    mockNetworkService.get.mockResolvedValueOnce({ data: allTransactions });
+
+    await request(app.getHttpServer())
+      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .expect(200)
+      .expect((response) =>
+        expect(response.body).toMatchObject({
+          modules: null,
+        }),
+      );
+  });
+});

--- a/src/routes/safes/safes.controller.ts
+++ b/src/routes/safes/safes.controller.ts
@@ -1,0 +1,20 @@
+import { ApiTags } from '@nestjs/swagger';
+import { Controller, Get, Param } from '@nestjs/common';
+import { SafesService } from './safes.service';
+import { SafeState } from './entities/safe-info.entity';
+
+@ApiTags('safes')
+@Controller({
+  version: '1',
+})
+export class SafesController {
+  constructor(private readonly service: SafesService) {}
+
+  @Get('chains/:chainId/safes/:safeAddress')
+  async getSafe(
+    @Param('chainId') chainId: string,
+    @Param('safeAddress') safeAddress: string,
+  ): Promise<SafeState> {
+    return this.service.getSafeInfo(chainId, safeAddress);
+  }
+}

--- a/src/routes/safes/safes.module.ts
+++ b/src/routes/safes/safes.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { SafesController } from './safes.controller';
+import { SafesService } from './safes.service';
+import { AddressInfoModule } from '../common/address-info/address-info.module';
+
+@Module({
+  controllers: [SafesController],
+  providers: [SafesService],
+  imports: [AddressInfoModule],
+})
+export class SafesModule {}

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -5,7 +5,6 @@ import { IChainsRepository } from '../../domain/chains/chains.repository.interfa
 import * as semver from 'semver';
 import { MasterCopy } from '../../domain/chains/entities/master-copies.entity';
 import { Safe } from '../../domain/safe/entities/safe.entity';
-import { IContractsRepository } from '../../domain/contracts/contracts.repository.interface';
 import { AddressInfoHelper } from '../common/address-info/address-info.helper';
 import {
   isEthereumTransaction,
@@ -21,8 +20,6 @@ export class SafesService {
     private readonly safeRepository: ISafeRepository,
     @Inject(IChainsRepository)
     private readonly chainsRepository: IChainsRepository,
-    @Inject(IContractsRepository)
-    private readonly contractsRepository: IContractsRepository,
     private readonly addressInfoHelper: AddressInfoHelper,
   ) {}
 
@@ -48,16 +45,10 @@ export class SafesService {
 
     let moduleAddressesInfo: AddressInfo[] | null = null;
     if (safe.modules) {
-      moduleAddressesInfo = await this.addressInfoHelper
-        .getCollection(chainId, safe.modules)
-        .then((modules) => {
-          // If modules are empty, return null instead (api spec)
-          if (modules.length == 0) {
-            return null;
-          } else {
-            return modules;
-          }
-        });
+      const moduleInfoCollection: Array<AddressInfo> =
+        await this.addressInfoHelper.getCollection(chainId, safe.modules);
+      moduleAddressesInfo =
+        moduleInfoCollection.length == 0 ? null : moduleInfoCollection;
     }
 
     const fallbackHandlerInfo: AddressInfo | null =

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -1,0 +1,186 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ISafeRepository } from '../../domain/safe/safe.repository.interface';
+import { MasterCopyVersionState, SafeState } from './entities/safe-info.entity';
+import { IChainsRepository } from '../../domain/chains/chains.repository.interface';
+import * as semver from 'semver';
+import { MasterCopy } from '../../domain/chains/entities/master-copies.entity';
+import { Safe } from '../../domain/safe/entities/safe.entity';
+import { IContractsRepository } from '../../domain/contracts/contracts.repository.interface';
+import { AddressInfoHelper } from '../common/address-info/address-info.helper';
+import {
+  isEthereumTransaction,
+  isModuleTransaction,
+  isMultisigTransaction,
+} from '../../domain/safe/entities/transaction.entity';
+import { AddressInfo } from '../common/entities/address-info.entity';
+
+@Injectable()
+export class SafesService {
+  constructor(
+    @Inject(ISafeRepository)
+    private readonly safeRepository: ISafeRepository,
+    @Inject(IChainsRepository)
+    private readonly chainsRepository: IChainsRepository,
+    @Inject(IContractsRepository)
+    private readonly contractsRepository: IContractsRepository,
+    private readonly addressInfoHelper: AddressInfoHelper,
+  ) {}
+
+  async getSafeInfo(chainId: string, safeAddress: string): Promise<SafeState> {
+    const safe = await this.safeRepository.getSafe(chainId, safeAddress);
+
+    const recommendedMasterCopyVersion = (
+      await this.chainsRepository.getChain(chainId)
+    ).recommendedMasterCopyVersion;
+
+    const supportedMasterCopies = await this.chainsRepository.getMasterCopies(
+      chainId,
+    );
+
+    const versionState = this.computeVersionState(
+      safe,
+      recommendedMasterCopyVersion,
+      supportedMasterCopies,
+    );
+
+    const masterCopyInfo: AddressInfo =
+      await this.addressInfoHelper.getOrDefault(chainId, safe.masterCopy);
+
+    let moduleAddressesInfo: AddressInfo[] | null = null;
+    if (safe.modules) {
+      moduleAddressesInfo = await this.addressInfoHelper
+        .getCollection(chainId, safe.modules)
+        .then((modules) => {
+          // If modules are empty, return null instead (api spec)
+          if (modules.length == 0) {
+            return null;
+          } else {
+            return modules;
+          }
+        });
+    }
+
+    const fallbackHandlerInfo: AddressInfo | null =
+      await this.addressInfoHelper.get(chainId, safe.fallbackHandler);
+
+    const guardInfo: AddressInfo | null = await this.addressInfoHelper.get(
+      chainId,
+      safe.guard,
+    );
+
+    const collectiblesTag = await this.getCollectiblesTag(chainId, safeAddress);
+    const queuedTransactionTag = await this.getQueuedTransactionTag(
+      chainId,
+      safeAddress,
+    );
+    const transactionHistoryTag = await this.executedTransactionTag(
+      chainId,
+      safeAddress,
+    );
+
+    return new SafeState(
+      new AddressInfo(safe.address),
+      chainId,
+      safe.nonce,
+      safe.threshold,
+      safe.owners.map((ownerAddress) => new AddressInfo(ownerAddress)),
+      masterCopyInfo,
+      versionState,
+      this.toUnixTimestampInSecondsOrNow(collectiblesTag).toString(),
+      this.toUnixTimestampInSecondsOrNow(queuedTransactionTag).toString(),
+      this.toUnixTimestampInSecondsOrNow(transactionHistoryTag).toString(),
+      moduleAddressesInfo,
+      fallbackHandlerInfo,
+      guardInfo,
+      safe.version,
+    );
+  }
+
+  private toUnixTimestampInSecondsOrNow(date: Date | null): number {
+    const dateValue = date ? date.valueOf() : Date.now();
+    return Math.floor(dateValue / 1000);
+  }
+
+  private async getCollectiblesTag(
+    chainId: string,
+    safeAddress: string,
+  ): Promise<Date | null> {
+    const lastCollectibleTransfer =
+      await this.safeRepository.getCollectibleTransfers(
+        chainId,
+        safeAddress,
+        1,
+        0,
+      );
+
+    return lastCollectibleTransfer.results[0]?.executionDate ?? null;
+  }
+
+  private async getQueuedTransactionTag(
+    chainId: string,
+    safeAddress: string,
+  ): Promise<Date | null> {
+    const lastQueuedTransaction = await this.safeRepository.getTransactionQueue(
+      chainId,
+      safeAddress,
+      1,
+    );
+
+    return lastQueuedTransaction.results[0]?.modified ?? null;
+  }
+
+  private async executedTransactionTag(
+    chainId: string,
+    safeAddress: string,
+  ): Promise<Date | null> {
+    const lastExecutedTransaction = (
+      await this.safeRepository.getTransactionHistoryByExecutionDate(
+        chainId,
+        safeAddress,
+      )
+    ).results[0];
+
+    if (!lastExecutedTransaction) return null;
+
+    if (isMultisigTransaction(lastExecutedTransaction)) {
+      return (
+        lastExecutedTransaction.modified ??
+        lastExecutedTransaction.submissionDate
+      );
+    } else if (isEthereumTransaction(lastExecutedTransaction)) {
+      return lastExecutedTransaction.executionDate;
+    } else if (isModuleTransaction(lastExecutedTransaction)) {
+      return lastExecutedTransaction.executionDate;
+    } else {
+      // This should never happen as AJV would not allow an unknown transaction to get to this stage
+      throw Error('Unrecognized transaction type');
+    }
+  }
+
+  private computeVersionState(
+    safe: Safe,
+    recommendedSafeVersion: string,
+    supportedMasterCopies: MasterCopy[],
+  ): MasterCopyVersionState {
+    // If the safe version or the recommended safe version is not valid we return UNKNOWN
+    if (!semver.valid(safe.version)) return MasterCopyVersionState.UNKNOWN;
+    if (!semver.valid(recommendedSafeVersion))
+      return MasterCopyVersionState.UNKNOWN;
+    // If the master copy of this safe is not part of the collection
+    // of the supported master copies we return UNKNOWN
+    if (
+      !supportedMasterCopies
+        .map((masterCopy) => masterCopy.address)
+        .includes(safe.masterCopy)
+    )
+      return MasterCopyVersionState.UNKNOWN;
+
+    // If the safe version is lower than the recommended safe version
+    // we return it as outdated
+    if (semver.lt(safe.version, recommendedSafeVersion))
+      return MasterCopyVersionState.OUTDATED;
+
+    // Else we consider that the safe is up-to-date
+    return MasterCopyVersionState.UP_TO_DATE;
+  }
+}

--- a/src/routes/transactions/mappers/transfers/transfer-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-info.mapper.spec.ts
@@ -11,7 +11,7 @@ import { Erc721Transfer } from '../../entities/transfers/erc721-transfer.entity'
 import { NativeCoinTransfer } from '../../entities/transfers/native-coin-transfer.entity';
 import { TransferInfoMapper } from './transfer-info.mapper';
 import { erc20TransferBuilder } from '../../../../domain/safe/entities/__tests__/erc20-transfer.builder';
-import { erc721TransferTransferBuilder } from '../../../../domain/safe/entities/__tests__/erc721-transfer.builder';
+import { erc721TransferBuilder } from '../../../../domain/safe/entities/__tests__/erc721-transfer.builder';
 import { nativeTokenTransferBuilder } from '../../../../domain/safe/entities/__tests__/native-token-transfer.builder';
 import { safeBuilder } from '../../../../domain/safe/entities/__tests__/safe.builder';
 import { tokenBuilder } from '../../../../domain/tokens/__tests__/token.builder';
@@ -64,7 +64,7 @@ describe('Transfer Info mapper (Unit)', () => {
 
   it('should build an ERC721 TransferTransactionInfo', async () => {
     const chainId = faker.random.numeric();
-    const transfer = erc721TransferTransferBuilder().build();
+    const transfer = erc721TransferBuilder().build();
     const safe = safeBuilder().build();
     const addressInfo = new AddressInfo(faker.finance.ethereumAddress());
     const token = tokenBuilder().build();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,6 +1454,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/semver@npm:^7.3.12":
+  version: 7.3.12
+  resolution: "@types/semver@npm:7.3.12"
+  checksum: 35536b2fc5602904f21cae681f6c9498e177dab3f54ae37c92f9a1b7e43c35f18bcd81e1c98c1cf0d33ee046bb06c771e9928c1c00a401d56a03f56549252a15
+  languageName: node
+  linkType: hard
+
 "@types/serve-static@npm:*":
   version: 1.15.0
   resolution: "@types/serve-static@npm:1.15.0"
@@ -5920,6 +5927,7 @@ __metadata:
     "@types/express": ^4.17.13
     "@types/jest": 28.1.4
     "@types/node": ^16.0.0
+    "@types/semver": ^7.3.12
     "@types/supertest": ^2.0.11
     "@typescript-eslint/eslint-plugin": ^5.32.0
     "@typescript-eslint/parser": ^5.32.0
@@ -5934,6 +5942,7 @@ __metadata:
     reflect-metadata: ^0.1.13
     rimraf: ^3.0.2
     rxjs: ^7.2.0
+    semver: ^7.3.7
     source-map-support: ^0.5.20
     supertest: ^6.1.3
     ts-jest: 28.0.5


### PR DESCRIPTION
Closes https://github.com/5afe/safe-client-gateway-nest/issues/115

- Add `GET /chains/{chainId}/safes/{safeAddress}`
- Adds `recommendedMasterCopyVersion` to `Chain` (required parameter)
- Adds type predicates for `MultisigTransaction`, `EthereumTransaction` and `ModuleTransaction`
- Adds `semver` package as a dependency – this is used to validate semantic versions (which is required to compute the version state of a Safe) – https://www.npmjs.com/package/semver
- `getTransactionHistory` was split into two:
  * `getTransactionHistoryByExecutionDate` – gets all executed transactions sorted by `executionDate`
  * `getTransactionHistory` – gets all executed transactions (no sorting set)