### PR TITLE
Implement POST /v1/chains/:chainId/messages/:messageHash/signatures

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -535,4 +535,17 @@ export class TransactionApi implements ITransactionApi {
       throw this.httpErrorFactory.from(error);
     }
   }
+
+  async postMessageSignature(
+    messageHash: string,
+    signature: string,
+  ): Promise<unknown> {
+    try {
+      const url = `${this.baseUrl}/api/v1/messages/${messageHash}/signatures/`;
+      const { data } = await this.networkService.post(url, { signature });
+      return data;
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
 }

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -164,4 +164,9 @@ export interface ITransactionApi {
     safeAppId: number | null,
     signature: string,
   ): Promise<Message>;
+
+  postMessageSignature(
+    messageHash: string,
+    signature: string,
+  ): Promise<unknown>;
 }

--- a/src/domain/messages/messages.repository.interface.ts
+++ b/src/domain/messages/messages.repository.interface.ts
@@ -20,4 +20,10 @@ export interface IMessagesRepository {
     safeAppId: number,
     signature: string,
   ): Promise<Message>;
+
+  updateMessageSignature(
+    chainId: string,
+    messageHash: string,
+    signature: string,
+  ): Promise<unknown>;
 }

--- a/src/domain/messages/messages.repository.ts
+++ b/src/domain/messages/messages.repository.ts
@@ -57,4 +57,15 @@ export class MessagesRepository implements IMessagesRepository {
     );
     return this.messageValidator.validate(createdMessage);
   }
+
+  async updateMessageSignature(
+    chainId: string,
+    messageHash: string,
+    signature: string,
+  ): Promise<unknown> {
+    const transactionService =
+      await this.transactionApiManager.getTransactionApi(chainId);
+
+    return transactionService.postMessageSignature(messageHash, signature);
+  }
 }

--- a/src/routes/messages/entities/__tests__/update-message-signature.dto.builder.ts
+++ b/src/routes/messages/entities/__tests__/update-message-signature.dto.builder.ts
@@ -1,0 +1,10 @@
+import { faker } from '@faker-js/faker';
+import { Builder, IBuilder } from '../../../../__tests__/builder';
+import { UpdateMessageSignatureDto } from '../update-message-signature.entity';
+
+export function updateMessageSignatureDtoBuilder(): IBuilder<UpdateMessageSignatureDto> {
+  return Builder.new<UpdateMessageSignatureDto>().with(
+    'signature',
+    faker.datatype.hexadecimal(32),
+  );
+}

--- a/src/routes/messages/entities/schemas/update-message-signature.dto.schema.ts
+++ b/src/routes/messages/entities/schemas/update-message-signature.dto.schema.ts
@@ -1,0 +1,12 @@
+import { JSONSchemaType } from 'ajv';
+import { UpdateMessageSignatureDto } from '../update-message-signature.entity';
+
+export const updateMessageSignatureDtoSchema: JSONSchemaType<UpdateMessageSignatureDto> =
+  {
+    $id: 'https://safe-client.safe.global/schemas/messages/update-message-signature.dto.json',
+    type: 'object',
+    properties: {
+      signature: { type: 'string' },
+    },
+    required: ['signature'],
+  };

--- a/src/routes/messages/entities/update-message-signature.entity.ts
+++ b/src/routes/messages/entities/update-message-signature.entity.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateMessageSignatureDto {
+  @ApiProperty()
+  signature: string;
+}

--- a/src/routes/messages/messages.controller.ts
+++ b/src/routes/messages/messages.controller.ts
@@ -10,8 +10,10 @@ import { CreatedMessage } from './entities/created-message.entity';
 import { MessageItem } from './entities/message-item.entity';
 import { Message } from './entities/message.entity';
 import { MessagePage } from './entities/messages-page.entity';
+import { UpdateMessageSignatureDto } from './entities/update-message-signature.entity';
 import { MessagesService } from './messages.service';
 import { CreateMessageDtoValidationPipe } from './pipes/create-message.dto.validation.pipe';
+import { UpdateMessageSignatureDtoValidationPipe } from './pipes/update-message-signature.dto.validation.pipe';
 
 @ApiTags('messages')
 @Controller({
@@ -59,6 +61,21 @@ export class MessagesController {
       chainId,
       safeAddress,
       createMessageDto,
+    );
+  }
+
+  @HttpCode(200)
+  @Post('chains/:chainId/messages/:messageHash/signatures')
+  async updateMessageSignature(
+    @Param('chainId') chainId: string,
+    @Param('messageHash') messageHash: string,
+    @Body(UpdateMessageSignatureDtoValidationPipe)
+    updateMessageSignatureDto: UpdateMessageSignatureDto,
+  ): Promise<unknown> {
+    return this.messagesService.updateMessageSignature(
+      chainId,
+      messageHash,
+      updateMessageSignatureDto,
     );
   }
 }

--- a/src/routes/messages/messages.service.ts
+++ b/src/routes/messages/messages.service.ts
@@ -15,6 +15,7 @@ import { CreateMessageDto } from './entities/create-message.dto.entity';
 import { CreatedMessage } from './entities/created-message.entity';
 import { MessageItem } from './entities/message-item.entity';
 import { Message } from './entities/message.entity';
+import { UpdateMessageSignatureDto } from './entities/update-message-signature.entity';
 import { MessageMapper } from './mappers/message-mapper';
 
 @Injectable()
@@ -117,6 +118,18 @@ export class MessagesService {
       createMessageDto.message,
       createMessageDto.safeAppId,
       createMessageDto.signature,
+    );
+  }
+
+  async updateMessageSignature(
+    chainId: string,
+    messageHash: string,
+    updateMessageSignatureDto: UpdateMessageSignatureDto,
+  ): Promise<unknown> {
+    return await this.messagesRepository.updateMessageSignature(
+      chainId,
+      messageHash,
+      updateMessageSignatureDto.signature,
     );
   }
 }

--- a/src/routes/messages/pipes/update-message-signature.dto.validation.pipe.ts
+++ b/src/routes/messages/pipes/update-message-signature.dto.validation.pipe.ts
@@ -1,0 +1,32 @@
+import { HttpStatus, Injectable, PipeTransform } from '@nestjs/common';
+import { ValidateFunction } from 'ajv';
+import { GenericValidator } from '../../../validation/providers/generic.validator';
+import { JsonSchemaService } from '../../../validation/providers/json-schema.service';
+import { updateMessageSignatureDtoSchema } from '../entities/schemas/update-message-signature.dto.schema';
+import { UpdateMessageSignatureDto } from '../entities/update-message-signature.entity';
+
+@Injectable()
+export class UpdateMessageSignatureDtoValidationPipe
+  implements PipeTransform<any, UpdateMessageSignatureDto>
+{
+  private readonly isValid: ValidateFunction<UpdateMessageSignatureDto>;
+
+  constructor(
+    private readonly genericValidator: GenericValidator,
+    private readonly jsonSchemaService: JsonSchemaService,
+  ) {
+    this.isValid = this.jsonSchemaService.getSchema(
+      'https://safe-client.safe.global/schemas/messages/update-message-signature.dto.json',
+      updateMessageSignatureDtoSchema,
+    );
+  }
+
+  transform(data: any): UpdateMessageSignatureDto {
+    try {
+      return this.genericValidator.validate(this.isValid, data);
+    } catch (err) {
+      err.status = HttpStatus.BAD_REQUEST;
+      throw err;
+    }
+  }
+}


### PR DESCRIPTION
Closes #259 

Adds the POST endpoint `/v1/chains/:chainId/messages/:messageHash/signatures`

- Unit (controller) tests were added for the route
- OpenAPI specification was added.