### PR TITLE
Push ARM64 and AMD64 Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2.1.0
+        with:
+          platforms: arm64
       - uses: docker/setup-buildx-action@v2
       - uses: docker/login-action@v2
         with:
@@ -90,6 +93,7 @@ jobs:
         env:
           DOCKER_IMAGE_TAG: safeglobal/safe-client-gateway-nest:staging
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ env.DOCKER_IMAGE_TAG }}
           # Use inline cache storage https://docs.docker.com/build/cache/backends/inline/


### PR DESCRIPTION
- `docker-publish` now publishes both `linux/amd64` and `linux/arm64` images.