### PR TITLE
Share configuration setup between app and tests

### DIFF
--- a/src/app.provider.ts
+++ b/src/app.provider.ts
@@ -1,0 +1,98 @@
+import { INestApplication, VersioningType } from '@nestjs/common';
+import { DataSourceErrorFilter } from './routes/common/filters/data-source-error.filter';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { NestFactory } from '@nestjs/core';
+import { TestingModule } from '@nestjs/testing/testing-module';
+
+function configureVersioning(app: INestApplication) {
+  app.enableVersioning({
+    type: VersioningType.URI,
+  });
+}
+
+function configureShutdownHooks(app: INestApplication) {
+  app.enableShutdownHooks();
+}
+
+function configureFilters(app: INestApplication) {
+  app.useGlobalFilters(new DataSourceErrorFilter());
+}
+
+function configureSwagger(app: INestApplication) {
+  const config = new DocumentBuilder()
+    .setTitle('Safe Client Gateway')
+    .setVersion(process.env.npm_package_version ?? '')
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('', app, document);
+}
+
+/**
+ * The main goal of {@link AppProvider} is to provide
+ * a {@link INestApplication}.
+ *
+ * Extensions of this class should return the application in
+ * {@link getApp}.
+ *
+ * By default the {@link AppProvider} has a configuration collection ({@link setup})
+ * that can be changed by each extension of the class
+ */
+export abstract class AppProvider {
+  protected readonly setup: Array<(app: INestApplication) => void> = [
+    configureVersioning,
+    configureShutdownHooks,
+    configureFilters,
+    configureSwagger,
+  ];
+
+  public async provide(module: any): Promise<INestApplication> {
+    const app = await this.getApp(module);
+    this.setup.forEach((f) => f(app));
+    return app;
+  }
+
+  protected abstract getApp(module: any): Promise<INestApplication>;
+}
+
+/**
+ * The default {@link AppProvider}
+ *
+ * This provider should be used to retrieve the actual implementation of the
+ * service
+ */
+export class DefaultAppProvider extends AppProvider {
+  protected getApp(module: any): Promise<INestApplication> {
+    return NestFactory.create(module);
+  }
+}
+
+/**
+ * A test {@link AppProvider}
+ *
+ * This provider provides an application given a {@link TestingModule}
+ *
+ * If the module provided is not a {@link TestingModule}, an error is thrown
+ */
+export class TestAppProvider extends AppProvider {
+  constructor() {
+    super();
+    if (process.env.NODE_ENV !== 'test') {
+      throw Error('TestAppProvider used outside of a testing environment');
+    }
+
+    // Disables shutdown hooks for tests (they are not required)
+    // Enabling this in the tests might result in a MaxListenersExceededWarning
+    // as the number of listeners that this adds exceed the default
+    const index = this.setup.indexOf(configureShutdownHooks);
+    if (index > -1) this.setup.splice(index, 1);
+  }
+
+  protected getApp(module: any): Promise<INestApplication> {
+    if (!(module instanceof TestingModule))
+      return Promise.reject(
+        `${module.constructor.name} is not a TestingModule`,
+      );
+    return Promise.resolve(module.createNestApplication());
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,34 +1,14 @@
-import { VersioningType } from '@nestjs/common';
-import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
-import { DataSourceErrorFilter } from './routes/common/filters/data-source-error.filter';
 import { IConfigurationService } from './config/configuration.service.interface';
+import { DefaultAppProvider } from './app.provider';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
-  app.enableVersioning({
-    type: VersioningType.URI,
-  });
-
-  // Starts listening for shutdown hooks
-  app.enableShutdownHooks();
-
-  app.useGlobalFilters(new DataSourceErrorFilter());
-
-  const config = new DocumentBuilder()
-    .setTitle('Safe Client Gateway')
-    .setVersion(process.env.npm_package_version ?? '')
-    .build();
-
-  const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('', app, document);
+  const app = await new DefaultAppProvider().provide(AppModule);
 
   const configurationService: IConfigurationService =
     app.get<IConfigurationService>(IConfigurationService);
   const applicationPort: string =
     configurationService.getOrThrow('applicationPort');
-
   await app.listen(applicationPort);
 }
 

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -15,11 +15,11 @@ import {
   TestCacheModule,
 } from '../../datasources/cache/__tests__/test.cache.module';
 import { DomainModule } from '../../domain.module';
-import { DataSourceErrorFilter } from '../common/filters/data-source-error.filter';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { exchangeRatesBuilder } from '../../domain/exchange/entities/__tests__/exchange-rates.builder';
 import { exchangeFiatCodesBuilder } from '../../domain/exchange/entities/__tests__/exchange-fiat-codes.builder';
 import { balanceBuilder } from '../../domain/balances/entities/__tests__/balance.builder';
+import { TestAppProvider } from '../../app.provider';
 
 describe('Balances Controller (Unit)', () => {
   let app: INestApplication;
@@ -48,8 +48,8 @@ describe('Balances Controller (Unit)', () => {
         TestNetworkModule,
       ],
     }).compile();
-    app = moduleFixture.createNestApplication();
-    app.useGlobalFilters(new DataSourceErrorFilter());
+
+    app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
   });
 
@@ -86,7 +86,7 @@ describe('Balances Controller (Unit)', () => {
 
       const expectedBalance = transactionApiBalancesResponse[0];
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/safes/${safeAddress}/balances/usd`)
+        .get(`/v1/chains/${chainId}/safes/${safeAddress}/balances/usd`)
         .expect(200)
         .expect({
           fiatTotal: expectedBalance.fiatBalance,
@@ -132,7 +132,7 @@ describe('Balances Controller (Unit)', () => {
         );
 
         await request(app.getHttpServer())
-          .get(`/chains/${chainId}/safes/${safeAddress}/balances/usd`)
+          .get(`/v1/chains/${chainId}/safes/${safeAddress}/balances/usd`)
           .expect(500)
           .expect({
             message: 'An error occurred',
@@ -167,7 +167,7 @@ describe('Balances Controller (Unit)', () => {
         });
 
         await request(app.getHttpServer())
-          .get(`/chains/${chainId}/safes/${safeAddress}/balances/usd`)
+          .get(`/v1/chains/${chainId}/safes/${safeAddress}/balances/usd`)
           .expect(503)
           .expect({
             message: 'Error getting exchange data',
@@ -201,7 +201,7 @@ describe('Balances Controller (Unit)', () => {
         });
 
         await request(app.getHttpServer())
-          .get(`/chains/${chainId}/safes/${safeAddress}/balances/usd`)
+          .get(`/v1/chains/${chainId}/safes/${safeAddress}/balances/usd`)
           .expect(500)
           .expect({
             message: 'Validation failed',
@@ -239,7 +239,7 @@ describe('Balances Controller (Unit)', () => {
         });
 
         await request(app.getHttpServer())
-          .get(`/chains/${chainId}/safes/${safeAddress}/balances/usd`)
+          .get(`/v1/chains/${chainId}/safes/${safeAddress}/balances/usd`)
           .expect(500)
           .expect({
             statusCode: 500,
@@ -277,7 +277,7 @@ describe('Balances Controller (Unit)', () => {
         });
 
         await request(app.getHttpServer())
-          .get(`/chains/${chainId}/safes/${safeAddress}/balances/usd`)
+          .get(`/v1/chains/${chainId}/safes/${safeAddress}/balances/usd`)
           .expect(500)
           .expect({
             statusCode: 500,
@@ -316,7 +316,7 @@ describe('Balances Controller (Unit)', () => {
         });
 
         await request(app.getHttpServer())
-          .get(`/chains/${chainId}/safes/${safeAddress}/balances/${toRate}`)
+          .get(`/v1/chains/${chainId}/safes/${safeAddress}/balances/${toRate}`)
           .expect(500)
           .expect({
             statusCode: 500,
@@ -353,7 +353,7 @@ describe('Balances Controller (Unit)', () => {
         });
 
         await request(app.getHttpServer())
-          .get(`/chains/${chainId}/safes/${safeAddress}/balances/usd`)
+          .get(`/v1/chains/${chainId}/safes/${safeAddress}/balances/usd`)
           .expect(500)
           .expect({
             message: 'An error occurred',
@@ -387,7 +387,7 @@ describe('Balances Controller (Unit)', () => {
         });
 
         await request(app.getHttpServer())
-          .get(`/chains/${chainId}/safes/${safeAddress}/balances/usd`)
+          .get(`/v1/chains/${chainId}/safes/${safeAddress}/balances/usd`)
           .expect(500)
           .expect({
             message: 'Validation failed',
@@ -415,7 +415,7 @@ describe('Balances Controller (Unit)', () => {
       mockNetworkService.get.mockResolvedValueOnce({ data: fiatCodes });
 
       await request(app.getHttpServer())
-        .get('/balances/supported-fiat-codes')
+        .get('/v1/balances/supported-fiat-codes')
         .expect(200)
         .expect(['USD', 'EUR', 'AED', 'AFN', 'ALL']);
     });
@@ -424,7 +424,7 @@ describe('Balances Controller (Unit)', () => {
       mockNetworkService.get.mockRejectedValueOnce(new Error());
 
       await request(app.getHttpServer())
-        .get('/balances/supported-fiat-codes')
+        .get('/v1/balances/supported-fiat-codes')
         .expect(503)
         .expect({
           code: 503,

--- a/src/routes/chains/chains.controller.spec.ts
+++ b/src/routes/chains/chains.controller.spec.ts
@@ -23,10 +23,10 @@ import { MasterCopy as DomainMasterCopy } from '../../domain/chains/entities/mas
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { masterCopyBuilder } from '../../domain/chains/entities/__tests__/master-copy.builder';
 import { Page } from '../../domain/entities/page.entity';
-import { DataSourceErrorFilter } from '../common/filters/data-source-error.filter';
 import { PaginationData } from '../common/pagination/pagination.data';
 import { ChainsModule } from './chains.module';
 import { MasterCopy } from './entities/master-copy.entity';
+import { TestAppProvider } from '../../app.provider';
 
 describe('Chains Controller (Unit)', () => {
   let app: INestApplication;
@@ -71,9 +71,7 @@ describe('Chains Controller (Unit)', () => {
       ],
     }).compile();
 
-    app = moduleFixture.createNestApplication();
-    app.useGlobalFilters(new DataSourceErrorFilter());
-
+    app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
   });
 
@@ -82,7 +80,7 @@ describe('Chains Controller (Unit)', () => {
       mockNetworkService.get.mockResolvedValueOnce({ data: chainsResponse });
 
       await request(app.getHttpServer())
-        .get('/chains')
+        .get('/v1/chains')
         .expect(200)
         .expect({
           count: chainsResponse.count,
@@ -147,7 +145,7 @@ describe('Chains Controller (Unit)', () => {
         status: 500,
       });
 
-      await request(app.getHttpServer()).get('/chains').expect(500).expect({
+      await request(app.getHttpServer()).get('/v1/chains').expect(500).expect({
         message: 'An error occurred',
         code: 500,
       });
@@ -172,7 +170,7 @@ describe('Chains Controller (Unit)', () => {
         },
       });
 
-      await request(app.getHttpServer()).get('/chains').expect(500).expect({
+      await request(app.getHttpServer()).get('/v1/chains').expect(500).expect({
         message: 'Validation failed',
         code: 42,
         arguments: [],
@@ -216,7 +214,7 @@ describe('Chains Controller (Unit)', () => {
       mockNetworkService.get.mockResolvedValueOnce({ data: chainDomain });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}`)
+        .get(`/v1/chains/${chainId}`)
         .expect(200)
         .expect(expectedResult);
     });
@@ -229,7 +227,7 @@ describe('Chains Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}`)
+        .get(`/v1/chains/${chainId}`)
         .expect(404)
         .expect({
           message: 'Not Found',
@@ -244,7 +242,7 @@ describe('Chains Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}`)
+        .get(`/v1/chains/${chainId}`)
         .expect(503)
         .expect({
           message: 'An error occurred',
@@ -259,7 +257,7 @@ describe('Chains Controller (Unit)', () => {
       mockNetworkService.get.mockResolvedValueOnce({ data: backboneResponse });
 
       await request(app.getHttpServer())
-        .get('/chains/1/about/backbone')
+        .get('/v1/chains/1/about/backbone')
         .expect(200)
         .expect(backboneResponse);
 
@@ -279,7 +277,7 @@ describe('Chains Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get('/chains/1/about/backbone')
+        .get('/v1/chains/1/about/backbone')
         .expect(400)
         .expect({
           message: 'An error occurred',
@@ -300,7 +298,7 @@ describe('Chains Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get('/chains/1/about/backbone')
+        .get('/v1/chains/1/about/backbone')
         .expect(502)
         .expect({
           message: 'An error occurred',
@@ -340,7 +338,7 @@ describe('Chains Controller (Unit)', () => {
       ];
 
       await request(app.getHttpServer())
-        .get('/chains/1/about/master-copies')
+        .get('/v1/chains/1/about/master-copies')
         .expect(200)
         .expect(masterCopiesResponse);
 
@@ -360,7 +358,7 @@ describe('Chains Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get('/chains/1/about/master-copies')
+        .get('/v1/chains/1/about/master-copies')
         .expect(400)
         .expect({
           message: 'An error occurred',
@@ -381,7 +379,7 @@ describe('Chains Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get('/chains/1/about/master-copies')
+        .get('/v1/chains/1/about/master-copies')
         .expect(502)
         .expect({
           message: 'An error occurred',
@@ -409,7 +407,7 @@ describe('Chains Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get('/chains/1/about/master-copies')
+        .get('/v1/chains/1/about/master-copies')
         .expect(500)
         .expect({
           message: 'Validation failed',
@@ -437,7 +435,7 @@ describe('Chains Controller (Unit)', () => {
       mockNetworkService.get.mockResolvedValueOnce({ data: chainDomain });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainDomain.chainId}/about`)
+        .get(`/v1/chains/${chainDomain.chainId}/about`)
         .expect(200)
         .expect(expectedResult);
     });
@@ -450,7 +448,7 @@ describe('Chains Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/about`)
+        .get(`/v1/chains/${chainId}/about`)
         .expect(404)
         .expect({
           message: 'Not Found',
@@ -465,7 +463,7 @@ describe('Chains Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/about`)
+        .get(`/v1/chains/${chainId}/about`)
         .expect(503)
         .expect({
           message: 'An error occurred',

--- a/src/routes/collectibles/collectibles.controller.spec.ts
+++ b/src/routes/collectibles/collectibles.controller.spec.ts
@@ -17,7 +17,6 @@ import {
   NetworkRequestError,
   NetworkResponseError,
 } from '../../datasources/network/entities/network.error.entity';
-import { DataSourceErrorFilter } from '../common/filters/data-source-error.filter';
 import {
   fakeConfigurationService,
   TestConfigurationModule,
@@ -29,6 +28,7 @@ import {
   pageBuilder,
 } from '../../domain/entities/__tests__/page.builder';
 import { PaginationData } from '../common/pagination/pagination.data';
+import { TestAppProvider } from '../../app.provider';
 
 describe('Collectibles Controller (Unit)', () => {
   let app: INestApplication;
@@ -58,8 +58,7 @@ describe('Collectibles Controller (Unit)', () => {
       ],
     }).compile();
 
-    app = moduleFixture.createNestApplication();
-    app.useGlobalFilters(new DataSourceErrorFilter());
+    app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
   });
 
@@ -95,7 +94,7 @@ describe('Collectibles Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/safes/${safeAddress}/collectibles`)
+        .get(`/v2/chains/${chainId}/safes/${safeAddress}/collectibles`)
         .expect(200)
         .expect((response) => {
           expect(response.body.count).toBe(collectiblesResponse.count);
@@ -139,7 +138,7 @@ describe('Collectibles Controller (Unit)', () => {
 
       await request(app.getHttpServer())
         .get(
-          `/chains/${chainId}/safes/${safeAddress}/collectibles/?cursor=limit%3D${limit}%26offset%3D${offset}`,
+          `/v2/chains/${chainId}/safes/${safeAddress}/collectibles/?cursor=limit%3D${limit}%26offset%3D${offset}`,
         )
         .expect(200);
 
@@ -183,7 +182,7 @@ describe('Collectibles Controller (Unit)', () => {
 
       await request(app.getHttpServer())
         .get(
-          `/chains/${chainId}/safes/${safeAddress}/collectibles/?exclude_spam=${excludeSpam}&trusted=${trusted}`,
+          `/v2/chains/${chainId}/safes/${safeAddress}/collectibles/?exclude_spam=${excludeSpam}&trusted=${trusted}`,
         )
         .expect(200);
 
@@ -216,7 +215,7 @@ describe('Collectibles Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/safes/${safeAddress}/collectibles`)
+        .get(`/v2/chains/${chainId}/safes/${safeAddress}/collectibles`)
         .expect(transactionServiceError.status)
         .expect({
           code: transactionServiceError.status,
@@ -241,7 +240,7 @@ describe('Collectibles Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/safes/${safeAddress}/collectibles`)
+        .get(`/v2/chains/${chainId}/safes/${safeAddress}/collectibles`)
         .expect(503)
         .expect({
           code: 503,

--- a/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
+++ b/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
@@ -6,6 +6,7 @@ import { AppModule } from '../../../app.module';
 import { readFileSync } from 'fs';
 import { Contract } from '../entities/contract.entity';
 import { redisClientFactory } from '../../../__tests__/redis-client.factory';
+import { TestAppProvider } from '../../../app.provider';
 
 describe('Get contract e2e test', () => {
   let app: INestApplication;
@@ -17,7 +18,7 @@ describe('Get contract e2e test', () => {
       imports: [AppModule],
     }).compile();
 
-    app = moduleRef.createNestApplication();
+    app = await new TestAppProvider().provide(moduleRef);
     await app.init();
     redisClient = await redisClientFactory();
   });
@@ -39,7 +40,7 @@ describe('Get contract e2e test', () => {
     );
 
     await request(app.getHttpServer())
-      .get(`/chains/${chainId}/contracts/${contractAddress}`)
+      .get(`/v1/chains/${chainId}/contracts/${contractAddress}`)
       .expect(200)
       .then(({ body }) => {
         expect(body).toEqual(expectedResponse);

--- a/src/routes/data-decode/__tests__/data-decode.e2e-spec.ts
+++ b/src/routes/data-decode/__tests__/data-decode.e2e-spec.ts
@@ -7,6 +7,7 @@ import { AppModule } from '../../../app.module';
 import { DataDecoded } from '../../../domain/data-decoder/entities/data-decoded.entity';
 import { redisClientFactory } from '../../../__tests__/redis-client.factory';
 import { CreateDataDecodedDto } from '../entities/create-data-decoded.dto';
+import { TestAppProvider } from '../../../app.provider';
 
 describe('Data decode e2e tests', () => {
   let app: INestApplication;
@@ -18,7 +19,7 @@ describe('Data decode e2e tests', () => {
       imports: [AppModule],
     }).compile();
 
-    app = moduleRef.createNestApplication();
+    app = await new TestAppProvider().provide(moduleRef);
     await app.init();
     redisClient = await redisClientFactory();
   });
@@ -46,7 +47,7 @@ describe('Data decode e2e tests', () => {
     );
 
     await request(app.getHttpServer())
-      .post(`/chains/${chainId}/data-decoder`)
+      .post(`/v1/chains/${chainId}/data-decoder`)
       .send(requestBody)
       .expect(200)
       .then(({ body }) => {

--- a/src/routes/delegates/delegates.controller.spec.ts
+++ b/src/routes/delegates/delegates.controller.spec.ts
@@ -17,12 +17,12 @@ import {
 import { Delegate } from './entities/delegate.entity';
 import { Page } from '../../domain/entities/page.entity';
 import { DomainModule } from '../../domain.module';
-import { DataSourceErrorFilter } from '../common/filters/data-source-error.filter';
 import { faker } from '@faker-js/faker';
 import createDelegateDtoFactory from './entities/__tests__/create-delegate.dto.factory';
 import deleteDelegateDtoFactory from './entities/__tests__/delete-delegate.dto.factory';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { delegateBuilder } from '../../domain/delegate/entities/__tests__/delegate.builder';
+import { TestAppProvider } from '../../app.provider';
 
 describe('Delegates controller', () => {
   let app: INestApplication;
@@ -57,9 +57,7 @@ describe('Delegates controller', () => {
       ],
     }).compile();
 
-    app = moduleFixture.createNestApplication();
-    app.useGlobalFilters(new DataSourceErrorFilter());
-
+    app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
   });
 
@@ -81,7 +79,7 @@ describe('Delegates controller', () => {
       mockNetworkService.get.mockResolvedValueOnce({ data: pageDelegates });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/delegates?safe=${safe}`)
+        .get(`/v1/chains/${chainId}/delegates?safe=${safe}`)
         .expect(200)
         .expect(pageDelegates);
     });
@@ -100,7 +98,7 @@ describe('Delegates controller', () => {
       mockNetworkService.get.mockResolvedValueOnce({ data: pageDelegates });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/delegates?safe=${safe}`)
+        .get(`/v1/chains/${chainId}/delegates?safe=${safe}`)
         .expect(200)
         .expect(pageDelegates);
     });
@@ -111,7 +109,7 @@ describe('Delegates controller', () => {
       mockNetworkService.get.mockResolvedValueOnce({ data: chainResponse });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/delegates`)
+        .get(`/v1/chains/${chainId}/delegates`)
         .expect(400)
         .expect({
           message: 'At least one query param must be provided',
@@ -129,7 +127,7 @@ describe('Delegates controller', () => {
       mockNetworkService.post.mockResolvedValueOnce({ status: 201 });
 
       await request(app.getHttpServer())
-        .post(`/chains/${chainId}/delegates/`)
+        .post(`/v1/chains/${chainId}/delegates/`)
         .send(body)
         .expect(200);
     });
@@ -143,7 +141,7 @@ describe('Delegates controller', () => {
       mockNetworkService.post.mockResolvedValueOnce({ status: 201 });
 
       await request(app.getHttpServer())
-        .post(`/chains/${chainId}/delegates/`)
+        .post(`/v1/chains/${chainId}/delegates/`)
         .send(body)
         .expect(200);
     });
@@ -162,7 +160,7 @@ describe('Delegates controller', () => {
       });
 
       await request(app.getHttpServer())
-        .post(`/chains/${chainId}/delegates/`)
+        .post(`/v1/chains/${chainId}/delegates/`)
         .send(body)
         .expect(400)
         .expect({
@@ -179,7 +177,7 @@ describe('Delegates controller', () => {
       mockNetworkService.post.mockRejectedValueOnce({ status: 503 });
 
       await request(app.getHttpServer())
-        .post(`/chains/${chainId}/delegates/`)
+        .post(`/v1/chains/${chainId}/delegates/`)
         .send(body)
         .expect(503)
         .expect({
@@ -201,7 +199,7 @@ describe('Delegates controller', () => {
       });
 
       await request(app.getHttpServer())
-        .delete(`/chains/${chainId}/delegates/${body.delegate}`)
+        .delete(`/v1/chains/${chainId}/delegates/${body.delegate}`)
         .send(body)
         .expect(200);
     });
@@ -217,7 +215,7 @@ describe('Delegates controller', () => {
       });
 
       await request(app.getHttpServer())
-        .delete(`/chains/${chainId}/delegates/${delegate}`)
+        .delete(`/v1/chains/${chainId}/delegates/${delegate}`)
         .expect(400)
         .expect({
           message: 'Malformed body',
@@ -233,7 +231,7 @@ describe('Delegates controller', () => {
       mockNetworkService.delete.mockRejectedValueOnce({ status: 503 });
 
       await request(app.getHttpServer())
-        .delete(`/chains/${chainId}/delegates/${body.delegate}`)
+        .delete(`/v1/chains/${chainId}/delegates/${body.delegate}`)
         .send(body)
         .expect(503)
         .expect({

--- a/src/routes/estimations/estimations.controller.spec.ts
+++ b/src/routes/estimations/estimations.controller.spec.ts
@@ -24,8 +24,8 @@ import {
   toJson as multisigTransactionToJson,
 } from '../../domain/safe/entities/__tests__/multisig-transaction.builder';
 import { safeBuilder } from '../../domain/safe/entities/__tests__/safe.builder';
-import { DataSourceErrorFilter } from '../common/filters/data-source-error.filter';
 import { EstimationsModule } from './estimations.module';
+import { TestAppProvider } from '../../app.provider';
 
 describe('Estimations Controller (Unit)', () => {
   let app: INestApplication;
@@ -54,9 +54,7 @@ describe('Estimations Controller (Unit)', () => {
       ],
     }).compile();
 
-    app = moduleFixture.createNestApplication();
-    app.useGlobalFilters(new DataSourceErrorFilter());
-
+    app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
   });
 
@@ -99,7 +97,7 @@ describe('Estimations Controller (Unit)', () => {
 
       await request(app.getHttpServer())
         .post(
-          `/chains/${chain.chainId}/safes/${safe.address}/multisig-transactions/estimations`,
+          `/v2/chains/${chain.chainId}/safes/${safe.address}/multisig-transactions/estimations`,
         )
         .send(
           new EstimationRequest(
@@ -157,7 +155,7 @@ describe('Estimations Controller (Unit)', () => {
 
     await request(app.getHttpServer())
       .post(
-        `/chains/${chain.chainId}/safes/${address}/multisig-transactions/estimations`,
+        `/v2/chains/${chain.chainId}/safes/${address}/multisig-transactions/estimations`,
       )
       .send(
         new EstimationRequest(
@@ -206,7 +204,7 @@ describe('Estimations Controller (Unit)', () => {
 
     await request(app.getHttpServer())
       .post(
-        `/chains/${chain.chainId}/safes/${address}/multisig-transactions/estimations`,
+        `/v2/chains/${chain.chainId}/safes/${address}/multisig-transactions/estimations`,
       )
       .send(
         new EstimationRequest(
@@ -261,7 +259,7 @@ describe('Estimations Controller (Unit)', () => {
 
     await request(app.getHttpServer())
       .post(
-        `/chains/${chain.chainId}/safes/${address}/multisig-transactions/estimations`,
+        `/v2/chains/${chain.chainId}/safes/${address}/multisig-transactions/estimations`,
       )
       .send(
         new EstimationRequest(

--- a/src/routes/health/__tests__/get-health.e2e-spec.ts
+++ b/src/routes/health/__tests__/get-health.e2e-spec.ts
@@ -2,6 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import * as request from 'supertest';
 import { AppModule } from '../../../app.module';
+import { TestAppProvider } from '../../../app.provider';
 
 describe('Get health e2e test', () => {
   let app: INestApplication;
@@ -10,8 +11,7 @@ describe('Get health e2e test', () => {
     const moduleRef = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
-
-    app = moduleRef.createNestApplication();
+    app = await new TestAppProvider().provide(moduleRef);
     await app.init();
   });
 

--- a/src/routes/notifications/notifications.controller.spec.ts
+++ b/src/routes/notifications/notifications.controller.spec.ts
@@ -18,10 +18,10 @@ import {
 } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
-import { DataSourceErrorFilter } from '../common/filters/data-source-error.filter';
 import { registerDeviceDtoBuilder } from './entities/__tests__/register-device.dto.builder';
 import { safeRegistrationBuilder } from './entities/__tests__/safe-registration.builder';
 import { NotificationsModule } from './notifications.module';
+import { TestAppProvider } from '../../app.provider';
 
 describe('Notifications Controller (Unit)', () => {
   let app: INestApplication;
@@ -52,9 +52,7 @@ describe('Notifications Controller (Unit)', () => {
       ],
     }).compile();
 
-    app = moduleFixture.createNestApplication();
-    app.useGlobalFilters(new DataSourceErrorFilter());
-
+    app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
   });
 
@@ -88,7 +86,7 @@ describe('Notifications Controller (Unit)', () => {
       );
 
       await request(app.getHttpServer())
-        .post('/register/notifications')
+        .post('/v1/register/notifications')
         .send(registerDeviceDto)
         .expect(200)
         .expect({});
@@ -117,7 +115,7 @@ describe('Notifications Controller (Unit)', () => {
       );
 
       await request(app.getHttpServer())
-        .post('/register/notifications')
+        .post('/v1/register/notifications')
         .send(registerDeviceDto)
         .expect(400)
         .expect(({ body }) =>
@@ -152,7 +150,7 @@ describe('Notifications Controller (Unit)', () => {
       );
 
       await request(app.getHttpServer())
-        .post('/register/notifications')
+        .post('/v1/register/notifications')
         .send(registerDeviceDto)
         .expect(500)
         .expect({
@@ -194,7 +192,7 @@ describe('Notifications Controller (Unit)', () => {
       );
 
       await request(app.getHttpServer())
-        .post('/register/notifications')
+        .post('/v1/register/notifications')
         .send(registerDeviceDto)
         .expect(500)
         .expect({
@@ -231,7 +229,7 @@ describe('Notifications Controller (Unit)', () => {
       );
 
       await request(app.getHttpServer())
-        .post('/register/notifications')
+        .post('/v1/register/notifications')
         .send(registerDeviceDto)
         .expect(500)
         .expect({
@@ -259,7 +257,7 @@ describe('Notifications Controller (Unit)', () => {
 
       await request(app.getHttpServer())
         .delete(
-          `/chains/${chain.chainId}/notifications/devices/${uuid}/safes/${safeAddress}`,
+          `/v1/chains/${chain.chainId}/notifications/devices/${uuid}/safes/${safeAddress}`,
         )
         .expect(200)
         .expect({});
@@ -279,7 +277,7 @@ describe('Notifications Controller (Unit)', () => {
 
       await request(app.getHttpServer())
         .delete(
-          `/chains/${chainId}/notifications/devices/${uuid}/safes/${safeAddress}`,
+          `/v1/chains/${chainId}/notifications/devices/${uuid}/safes/${safeAddress}`,
         )
         .expect(503);
       expect(mockNetworkService.delete).toBeCalledTimes(0);
@@ -303,7 +301,7 @@ describe('Notifications Controller (Unit)', () => {
 
       await request(app.getHttpServer())
         .delete(
-          `/chains/${chain.chainId}/notifications/devices/${uuid}/safes/${safeAddress}`,
+          `/v1/chains/${chain.chainId}/notifications/devices/${uuid}/safes/${safeAddress}`,
         )
         .expect(503);
       expect(mockNetworkService.delete).toBeCalledTimes(1);

--- a/src/routes/owners/owners.controller.spec.ts
+++ b/src/routes/owners/owners.controller.spec.ts
@@ -15,9 +15,9 @@ import {
   TestNetworkModule,
 } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';
-import { DataSourceErrorFilter } from '../common/filters/data-source-error.filter';
 import { OwnersModule } from './owners.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
+import { TestAppProvider } from '../../app.provider';
 
 describe('Owners Controller (Unit)', () => {
   let app: INestApplication;
@@ -46,9 +46,7 @@ describe('Owners Controller (Unit)', () => {
       ],
     }).compile();
 
-    app = moduleFixture.createNestApplication();
-    app.useGlobalFilters(new DataSourceErrorFilter());
-
+    app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
   });
 
@@ -74,7 +72,7 @@ describe('Owners Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/owners/${ownerAddress}/safes`)
+        .get(`/v1/chains/${chainId}/owners/${ownerAddress}/safes`)
         .expect(200)
         .expect(transactionApiSafeListResponse);
     });
@@ -87,7 +85,7 @@ describe('Owners Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/owners/${ownerAddress}/safes`)
+        .get(`/v1/chains/${chainId}/owners/${ownerAddress}/safes`)
         .expect(500)
         .expect({
           message: 'An error occurred',
@@ -111,7 +109,7 @@ describe('Owners Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/owners/${ownerAddress}/safes`)
+        .get(`/v1/chains/${chainId}/owners/${ownerAddress}/safes`)
         .expect(500)
         .expect({
           message: 'An error occurred',
@@ -146,7 +144,7 @@ describe('Owners Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/owners/${ownerAddress}/safes`)
+        .get(`/v1/chains/${chainId}/owners/${ownerAddress}/safes`)
         .expect(500)
         .expect({
           message: 'Validation failed',

--- a/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
+++ b/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
@@ -4,6 +4,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { AppModule } from '../../../app.module';
 import { redisClientFactory } from '../../../__tests__/redis-client.factory';
+import { TestAppProvider } from '../../../app.provider';
 
 describe('Get Safe Apps e2e test', () => {
   let app: INestApplication;
@@ -15,7 +16,7 @@ describe('Get Safe Apps e2e test', () => {
       imports: [AppModule],
     }).compile();
 
-    app = moduleRef.createNestApplication();
+    app = await new TestAppProvider().provide(moduleRef);
     await app.init();
     redisClient = await redisClientFactory();
   });
@@ -29,7 +30,7 @@ describe('Get Safe Apps e2e test', () => {
     const safeAppsCacheField = `${chainId}_undefined_undefined`;
 
     await request(app.getHttpServer())
-      .get(`/chains/${chainId}/safe-apps`)
+      .get(`/v1/chains/${chainId}/safe-apps`)
       .expect(200)
       .then(({ body }) => {
         expect(body).toEqual(expect.any(Array));
@@ -58,7 +59,7 @@ describe('Get Safe Apps e2e test', () => {
     const safeAppsCacheField = `${chainId}_undefined_${transactionBuilderUrl}`;
 
     await request(app.getHttpServer())
-      .get(`/chains/${chainId}/safe-apps/?url=${transactionBuilderUrl}`)
+      .get(`/v1/chains/${chainId}/safe-apps/?url=${transactionBuilderUrl}`)
       .expect(200)
       .then(({ body }) => {
         expect(body).toEqual(expect.any(Array));

--- a/src/routes/safes/safes.controller.spec.ts
+++ b/src/routes/safes/safes.controller.spec.ts
@@ -13,7 +13,6 @@ import {
   mockNetworkService,
   TestNetworkModule,
 } from '../../datasources/network/__tests__/test.network.module';
-import { DataSourceErrorFilter } from '../common/filters/data-source-error.filter';
 import { SafesModule } from './safes.module';
 import * as request from 'supertest';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
@@ -38,6 +37,7 @@ import {
   moduleTransactionBuilder,
   toJson as moduleTransactionToJson,
 } from '../../domain/safe/entities/__tests__/module-transaction.builder';
+import { TestAppProvider } from '../../app.provider';
 
 describe('Safes Controller (Unit)', () => {
   let app: INestApplication;
@@ -69,9 +69,7 @@ describe('Safes Controller (Unit)', () => {
       ],
     }).compile();
 
-    app = moduleFixture.createNestApplication();
-    app.useGlobalFilters(new DataSourceErrorFilter());
-
+    app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
   });
 
@@ -151,7 +149,7 @@ describe('Safes Controller (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .get(`/v1/chains/${chain.chainId}/safes/${safeInfo.address}`)
       .expect(200)
       .expect({
         address: {
@@ -233,7 +231,7 @@ describe('Safes Controller (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .get(`/v1/chains/${chain.chainId}/safes/${safeInfo.address}`)
       .expect(200)
       .expect((response) =>
         expect(response.body).toMatchObject({
@@ -283,7 +281,7 @@ describe('Safes Controller (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .get(`/v1/chains/${chain.chainId}/safes/${safeInfo.address}`)
       .expect(200)
       .expect((response) =>
         expect(response.body).toMatchObject({
@@ -334,7 +332,7 @@ describe('Safes Controller (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .get(`/v1/chains/${chain.chainId}/safes/${safeInfo.address}`)
       .expect(200)
       .expect((response) =>
         expect(response.body).toMatchObject({
@@ -388,7 +386,7 @@ describe('Safes Controller (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .get(`/v1/chains/${chain.chainId}/safes/${safeInfo.address}`)
       .expect(200)
       .expect((response) =>
         expect(response.body).toMatchObject({
@@ -454,7 +452,7 @@ describe('Safes Controller (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .get(`/v1/chains/${chain.chainId}/safes/${safeInfo.address}`)
       .expect(200)
       .expect((response) =>
         expect(response.body).toMatchObject({
@@ -523,7 +521,7 @@ describe('Safes Controller (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .get(`/v1/chains/${chain.chainId}/safes/${safeInfo.address}`)
       .expect(200)
       .expect((response) =>
         expect(response.body).toMatchObject({
@@ -591,7 +589,7 @@ describe('Safes Controller (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .get(`/v1/chains/${chain.chainId}/safes/${safeInfo.address}`)
       .expect(200)
       .expect((response) =>
         expect(response.body).toMatchObject({
@@ -659,7 +657,7 @@ describe('Safes Controller (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .get(`/v1/chains/${chain.chainId}/safes/${safeInfo.address}`)
       .expect(200)
       .expect((response) =>
         expect(response.body).toMatchObject({
@@ -720,7 +718,7 @@ describe('Safes Controller (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .get(`/v1/chains/${chain.chainId}/safes/${safeInfo.address}`)
       .expect(200)
       .expect((response) =>
         expect(response.body).toMatchObject({
@@ -785,7 +783,7 @@ describe('Safes Controller (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .get(`/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .get(`/v1/chains/${chain.chainId}/safes/${safeInfo.address}`)
       .expect(200)
       .expect((response) =>
         expect(response.body).toMatchObject({

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -26,7 +26,6 @@ import {
   toJson as multisigTransactionToJson,
 } from '../../domain/safe/entities/__tests__/multisig-transaction.builder';
 import { safeBuilder } from '../../domain/safe/entities/__tests__/safe.builder';
-import { DataSourceErrorFilter } from '../common/filters/data-source-error.filter';
 import { TransactionsModule } from './transactions.module';
 import {
   ethereumTransactionBuilder,
@@ -40,6 +39,7 @@ import {
   creationTransactionBuilder,
   toJson as creationTransactionToJson,
 } from '../../domain/safe/entities/__tests__/creation-transaction.builder';
+import { TestAppProvider } from '../../app.provider';
 
 describe('Transactions History Controller (Unit)', () => {
   let app: INestApplication;
@@ -68,9 +68,7 @@ describe('Transactions History Controller (Unit)', () => {
       ],
     }).compile();
 
-    app = moduleFixture.createNestApplication();
-    app.useGlobalFilters(new DataSourceErrorFilter());
-
+    app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
   });
 
@@ -90,7 +88,7 @@ describe('Transactions History Controller (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .get(`/chains/${chainId}/safes/${safeAddress}/transactions/history`)
+      .get(`/v1/chains/${chainId}/safes/${safeAddress}/transactions/history`)
       .expect(500)
       .expect({
         message: 'An error occurred',
@@ -114,7 +112,7 @@ describe('Transactions History Controller (Unit)', () => {
       return Promise.reject(new Error(`Could not match ${url}`));
     });
     await request(app.getHttpServer())
-      .get(`/chains/${chainId}/safes/${safeAddress}/transactions/history/`)
+      .get(`/v1/chains/${chainId}/safes/${safeAddress}/transactions/history/`)
       .expect(500)
       .expect({
         message: 'An error occurred',
@@ -159,7 +157,7 @@ describe('Transactions History Controller (Unit)', () => {
 
     await request(app.getHttpServer())
       .get(
-        `/chains/${chainId}/safes/${safeAddress}/transactions/history/?timezone_offset=${timezoneOffset}`,
+        `/v1/chains/${chainId}/safes/${safeAddress}/transactions/history/?timezone_offset=${timezoneOffset}`,
       )
       .expect(200)
       .then(({ body }) => {
@@ -227,7 +225,7 @@ describe('Transactions History Controller (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .get(`/chains/${chainId}/safes/${safeAddress}/transactions/history/`)
+      .get(`/v1/chains/${chainId}/safes/${safeAddress}/transactions/history/`)
       .expect(200)
       .then(({ body }) => {
         expect(body.results).toHaveLength(
@@ -281,7 +279,7 @@ describe('Transactions History Controller (Unit)', () => {
 
     await request(app.getHttpServer())
       .get(
-        `/chains/${chainId}/safes/${safeAddress}/transactions/history/?timezone_offset=${timezoneOffset}`,
+        `/v1/chains/${chainId}/safes/${safeAddress}/transactions/history/?timezone_offset=${timezoneOffset}`,
       )
       .expect(200)
       .then(({ body }) => {
@@ -350,7 +348,7 @@ describe('Transactions History Controller (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .get(`/chains/${chainId}/safes/${safeAddress}/transactions/history/`)
+      .get(`/v1/chains/${chainId}/safes/${safeAddress}/transactions/history/`)
       .expect(200)
       .then(({ body }) => {
         expect(body.results).toHaveLength(
@@ -424,7 +422,7 @@ describe('Transactions History Controller (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .get(`/chains/${chainId}/safes/${safeAddress}/transactions/history/`)
+      .get(`/v1/chains/${chainId}/safes/${safeAddress}/transactions/history/`)
       .expect(200)
       .then(({ body }) => {
         expect(body.results).toHaveLength(3);
@@ -482,7 +480,7 @@ describe('Transactions History Controller (Unit)', () => {
 
     await request(app.getHttpServer())
       .get(
-        `/chains/${chainId}/safes/${safeAddress}/transactions/history/?cursor=limit%3D${limit}%26offset%3D${offset}`,
+        `/v1/chains/${chainId}/safes/${safeAddress}/transactions/history/?cursor=limit%3D${limit}%26offset%3D${offset}`,
       )
       .expect(200)
       .then(({ body }) => {

--- a/src/routes/transactions/transactions.controller.spec.ts
+++ b/src/routes/transactions/transactions.controller.spec.ts
@@ -34,8 +34,8 @@ import {
   toJson as multisigTransactionToJson,
 } from '../../domain/safe/entities/__tests__/multisig-transaction.builder';
 import { safeBuilder } from '../../domain/safe/entities/__tests__/safe.builder';
-import { DataSourceErrorFilter } from '../common/filters/data-source-error.filter';
 import { TransactionsModule } from './transactions.module';
+import { TestAppProvider } from '../../app.provider';
 
 describe('Transactions Controller (Unit)', () => {
   let app: INestApplication;
@@ -64,9 +64,7 @@ describe('Transactions Controller (Unit)', () => {
       ],
     }).compile();
 
-    app = moduleFixture.createNestApplication();
-    app.useGlobalFilters(new DataSourceErrorFilter());
-
+    app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
   });
 
@@ -83,7 +81,7 @@ describe('Transactions Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/safes/${safeAddress}/multisig-transactions`)
+        .get(`/v1/chains/${chainId}/safes/${safeAddress}/multisig-transactions`)
         .expect(500)
         .expect({
           message: 'An error occurred',
@@ -107,7 +105,7 @@ describe('Transactions Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/safes/${safeAddress}/multisig-transactions`)
+        .get(`/v1/chains/${chainId}/safes/${safeAddress}/multisig-transactions`)
         .expect(500)
         .expect({
           message: 'An error occurred',
@@ -141,7 +139,7 @@ describe('Transactions Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/safes/${safeAddress}/multisig-transactions`)
+        .get(`/v1/chains/${chainId}/safes/${safeAddress}/multisig-transactions`)
         .expect(500)
         .expect({
           message: 'Validation failed',
@@ -193,7 +191,7 @@ describe('Transactions Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/safes/${safeAddress}/multisig-transactions`)
+        .get(`/v1/chains/${chainId}/safes/${safeAddress}/multisig-transactions`)
         .expect(200)
         .then(({ body }) => {
           expect(body).toEqual(
@@ -247,7 +245,7 @@ describe('Transactions Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/safes/${safeAddress}/multisig-transactions`)
+        .get(`/v1/chains/${chainId}/safes/${safeAddress}/multisig-transactions`)
         .expect(200)
         .then(({ body }) => {
           expect(body).toEqual(
@@ -326,7 +324,7 @@ describe('Transactions Controller (Unit)', () => {
 
       await request(app.getHttpServer())
         .get(
-          `/chains/${chainId}/safes/${domainTransaction.safe}/multisig-transactions`,
+          `/v1/chains/${chainId}/safes/${domainTransaction.safe}/multisig-transactions`,
         )
         .expect(200)
         .then(({ body }) => {
@@ -385,7 +383,7 @@ describe('Transactions Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/safes/${safeAddress}/module-transactions`)
+        .get(`/v1/chains/${chainId}/safes/${safeAddress}/module-transactions`)
         .expect(500)
         .expect({
           message: 'An error occurred',
@@ -409,7 +407,7 @@ describe('Transactions Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/safes/${safeAddress}/module-transactions`)
+        .get(`/v1/chains/${chainId}/safes/${safeAddress}/module-transactions`)
         .expect(500)
         .expect({
           message: 'An error occurred',
@@ -434,7 +432,7 @@ describe('Transactions Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/safes/${safeAddress}/module-transactions`)
+        .get(`/v1/chains/${chainId}/safes/${safeAddress}/module-transactions`)
         .expect(404)
         .expect({
           message: 'An error occurred',
@@ -468,7 +466,7 @@ describe('Transactions Controller (Unit)', () => {
       mockNetworkService.get.mockResolvedValueOnce({ data: safe });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/safes/${safeAddress}/module-transactions`)
+        .get(`/v1/chains/${chainId}/safes/${safeAddress}/module-transactions`)
         .expect(200);
     });
   });
@@ -482,7 +480,7 @@ describe('Transactions Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/safes/${safeAddress}/incoming-transfers`)
+        .get(`/v1/chains/${chainId}/safes/${safeAddress}/incoming-transfers`)
         .expect(500)
         .expect({
           message: 'An error occurred',
@@ -509,7 +507,7 @@ describe('Transactions Controller (Unit)', () => {
 
       await request(app.getHttpServer())
         .get(
-          `/chains/${chainId}/safes/${safeAddress}/incoming-transfers/?cursor=limit%3D${limit}%26offset%3D${offset}`,
+          `/v1/chains/${chainId}/safes/${safeAddress}/incoming-transfers/?cursor=limit%3D${limit}%26offset%3D${offset}`,
         )
         .expect(500)
         .expect({
@@ -540,7 +538,7 @@ describe('Transactions Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/safes/${safeAddress}/incoming-transfers`)
+        .get(`/v1/chains/${chainId}/safes/${safeAddress}/incoming-transfers`)
         .expect(500)
         .expect({
           message: 'Validation failed',
@@ -592,7 +590,7 @@ describe('Transactions Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/safes/${safeAddress}/incoming-transfers/`)
+        .get(`/v1/chains/${chainId}/safes/${safeAddress}/incoming-transfers/`)
         .expect(200)
         .then(({ body }) => {
           expect(body).toEqual(
@@ -644,7 +642,7 @@ describe('Transactions Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/safes/${safeAddress}/incoming-transfers/`)
+        .get(`/v1/chains/${chainId}/safes/${safeAddress}/incoming-transfers/`)
         .expect(200)
         .then(({ body }) => {
           expect(body).toEqual(
@@ -688,7 +686,7 @@ describe('Transactions Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/safes/${safeAddress}/incoming-transfers/`)
+        .get(`/v1/chains/${chainId}/safes/${safeAddress}/incoming-transfers/`)
         .expect(200)
         .then(({ body }) => {
           expect(body).toEqual(
@@ -806,7 +804,7 @@ describe('Transactions Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/chains/${chainId}/safes/${safeAddress}/transactions/queued`)
+        .get(`/v1/chains/${chainId}/safes/${safeAddress}/transactions/queued`)
         .expect(200)
         .then(({ body }) => {
           expect(body).toEqual({
@@ -1000,7 +998,7 @@ describe('Transactions Controller (Unit)', () => {
 
       await request(app.getHttpServer())
         .get(
-          `/chains/${chainId}/safes/${safeAddress}/transactions/queued/?cursor=limit%3D10%26offset%3D2`,
+          `/v1/chains/${chainId}/safes/${safeAddress}/transactions/queued/?cursor=limit%3D10%26offset%3D2`,
         )
         .expect(200)
         .then(({ body }) => {


### PR DESCRIPTION
- Introduces `AppProvider` – its main goal is to provide a `INestApplication`.
- This class was introduced because the application created for the service and the applications created for a testing scenario should be mostly the same (besides some differences like the module being targeted).
- This also allows to configure applications in a more centralized manner given that in most scenarios, they should have the same configuration
- In a testing scenario `TestAppProvider` should be used as it supports instances of `TestingModule`.
- Given that API versioning is now part of the testing application, the tests were adjusted to include the version in the path