### PR TITLE
Add default values to PaginationData

### DIFF
--- a/src/routes/chains/chains.controller.spec.ts
+++ b/src/routes/chains/chains.controller.spec.ts
@@ -24,6 +24,7 @@ import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.build
 import { masterCopyBuilder } from '../../domain/chains/entities/__tests__/master-copy.builder';
 import { Page } from '../../domain/entities/page.entity';
 import { DataSourceErrorFilter } from '../common/filters/data-source-error.filter';
+import { PaginationData } from '../common/pagination/pagination.data';
 import { ChainsModule } from './chains.module';
 import { MasterCopy } from './entities/master-copy.entity';
 
@@ -132,7 +133,12 @@ describe('Chains Controller (Unit)', () => {
       expect(mockNetworkService.get).toBeCalledTimes(1);
       expect(mockNetworkService.get).toBeCalledWith(
         'https://test.safe.config/api/v1/chains',
-        { params: { limit: undefined, offset: undefined } },
+        {
+          params: {
+            limit: PaginationData.DEFAULT_LIMIT,
+            offset: PaginationData.DEFAULT_OFFSET,
+          },
+        },
       );
     });
 
@@ -149,7 +155,12 @@ describe('Chains Controller (Unit)', () => {
       expect(mockNetworkService.get).toBeCalledTimes(1);
       expect(mockNetworkService.get).toBeCalledWith(
         'https://test.safe.config/api/v1/chains',
-        { params: { limit: undefined, offset: undefined } },
+        {
+          params: {
+            limit: PaginationData.DEFAULT_LIMIT,
+            offset: PaginationData.DEFAULT_OFFSET,
+          },
+        },
       );
     });
 
@@ -170,7 +181,12 @@ describe('Chains Controller (Unit)', () => {
       expect(mockNetworkService.get).toBeCalledTimes(1);
       expect(mockNetworkService.get).toBeCalledWith(
         'https://test.safe.config/api/v1/chains',
-        { params: { limit: undefined, offset: undefined } },
+        {
+          params: {
+            limit: PaginationData.DEFAULT_LIMIT,
+            offset: PaginationData.DEFAULT_OFFSET,
+          },
+        },
       );
     });
   });

--- a/src/routes/collectibles/collectibles.controller.spec.ts
+++ b/src/routes/collectibles/collectibles.controller.spec.ts
@@ -28,6 +28,7 @@ import {
   limitAndOffsetUrlFactory,
   pageBuilder,
 } from '../../domain/entities/__tests__/page.builder';
+import { PaginationData } from '../common/pagination/pagination.data';
 
 describe('Collectibles Controller (Unit)', () => {
   let app: INestApplication;
@@ -188,8 +189,8 @@ describe('Collectibles Controller (Unit)', () => {
 
       expect(mockNetworkService.get.mock.calls[1][1]).toStrictEqual({
         params: {
-          limit: undefined,
-          offset: undefined,
+          limit: PaginationData.DEFAULT_LIMIT,
+          offset: PaginationData.DEFAULT_OFFSET,
           exclude_spam: excludeSpam.toString(),
           trusted: trusted.toString(),
         },

--- a/src/routes/common/decorators/pagination.data.decorator.spec.ts
+++ b/src/routes/common/decorators/pagination.data.decorator.spec.ts
@@ -39,8 +39,8 @@ describe('PaginationDataDecorator', () => {
       .query('some_param=test')
       .expect(200);
 
-    expect(paginationData.limit).toBe(undefined);
-    expect(paginationData.offset).toBe(undefined);
+    expect(paginationData.limit).toBe(PaginationData.DEFAULT_LIMIT);
+    expect(paginationData.offset).toBe(PaginationData.DEFAULT_OFFSET);
   });
 
   it('with cursor', async () => {

--- a/src/routes/common/pagination/pagination.data.ts
+++ b/src/routes/common/pagination/pagination.data.ts
@@ -8,7 +8,7 @@ export class PaginationData {
    * These values are intended to apply if no pagination data is present in the client request.
    * They limit the amount of items retrieved from provider services, and abstracts the clients
    * from pagination data management.
-   * 
+   *
    * Relying on pagination values returned by provider services is not feasible, since the
    * provider pagination data could have been customized depending on the use case.
    */

--- a/src/routes/common/pagination/pagination.data.ts
+++ b/src/routes/common/pagination/pagination.data.ts
@@ -3,6 +3,15 @@ const QUERY_PARAM_LIMIT = 'limit';
 const QUERY_PARAM_OFFSET = 'offset';
 
 export class PaginationData {
+  /**
+   * Default pagination (limit and offset) values.
+   * These values are intended to apply if no pagination data is present in the client request.
+   * They limit the amount of items retrieved from provider services, and abstracts the clients
+   * from pagination data management.
+   * 
+   * Relying on pagination values returned by provider services is not feasible, since the
+   * provider pagination data could have been customized depending on the use case.
+   */
   public static readonly DEFAULT_LIMIT = 20;
   public static readonly DEFAULT_OFFSET = 0;
 

--- a/src/routes/transactions/__tests__/get-incoming-transfers.e2e-spec.ts
+++ b/src/routes/transactions/__tests__/get-incoming-transfers.e2e-spec.ts
@@ -5,6 +5,7 @@ import { RedisClientType } from 'redis';
 import * as request from 'supertest';
 import { AppModule } from '../../../app.module';
 import { redisClientFactory } from '../../../__tests__/redis-client.factory';
+import { PaginationData } from '../../common/pagination/pagination.data';
 
 describe('Get incoming transfers e2e test', () => {
   let app: INestApplication;
@@ -30,7 +31,7 @@ describe('Get incoming transfers e2e test', () => {
     const executionDateGte = '2022-10-20T00:00:00.000Z';
     const executionDateLte = '2022-11-03T00:00:00.000Z';
     const cacheKey = `${chainId}_${safeAddress}_incoming_transfers`;
-    const cacheKeyField = `${executionDateGte}_${executionDateLte}_undefined_undefined_undefined_undefined_undefined`;
+    const cacheKeyField = `${executionDateGte}_${executionDateLte}_undefined_undefined_undefined_${PaginationData.DEFAULT_LIMIT}_${PaginationData.DEFAULT_OFFSET}`;
     const expected = getJsonResource('e2e/erc20-expected-response.json');
 
     await request(app.getHttpServer())
@@ -51,7 +52,7 @@ describe('Get incoming transfers e2e test', () => {
     const executionDateGte = '2022-08-01T00:00:00.000Z';
     const executionDateLte = '2022-08-04T12:50:00.000Z';
     const cacheKey = `${chainId}_${safeAddress}_incoming_transfers`;
-    const cacheKeyField = `${executionDateGte}_${executionDateLte}_undefined_undefined_undefined_undefined_undefined`;
+    const cacheKeyField = `${executionDateGte}_${executionDateLte}_undefined_undefined_undefined_${PaginationData.DEFAULT_LIMIT}_${PaginationData.DEFAULT_OFFSET}`;
     const expected = getJsonResource('e2e/erc721-expected-response.json');
 
     await request(app.getHttpServer())

--- a/src/routes/transactions/__tests__/get-module-transactions.e2e-spec.ts
+++ b/src/routes/transactions/__tests__/get-module-transactions.e2e-spec.ts
@@ -5,6 +5,7 @@ import { RedisClientType } from 'redis';
 import * as request from 'supertest';
 import { AppModule } from '../../../app.module';
 import { redisClientFactory } from '../../../__tests__/redis-client.factory';
+import { PaginationData } from '../../common/pagination/pagination.data';
 
 describe('Get module transactions e2e test', () => {
   let app: INestApplication;
@@ -28,7 +29,7 @@ describe('Get module transactions e2e test', () => {
   it('GET /safes/<address>/module-transactions (native token)', async () => {
     const safeAddress = '0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C';
     const cacheKey = `${chainId}_${safeAddress}_module_transactions`;
-    const cacheKeyField = `undefined_undefined_undefined_undefined`;
+    const cacheKeyField = `undefined_undefined_${PaginationData.DEFAULT_LIMIT}_${PaginationData.DEFAULT_OFFSET}`;
     const expectedResponse = getJsonResource(
       'e2e/module-transactions/native-token-expected-response.json',
     );

--- a/src/routes/transactions/__tests__/get-multisig-transactions.e2e-spec.ts
+++ b/src/routes/transactions/__tests__/get-multisig-transactions.e2e-spec.ts
@@ -5,6 +5,7 @@ import { RedisClientType } from 'redis';
 import * as request from 'supertest';
 import { AppModule } from '../../../app.module';
 import { redisClientFactory } from '../../../__tests__/redis-client.factory';
+import { PaginationData } from '../../common/pagination/pagination.data';
 
 describe('Get multisig transactions e2e test', () => {
   let app: INestApplication;
@@ -30,7 +31,7 @@ describe('Get multisig transactions e2e test', () => {
     const executionDateGte = '2022-11-04T00:00:00.000Z';
     const executionDateLte = '2022-11-08T00:00:00.000Z';
     const cacheKey = `${chainId}_${safeAddress}_multisig_transactions`;
-    const cacheKeyField = `-modified_undefined_true_${executionDateGte}_${executionDateLte}_undefined_undefined_undefined_undefined_undefined`;
+    const cacheKeyField = `-modified_undefined_true_${executionDateGte}_${executionDateLte}_undefined_undefined_undefined_${PaginationData.DEFAULT_LIMIT}_${PaginationData.DEFAULT_OFFSET}`;
     const expectedResponse = getJsonResource(
       'e2e/native-token-expected-response.json',
     );
@@ -53,7 +54,7 @@ describe('Get multisig transactions e2e test', () => {
     const executionDateGte = '2022-12-01T00:00:00.000Z';
     const executionDateLte = '2022-12-07T11:00:00.000Z';
     const cacheKey = `${chainId}_${safeAddress}_multisig_transactions`;
-    const cacheKeyField = `-modified_undefined_true_${executionDateGte}_${executionDateLte}_undefined_undefined_undefined_undefined_undefined`;
+    const cacheKeyField = `-modified_undefined_true_${executionDateGte}_${executionDateLte}_undefined_undefined_undefined_${PaginationData.DEFAULT_LIMIT}_${PaginationData.DEFAULT_OFFSET}`;
     const expectedResponse = getJsonResource(
       'e2e/erc20-expected-response.json',
     );
@@ -76,7 +77,7 @@ describe('Get multisig transactions e2e test', () => {
     const executionDateGte = '2022-11-29T14:00:00.000Z';
     const executionDateLte = '2022-12-06T00:00:00.000Z';
     const cacheKey = `${chainId}_${safeAddress}_multisig_transactions`;
-    const cacheKeyField = `-modified_undefined_true_${executionDateGte}_${executionDateLte}_undefined_undefined_undefined_undefined_undefined`;
+    const cacheKeyField = `-modified_undefined_true_${executionDateGte}_${executionDateLte}_undefined_undefined_undefined_${PaginationData.DEFAULT_LIMIT}_${PaginationData.DEFAULT_OFFSET}`;
     const expectedResponse = getJsonResource(
       'e2e/erc721-expected-response.json',
     );


### PR DESCRIPTION
This PR aims to establish default values for pagination data.

Previously, the service was returning `undefined` when no valid values were passed to `PaginationData`. The current Rust implementation does use default values for this use case since default values for `next` URLs are returned to the clients when no valid cursor is sent: see [the Rust implementation](https://github.com/safe-global/safe-client-gateway/blob/ad6e9f132e804fbacbbecbc878cb8b7efe4d2dc1/src/common/converters/page_metadata.rs).

Some tests were adjusted to match the default `limit` and `offset` values.