### PR TITLE
Add winston logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",
-    "semver": "^7.3.7"
+    "semver": "^7.3.7",
+    "winston": "^3.8.2"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.4.0",

--- a/src/app.provider.ts
+++ b/src/app.provider.ts
@@ -3,6 +3,21 @@ import { DataSourceErrorFilter } from './routes/common/filters/data-source-error
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { NestFactory } from '@nestjs/core';
 import { TestingModule } from '@nestjs/testing/testing-module';
+import * as winston from 'winston';
+import { format } from 'winston';
+
+function configureLogger() {
+  winston.add(
+    new winston.transports.Console({
+      level: 'debug',
+      format: format.combine(
+        format.colorize({ all: true }),
+        format.splat(),
+        format.simple(),
+      ),
+    }),
+  );
+}
 
 function configureVersioning(app: INestApplication) {
   app.enableVersioning({
@@ -29,6 +44,7 @@ function configureSwagger(app: INestApplication) {
 }
 
 const DEFAULT_CONFIGURATION: ((app: INestApplication) => void)[] = [
+  configureLogger,
   configureVersioning,
   configureShutdownHooks,
   configureFilters,

--- a/src/datasources/cache/cache.first.data.source.ts
+++ b/src/datasources/cache/cache.first.data.source.ts
@@ -4,8 +4,8 @@ import {
   INetworkService,
   NetworkService,
 } from '../network/network.service.interface';
-import { Inject, Injectable, Logger } from '@nestjs/common';
-import { LoggerMiddleware } from '../../middleware/logger.middleware';
+import { Inject, Injectable } from '@nestjs/common';
+import * as winston from 'winston';
 
 /**
  * A data source which tries to retrieve values from cache using
@@ -18,8 +18,6 @@ import { LoggerMiddleware } from '../../middleware/logger.middleware';
  */
 @Injectable()
 export class CacheFirstDataSource {
-  private readonly logger = new Logger(LoggerMiddleware.name);
-
   constructor(
     @Inject(CacheService) private readonly cacheService: ICacheService,
     @Inject(NetworkService) private readonly networkService: INetworkService,
@@ -47,10 +45,10 @@ export class CacheFirstDataSource {
   ): Promise<T> {
     const cached = await this.cacheService.get(key, field);
     if (cached != null) {
-      this.logger.debug(`[Cache] Cache hit: ${key}`);
+      winston.debug(`[Cache] Cache hit: ${key}`);
       return JSON.parse(cached);
     }
-    this.logger.debug(`[Cache] Cache miss: ${key}`);
+    winston.debug(`[Cache] Cache miss: ${key}`);
     const { data } = await this.networkService.get(url, params);
     const rawJson = JSON.stringify(data);
     await this.cacheService.set(key, field, rawJson, expireTimeSeconds);

--- a/src/datasources/cache/cache.module.ts
+++ b/src/datasources/cache/cache.module.ts
@@ -3,7 +3,7 @@ import { CacheService } from './cache.service.interface';
 import { RedisCacheService } from './redis.cache.service';
 import { createClient } from 'redis';
 import { IConfigurationService } from '../../config/configuration.service.interface';
-import winston from 'winston';
+import * as winston from 'winston';
 
 export type RedisClientType = ReturnType<typeof createClient>;
 

--- a/src/datasources/cache/cache.module.ts
+++ b/src/datasources/cache/cache.module.ts
@@ -1,12 +1,11 @@
-import { Global, Logger, Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import { CacheService } from './cache.service.interface';
 import { RedisCacheService } from './redis.cache.service';
 import { createClient } from 'redis';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import winston from 'winston';
 
 export type RedisClientType = ReturnType<typeof createClient>;
-
-const logger = new Logger(redisClientFactory.name);
 
 async function redisClientFactory(
   configurationService: IConfigurationService,
@@ -16,7 +15,7 @@ async function redisClientFactory(
   const client: RedisClientType = createClient({
     url: `redis://${redisHost}:${redisPort}`,
   });
-  client.on('error', (err) => logger.error('Redis Client Error', err));
+  client.on('error', (err) => winston.error('Redis Client Error', err));
   client.connect();
   return client;
 }

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -1,12 +1,11 @@
-import { Inject, Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
 import { ICacheService } from './cache.service.interface';
 import { RedisClientType } from './cache.module';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import * as winston from 'winston';
 
 @Injectable()
 export class RedisCacheService implements ICacheService, OnModuleDestroy {
-  private readonly logger = new Logger(RedisCacheService.name);
-
   private readonly defaultExpirationTimeInSeconds: number;
   private readonly quitTimeoutInSeconds: number = 2;
 
@@ -53,22 +52,22 @@ export class RedisCacheService implements ICacheService, OnModuleDestroy {
    * instance is not responding it invokes {@link forceQuit}.
    */
   async onModuleDestroy(): Promise<void> {
-    this.logger.verbose('Closing Redis connection');
+    winston.verbose('Closing Redis connection');
     const forceQuitTimeout = setTimeout(
       this.forceQuit.bind(this),
       this.quitTimeoutInSeconds * 1000,
     );
     await this.client.quit();
     clearTimeout(forceQuitTimeout);
-    this.logger.verbose('Redis connection closed');
+    winston.verbose('Redis connection closed');
   }
 
   /**
    * Forces the closing of the Redis connection associated with this service.
    */
   private async forceQuit() {
-    this.logger.verbose('Forcing Redis connection close');
+    winston.verbose('Forcing Redis connection close');
     await this.client.disconnect();
-    this.logger.verbose('Redis connection closed');
+    winston.verbose('Redis connection closed');
   }
 }

--- a/src/datasources/errors/http-error-factory.ts
+++ b/src/datasources/errors/http-error-factory.ts
@@ -1,9 +1,10 @@
-import { HttpStatus, Injectable, Logger } from '@nestjs/common';
+import { HttpStatus, Injectable } from '@nestjs/common';
 import {
   NetworkError,
   NetworkResponseError,
 } from '../network/entities/network.error.entity';
 import { DataSourceError } from '../../domain/errors/data-source.error';
+import * as winston from 'winston';
 
 /**
  * Maps a {@link NetworkError} or {@link Error} into a {@link DataSourceError}
@@ -16,8 +17,6 @@ import { DataSourceError } from '../../domain/errors/data-source.error';
  */
 @Injectable()
 export class HttpErrorFactory {
-  private readonly logger = new Logger(HttpErrorFactory.name);
-
   private mapError(error: NetworkError | Error): DataSourceError {
     if (isNetworkResponseError(error)) {
       const errorMessage: string = error.data?.message ?? 'An error occurred';
@@ -32,7 +31,7 @@ export class HttpErrorFactory {
 
   from(source: NetworkError | Error): DataSourceError {
     const error = this.mapError(source);
-    this.logger.error(error);
+    winston.error(error);
     return error;
   }
 }

--- a/src/datasources/transaction-api/transaction-api.manager.ts
+++ b/src/datasources/transaction-api/transaction-api.manager.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { Chain } from '../../domain/chains/entities/chain.entity';
 import { TransactionApi } from './transaction-api.service';
 import { CacheFirstDataSource } from '../cache/cache.first.data.source';
@@ -7,13 +7,13 @@ import { IConfigApi } from '../../domain/interfaces/config-api.interface';
 import { CacheService, ICacheService } from '../cache/cache.service.interface';
 import { HttpErrorFactory } from '../errors/http-error-factory';
 import {
-  NetworkService,
   INetworkService,
+  NetworkService,
 } from '../network/network.service.interface';
+import * as winston from 'winston';
 
 @Injectable()
 export class TransactionApiManager implements ITransactionApiManager {
-  private readonly logger = new Logger(TransactionApiManager.name);
   private transactionApiMap: Record<string, TransactionApi> = {};
 
   constructor(
@@ -25,11 +25,11 @@ export class TransactionApiManager implements ITransactionApiManager {
   ) {}
 
   async getTransactionApi(chainId: string): Promise<TransactionApi> {
-    this.logger.log(`Getting TransactionApi instance for chain ${chainId}`);
+    winston.debug(`Getting TransactionApi instance for chain ${chainId}`);
     const transactionApi = this.transactionApiMap[chainId];
     if (transactionApi !== undefined) return transactionApi;
 
-    this.logger.log(
+    winston.debug(
       `Transaction API for chain ${chainId} not available. Fetching from the Config Service`,
     );
     const chain: Chain = await this.configApi.getChain(chainId);

--- a/src/domain/schema/validation-error-factory.ts
+++ b/src/domain/schema/validation-error-factory.ts
@@ -1,6 +1,7 @@
-import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { DefinedError } from 'ajv';
 import { HttpExceptionPayload } from '../../datasources/errors/interfaces/http-exception-payload.interface';
+import * as winston from 'winston';
 
 /**
  * Creates an {@link HttpException} from an array of validation errors.
@@ -9,7 +10,6 @@ import { HttpExceptionPayload } from '../../datasources/errors/interfaces/http-e
  */
 @Injectable()
 export class ValidationErrorFactory {
-  private readonly logger = new Logger(ValidationErrorFactory.name);
   private readonly VALIDATION_ERROR_CODE = 42;
 
   from(errors: DefinedError[]): HttpException {
@@ -25,7 +25,7 @@ export class ValidationErrorFactory {
       message,
     }));
 
-    this.logger.error({ ...errPayload, detail });
+    winston.error({ ...errPayload, detail });
     return new HttpException(errPayload, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 }

--- a/src/middleware/logger.middleware.ts
+++ b/src/middleware/logger.middleware.ts
@@ -1,32 +1,29 @@
-import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
+import { Injectable, NestMiddleware } from '@nestjs/common';
 import { NextFunction, Request, Response } from 'express';
+import * as winston from 'winston';
 
 @Injectable()
 export class LoggerMiddleware implements NestMiddleware {
-  private readonly logger = new Logger(LoggerMiddleware.name);
+  use(req: Request, res: Response, next: NextFunction) {
+    winston.debug('[==>] %s %s', req.method, req.url);
 
-  private formatRequestMessage = (req: Request) =>
-    `[==>] ${req.method} ${req.url}`;
-
-  private formatResponseMessage = (res: Response) => {
     const contentLength = res.get('content-length') || '';
     const contentType = res.get('content-type') || '';
-    return `[<==] ${res.statusCode} ${contentLength} ${contentType}`;
-  };
 
-  use(req: Request, res: Response, next: NextFunction) {
-    this.logger.log(this.formatRequestMessage(req));
+    const responseMessage: [string, number, string, string] = [
+      '[<==] %d %s %s',
+      res.statusCode,
+      contentLength,
+      contentType,
+    ];
 
     res.on('finish', () => {
       const { statusCode } = res;
-
-      if (statusCode <= 299) {
-        this.logger.log(this.formatResponseMessage(res));
-      } else if (statusCode >= 300 && statusCode <= 499) {
-        this.logger.warn(this.formatResponseMessage(res));
-      } else {
-        this.logger.error(this.formatResponseMessage(res));
-      }
+      if (statusCode < 400) {
+        winston.info(...responseMessage);
+      } else if (statusCode >= 400 && statusCode < 500) {
+        winston.warn(...responseMessage);
+      } else winston.error(...responseMessage);
     });
 
     next();

--- a/src/routes/transactions/mappers/common/safe-app-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/safe-app-info.mapper.ts
@@ -1,12 +1,12 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { SafeAppsRepository } from '../../../../domain/safe-apps/safe-apps.repository';
 import { ISafeAppsRepository } from '../../../../domain/safe-apps/safe-apps.repository.interface';
 import { MultisigTransaction } from '../../../../domain/safe/entities/multisig-transaction.entity';
 import { SafeAppInfo } from '../../entities/safe-app-info.entity';
+import * as winston from 'winston';
 
 @Injectable()
 export class SafeAppInfoMapper {
-  private readonly logger = new Logger(SafeAppInfoMapper.name);
   private static readonly IPFS_URL = 'ipfs.io';
   private static readonly CF_IPFS_URL = 'cloudflare-ipfs.com';
 
@@ -28,7 +28,7 @@ export class SafeAppInfoMapper {
       originUrl,
     );
     if (!safeApp) {
-      this.logger.warn(
+      winston.warn(
         `No Safe Apps matching the origin url ${originUrl} (safeTxHash: ${transaction.safeTxHash})`,
       );
       return null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -470,6 +470,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@dabh/diagnostics@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "@dabh/diagnostics@npm:2.0.3"
+  dependencies:
+    colorspace: 1.1.x
+    enabled: 2.0.x
+    kuler: ^2.0.0
+  checksum: 4879600c55c8315a0fb85fbb19057bad1adc08f0a080a8cb4e2b63f723c379bfc4283b68123a2b078d367b327dd8df12fcb27464efe791addc0a48b9df6d79a1
+  languageName: node
+  linkType: hard
+
 "@eslint/eslintrc@npm:^1.3.0":
   version: 1.3.0
   resolution: "@eslint/eslintrc@npm:1.3.0"
@@ -2056,6 +2067,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"async@npm:^3.2.3":
+  version: 3.2.4
+  resolution: "async@npm:3.2.4"
+  checksum: 43d07459a4e1d09b84a20772414aa684ff4de085cbcaec6eea3c7a8f8150e8c62aa6cd4e699fe8ee93c3a5b324e777d34642531875a0817a35697522c1b02e89
+  languageName: node
+  linkType: hard
+
 "asynckit@npm:^0.4.0":
   version: 0.4.0
   resolution: "asynckit@npm:0.4.0"
@@ -2532,7 +2550,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-convert@npm:^1.9.0":
+"color-convert@npm:^1.9.0, color-convert@npm:^1.9.3":
   version: 1.9.3
   resolution: "color-convert@npm:1.9.3"
   dependencies:
@@ -2557,10 +2575,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:~1.1.4":
+"color-name@npm:^1.0.0, color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: b0445859521eb4021cd0fb0cc1a75cecf67fceecae89b63f62b201cca8d345baf8b952c966862a9d9a2632987d4f6581f0ec8d957dfacece86f0a7919316f610
+  languageName: node
+  linkType: hard
+
+"color-string@npm:^1.6.0":
+  version: 1.9.1
+  resolution: "color-string@npm:1.9.1"
+  dependencies:
+    color-name: ^1.0.0
+    simple-swizzle: ^0.2.2
+  checksum: c13fe7cff7885f603f49105827d621ce87f4571d78ba28ef4a3f1a104304748f620615e6bf065ecd2145d0d9dad83a3553f52bb25ede7239d18e9f81622f1cc5
   languageName: node
   linkType: hard
 
@@ -2570,6 +2598,26 @@ __metadata:
   bin:
     color-support: bin.js
   checksum: 9b7356817670b9a13a26ca5af1c21615463b500783b739b7634a0c2047c16cef4b2865d7576875c31c3cddf9dd621fa19285e628f20198b233a5cfdda6d0793b
+  languageName: node
+  linkType: hard
+
+"color@npm:^3.1.3":
+  version: 3.2.1
+  resolution: "color@npm:3.2.1"
+  dependencies:
+    color-convert: ^1.9.3
+    color-string: ^1.6.0
+  checksum: f81220e8b774d35865c2561be921f5652117638dcda7ca4029262046e37fc2444ac7bbfdd110cf1fd9c074a4ee5eda8f85944ffbdda26186b602dd9bb05f6400
+  languageName: node
+  linkType: hard
+
+"colorspace@npm:1.1.x":
+  version: 1.1.4
+  resolution: "colorspace@npm:1.1.4"
+  dependencies:
+    color: ^3.1.3
+    text-hex: 1.0.x
+  checksum: bb3934ef3c417e961e6d03d7ca60ea6e175947029bfadfcdb65109b01881a1c0ecf9c2b0b59abcd0ee4a0d7c1eae93beed01b0e65848936472270a0b341ebce8
   languageName: node
   linkType: hard
 
@@ -2904,6 +2952,13 @@ __metadata:
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
   checksum: d4c5c39d5a9868b5fa152f00cada8a936868fd3367f33f71be515ecee4c803132d11b31a6222b2571b1e5f7e13890156a94880345594d0ce7e3c9895f560f192
+  languageName: node
+  linkType: hard
+
+"enabled@npm:2.0.x":
+  version: 2.0.0
+  resolution: "enabled@npm:2.0.0"
+  checksum: 9d256d89f4e8a46ff988c6a79b22fa814b4ffd82826c4fdacd9b42e9b9465709d3b748866d0ab4d442dfc6002d81de7f7b384146ccd1681f6a7f868d2acca063
   languageName: node
   linkType: hard
 
@@ -3349,6 +3404,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fecha@npm:^4.2.0":
+  version: 4.2.3
+  resolution: "fecha@npm:4.2.3"
+  checksum: f94e2fb3acf5a7754165d04549460d3ae6c34830394d20c552197e3e000035d69732d74af04b9bed3283bf29fe2a9ebdcc0085e640b0be3cc3658b9726265e31
+  languageName: node
+  linkType: hard
+
 "figures@npm:^3.0.0":
   version: 3.2.0
   resolution: "figures@npm:3.2.0"
@@ -3425,6 +3487,13 @@ __metadata:
   version: 3.2.6
   resolution: "flatted@npm:3.2.6"
   checksum: 33b87aa88dfa40ca6ee31d7df61712bbbad3d3c05c132c23e59b9b61d34631b337a18ff2b8dc5553acdc871ec72b741e485f78969cf006124a3f57174de29a0e
+  languageName: node
+  linkType: hard
+
+"fn.name@npm:1.x.x":
+  version: 1.1.0
+  resolution: "fn.name@npm:1.1.0"
+  checksum: e357144f48cfc9a7f52a82bbc6c23df7c8de639fce049cac41d41d62cabb740cdb9f14eddc6485e29c933104455bdd7a69bb14a9012cef9cd4fa252a4d0cf293
   languageName: node
   linkType: hard
 
@@ -4020,6 +4089,13 @@ __metadata:
   version: 0.2.1
   resolution: "is-arrayish@npm:0.2.1"
   checksum: eef4417e3c10e60e2c810b6084942b3ead455af16c4509959a27e490e7aee87cfb3f38e01bbde92220b528a0ee1a18d52b787e1458ee86174d8c7f0e58cd488f
+  languageName: node
+  linkType: hard
+
+"is-arrayish@npm:^0.3.1":
+  version: 0.3.2
+  resolution: "is-arrayish@npm:0.3.2"
+  checksum: 977e64f54d91c8f169b59afcd80ff19227e9f5c791fa28fa2e5bce355cbaf6c2c356711b734656e80c9dd4a854dd7efcf7894402f1031dfc5de5d620775b4d5f
   languageName: node
   linkType: hard
 
@@ -4743,6 +4819,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"kuler@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "kuler@npm:2.0.0"
+  checksum: 9e10b5a1659f9ed8761d38df3c35effabffbd19fc6107324095238e4ef0ff044392cae9ac64a1c2dda26e532426485342226b93806bd97504b174b0dcf04ed81
+  languageName: node
+  linkType: hard
+
 "leven@npm:^3.1.0":
   version: 3.1.0
   resolution: "leven@npm:3.1.0"
@@ -4820,6 +4903,19 @@ __metadata:
     chalk: ^4.1.0
     is-unicode-supported: ^0.1.0
   checksum: fce1497b3135a0198803f9f07464165e9eb83ed02ceb2273930a6f8a508951178d8cf4f0378e9d28300a2ed2bc49050995d2bd5f53ab716bb15ac84d58c6ef74
+  languageName: node
+  linkType: hard
+
+"logform@npm:^2.3.2, logform@npm:^2.4.0":
+  version: 2.4.2
+  resolution: "logform@npm:2.4.2"
+  dependencies:
+    "@colors/colors": 1.5.0
+    fecha: ^4.2.0
+    ms: ^2.1.1
+    safe-stable-stringify: ^2.3.1
+    triple-beam: ^1.3.0
+  checksum: 3d00f4e1ccaf0a86886aabbf66d1f1d207441d5b408f103457da6d64d055aee76c02af4b40a31ca77a1db4cbcdecb007149f731536c39cbd89b7b6ba3dda6d7b
   languageName: node
   linkType: hard
 
@@ -5128,7 +5224,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:2.1.3, ms@npm:^2.0.0":
+"ms@npm:2.1.3, ms@npm:^2.0.0, ms@npm:^2.1.1":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
@@ -5310,6 +5406,15 @@ __metadata:
   dependencies:
     wrappy: 1
   checksum: cd0a88501333edd640d95f0d2700fbde6bff20b3d4d9bdc521bdd31af0656b5706570d6c6afe532045a20bb8dc0849f8332d6f2a416e0ba6d3d3b98806c7db68
+  languageName: node
+  linkType: hard
+
+"one-time@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "one-time@npm:1.0.0"
+  dependencies:
+    fn.name: 1.x.x
+  checksum: fd008d7e992bdec1c67f53a2f9b46381ee12a9b8c309f88b21f0223546003fb47e8ad7c1fd5843751920a8d276c63bd4b45670ef80c61fb3e07dbccc962b5c7d
   languageName: node
   linkType: hard
 
@@ -5959,8 +6064,16 @@ __metadata:
     ts-node: ^10.0.0
     tsconfig-paths: 4.0.0
     typescript: ^4.7.4
+    winston: ^3.8.2
   languageName: unknown
   linkType: soft
+
+"safe-stable-stringify@npm:^2.3.1":
+  version: 2.4.2
+  resolution: "safe-stable-stringify@npm:2.4.2"
+  checksum: 0324ba2e40f78cae63e31a02b1c9bdf1b786621f9e8760845608eb9e81aef401944ac2078e5c9c1533cf516aea34d08fa8052ca853637ced84b791caaf1e394e
+  languageName: node
+  linkType: hard
 
 "safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
@@ -6103,6 +6216,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"simple-swizzle@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "simple-swizzle@npm:0.2.2"
+  dependencies:
+    is-arrayish: ^0.3.1
+  checksum: a7f3f2ab5c76c4472d5c578df892e857323e452d9f392e1b5cf74b74db66e6294a1e1b8b390b519fa1b96b5b613f2a37db6cffef52c3f1f8f3c5ea64eb2d54c0
+  languageName: node
+  linkType: hard
+
 "sisteransi@npm:^1.0.5":
   version: 1.0.5
   resolution: "sisteransi@npm:1.0.5"
@@ -6199,6 +6321,13 @@ __metadata:
   dependencies:
     minipass: ^3.1.1
   checksum: fb58f5e46b6923ae67b87ad5ef1c5ab6d427a17db0bead84570c2df3cd50b4ceb880ebdba2d60726588272890bae842a744e1ecce5bd2a2a582fccd5068309eb
+  languageName: node
+  linkType: hard
+
+"stack-trace@npm:0.0.x":
+  version: 0.0.10
+  resolution: "stack-trace@npm:0.0.10"
+  checksum: 473036ad32f8c00e889613153d6454f9be0536d430eb2358ca51cad6b95cea08a3cc33cc0e34de66b0dad221582b08ed2e61ef8e13f4087ab690f388362d6610
   languageName: node
   linkType: hard
 
@@ -6466,6 +6595,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"text-hex@npm:1.0.x":
+  version: 1.0.0
+  resolution: "text-hex@npm:1.0.0"
+  checksum: 1138f68adc97bf4381a302a24e2352f04992b7b1316c5003767e9b0d3367ffd0dc73d65001ea02b07cd0ecc2a9d186de0cf02f3c2d880b8a522d4ccb9342244a
+  languageName: node
+  linkType: hard
+
 "text-table@npm:^0.2.0":
   version: 0.2.0
   resolution: "text-table@npm:0.2.0"
@@ -6532,6 +6668,13 @@ __metadata:
   bin:
     tree-kill: cli.js
   checksum: 49117f5f410d19c84b0464d29afb9642c863bc5ba40fcb9a245d474c6d5cc64d1b177a6e6713129eb346b40aebb9d4631d967517f9fbe8251c35b21b13cd96c7
+  languageName: node
+  linkType: hard
+
+"triple-beam@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "triple-beam@npm:1.3.0"
+  checksum: 7d7b77d8625fb252c126c24984a68de462b538a8fcd1de2abd0a26421629cf3527d48e23b3c2264f08f4a6c3bc40a478a722176f4d7b6a1acc154cb70c359f2b
   languageName: node
   linkType: hard
 
@@ -6976,6 +7119,36 @@ __metadata:
   dependencies:
     execa: ^4.0.2
   checksum: 77c87d332d9e8ad94a72844c0bee169babd63ab06636521fc6ffacb2f1fb2ec3f38b81bc3fcb53ec76b57c1add33348c16660a38ac6aed381190d9c2b95c39e6
+  languageName: node
+  linkType: hard
+
+"winston-transport@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "winston-transport@npm:4.5.0"
+  dependencies:
+    logform: ^2.3.2
+    readable-stream: ^3.6.0
+    triple-beam: ^1.3.0
+  checksum: a56e5678a80b88a73e77ed998fc6e19d0db19c989a356b137ec236782f2bf58ae4511b11c29163f99391fa4dc12102c7bc5738dcb6543f28877fa2819adc3ee9
+  languageName: node
+  linkType: hard
+
+"winston@npm:^3.8.2":
+  version: 3.8.2
+  resolution: "winston@npm:3.8.2"
+  dependencies:
+    "@colors/colors": 1.5.0
+    "@dabh/diagnostics": ^2.0.2
+    async: ^3.2.3
+    is-stream: ^2.0.0
+    logform: ^2.4.0
+    one-time: ^1.0.0
+    readable-stream: ^3.4.0
+    safe-stable-stringify: ^2.3.1
+    stack-trace: 0.0.x
+    triple-beam: ^1.3.0
+    winston-transport: ^4.5.0
+  checksum: f7b901798b92ab9e93c850110bf6e98500e9a0e762b62dab410cf928b2a4145533dfa6d3d2b24f7bf0dc94b53808d5bd28aaaeff9a4b43b89ea4c798cce308ea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #266

- Introduce winston as the main logger for the application – https://github.com/winstonjs/winston
- Winston was chosen due to its support and direct mention from the team behind NestJS – https://docs.nestjs.com/techniques/logger#use-external-logger
- The goal is to introduce a logger which can provide more flexibility in the logging process including support for multiple transports and the possibility to have different loggers (e.g.: one for local development purposes on top of the production one).
- Currently the application only uses one Winston instance – i.e. the default logger – https://github.com/winstonjs/winston#using-the-default-logger (this is subject to change as we refine the final format for our logs)
- This does not change the current log format in the application – this is something outside the scope of this change.