### PR TITLE
Fix AddressInfoHelper.getCollection return type

### DIFF
--- a/src/routes/common/address-info/address-info.helper.ts
+++ b/src/routes/common/address-info/address-info.helper.ts
@@ -62,7 +62,7 @@ export class AddressInfoHelper {
   getCollection(
     chainId: string,
     addresses: string[],
-  ): Promise<Array<AddressInfo | null>> {
+  ): Promise<Array<AddressInfo>> {
     return Promise.allSettled(
       addresses.map((address) => this.getOrDefault(chainId, address)),
     ).then((results) =>


### PR DESCRIPTION
- `AddressInfoHelper.getCollection` should either return an array of `AddressInfo` (promise fulfilled) or throw an error (promise rejected) i.e. `null` should not be in the resulting array