### PR TITLE
Add pagination builder functions

### DIFF
--- a/src/routes/common/pagination/pagination.data.ts
+++ b/src/routes/common/pagination/pagination.data.ts
@@ -3,7 +3,7 @@ const QUERY_PARAM_LIMIT = 'limit';
 const QUERY_PARAM_OFFSET = 'offset';
 
 export class PaginationData {
-  private constructor(readonly limit?: number, readonly offset?: number) {}
+  constructor(readonly limit?: number, readonly offset?: number) {}
 
   /**
    * Extracts {@link PaginationData} from {@link url}. The url
@@ -46,6 +46,46 @@ export class PaginationData {
       isNaN(offset) ? undefined : offset,
     );
   }
+}
+
+/**
+ * Returns a URL with a cursor containing the next page to be retrieved.
+ * If no cursor is passed in {@link base} or it is invalid, a null reference will be returned.
+ * If there are no items remaining, a null reference will be returned.
+ *
+ * @param base - The base url which should serve as reference
+ * @param itemsCount - Total items count, useful to detect if a next page exists.
+ */
+export function buildNextPageURL(
+  base: Readonly<URL | string>,
+  itemsCount: number,
+): Readonly<URL> | null {
+  const baseUrl = new URL(base);
+  const { limit, offset } = PaginationData.fromCursor(baseUrl);
+  const hasNext = limit && offset && limit + offset < itemsCount;
+  return hasNext
+    ? setCursor(baseUrl, new PaginationData(limit, limit + offset))
+    : null;
+}
+
+/**
+ * Returns a URL with a cursor containing the previous page to be retrieved.
+ * If no cursor is passed in {@link base} or it is invalid, a null reference will be returned.
+ * If no previous items are found, a null reference will be returned.
+ *
+ * @param base - The base url which should serve as reference
+ */
+export function buildPreviousPageURL(
+  base: Readonly<URL | string>,
+): Readonly<URL> | null {
+  const baseUrl = new URL(base);
+  const { limit, offset } = PaginationData.fromCursor(baseUrl);
+  return limit && offset
+    ? setCursor(
+        baseUrl,
+        new PaginationData(limit, limit <= offset ? offset - limit : 0),
+      )
+    : null;
 }
 
 /**


### PR DESCRIPTION
This PR adds a pair of URL builder functions to calculate `next` and `previous` URL values given a paginated client request.

This is needed for both #242 and #215 since in these cases, relying on Transaction Service `next` and `previous` values is not possible, because pagination is being modified in the request sent to Transaction Service. More context is present [in this discussion](https://github.com/5afe/safe-client-gateway-nest/pull/215#discussion_r1085543681).

In this PR:
- `buildNextPageURL` and `buildPreviousPageURL` functions are added to the service codebase.
-  Unit tests are added to `PaginationData` covering these new functions.