### PR TITLE
Extract cache directions calculation

### DIFF
--- a/src/datasources/cache/__tests__/fake.cache.service.spec.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.spec.ts
@@ -1,3 +1,5 @@
+import { faker } from '@faker-js/faker';
+import { CacheDir } from '../entities/cache-dir.entity';
 import { FakeCacheService } from './fake.cache.service';
 
 describe('FakeCacheService', () => {
@@ -8,32 +10,38 @@ describe('FakeCacheService', () => {
   });
 
   it(`sets key`, async () => {
-    const key = 'test-key';
-    const field = 'test-field';
-    const value = 'some-value';
+    const cacheDir = new CacheDir(
+      faker.random.alphaNumeric(),
+      faker.random.alphaNumeric(),
+    );
+    const value = faker.random.alphaNumeric();
 
-    await target.set(key, field, value, 0);
+    await target.set(cacheDir, value, 0);
 
-    await expect(target.get(key, field)).resolves.toBe(value);
+    await expect(target.get(cacheDir)).resolves.toBe(value);
     expect(target.keyCount()).toBe(1);
   });
 
   it(`deletes key`, async () => {
-    const key = 'test-key';
-    const field = 'test-field';
-    const value = 'some-value';
+    const cacheDir = new CacheDir(
+      faker.random.alphaNumeric(),
+      faker.random.alphaNumeric(),
+    );
+    const value = faker.random.alphaNumeric();
 
-    await target.set(key, field, value, 0);
-    await target.delete(key);
+    await target.set(cacheDir, value, 0);
+    await target.delete(cacheDir.key);
 
-    await expect(target.get(key, field)).resolves.toBe(undefined);
+    await expect(target.get(cacheDir)).resolves.toBe(undefined);
     expect(target.keyCount()).toBe(0);
   });
 
   it(`clears keys`, async () => {
     const actions: Promise<void>[] = [];
     for (let i = 0; i < 5; i++) {
-      actions.push(target.set(`key${i}`, `field${i}`, `value${i}`, 0));
+      actions.push(
+        target.set(new CacheDir(`key${i}`, `field${i}`), `value${i}`, 0),
+      );
     }
 
     await Promise.all(actions);

--- a/src/datasources/cache/__tests__/fake.cache.service.spec.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.spec.ts
@@ -30,7 +30,7 @@ describe('FakeCacheService', () => {
     const value = faker.random.alphaNumeric();
 
     await target.set(cacheDir, value, 0);
-    await target.delete(cacheDir.key);
+    await target.delete(cacheDir);
 
     await expect(target.get(cacheDir)).resolves.toBe(undefined);
     expect(target.keyCount()).toBe(0);

--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -12,8 +12,8 @@ export class FakeCacheService implements ICacheService {
     this.cache = {};
   }
 
-  delete(key: string): Promise<number> {
-    delete this.cache[key];
+  delete(cacheDir: CacheDir): Promise<number> {
+    delete this.cache[cacheDir.key];
     return Promise.resolve(1);
   }
 

--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -1,4 +1,5 @@
 import { ICacheService } from '../cache.service.interface';
+import { CacheDir } from '../entities/cache-dir.entity';
 
 export class FakeCacheService implements ICacheService {
   private cache: Record<string, Record<string, any>> = {};
@@ -16,24 +17,23 @@ export class FakeCacheService implements ICacheService {
     return Promise.resolve(1);
   }
 
-  get(key: string, field: string): Promise<string | undefined> {
-    const fields = this.cache[key];
+  get(cacheDir: CacheDir): Promise<string | undefined> {
+    const fields = this.cache[cacheDir.key];
     if (fields === undefined) return Promise.resolve(undefined);
-    return Promise.resolve(this.cache[key][field]);
+    return Promise.resolve(this.cache[cacheDir.key][cacheDir.field]);
   }
 
   set(
-    key: string,
-    field: string,
+    cacheDir: CacheDir,
     value: string,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     expireTimeSeconds?: number,
   ): Promise<void> {
-    const fields = this.cache[key];
+    const fields = this.cache[cacheDir.key];
     if (fields === undefined) {
-      this.cache[key] = {};
+      this.cache[cacheDir.key] = {};
     }
-    this.cache[key][field] = value;
+    this.cache[cacheDir.key][cacheDir.field] = value;
     return Promise.resolve();
   }
 }

--- a/src/datasources/cache/cache.first.data.source.ts
+++ b/src/datasources/cache/cache.first.data.source.ts
@@ -1,11 +1,12 @@
+import { Inject, Injectable } from '@nestjs/common';
+import * as winston from 'winston';
 import { NetworkRequest } from '../network/entities/network.request.entity';
-import { CacheService, ICacheService } from './cache.service.interface';
 import {
   INetworkService,
   NetworkService,
 } from '../network/network.service.interface';
-import { Inject, Injectable } from '@nestjs/common';
-import * as winston from 'winston';
+import { CacheService, ICacheService } from './cache.service.interface';
+import { CacheDir } from './entities/cache-dir.entity';
 
 /**
  * A data source which tries to retrieve values from cache using
@@ -24,34 +25,36 @@ export class CacheFirstDataSource {
   ) {}
 
   /**
-   * Gets the cached value behind the {@link field} of {@link key}.
+   * Gets the cached value behind the {@link CacheDir}.
    * If the value is not present, it tries to get the respective JSON
    * payload from {@link url}.
    * Errors are not cached.
    *
-   * @param key - the key to be used to retrieve from cache
-   * @param field - the field to get from {@link key}
+   * @param cacheDir - {@link CacheDir} containing the key and field to be used to retrieve from cache
    * @param url - the HTTP endpoint to retrieve the JSON payload
    * @param params - the parameters to be used for the HTTP request
    * @param expireTimeSeconds - the time to live in seconds for the payload
    * behind {@link key}
    */
   async get<T>(
-    key: string,
-    field: string,
+    cacheDir: CacheDir,
     url: string,
     params?: NetworkRequest,
     expireTimeSeconds?: number,
   ): Promise<T> {
-    const cached = await this.cacheService.get(key, field);
+    const cached = await this.cacheService.get(cacheDir);
     if (cached != null) {
-      winston.debug(`[Cache] Cache hit: ${key}`);
+      winston.debug(`[Cache] Cache hit: ${cacheDir.key}`);
       return JSON.parse(cached);
     }
-    winston.debug(`[Cache] Cache miss: ${key}`);
+    winston.debug(`[Cache] Cache miss: ${cacheDir.key}`);
     const { data } = await this.networkService.get(url, params);
     const rawJson = JSON.stringify(data);
-    await this.cacheService.set(key, field, rawJson, expireTimeSeconds);
+    await this.cacheService.set(
+      new CacheDir(cacheDir.key, cacheDir.field),
+      rawJson,
+      expireTimeSeconds,
+    );
     return data;
   }
 }

--- a/src/datasources/cache/cache.first.data.source.ts
+++ b/src/datasources/cache/cache.first.data.source.ts
@@ -1,11 +1,11 @@
-import { Inject, Injectable } from '@nestjs/common';
-import * as winston from 'winston';
 import { NetworkRequest } from '../network/entities/network.request.entity';
+import { CacheService, ICacheService } from './cache.service.interface';
 import {
   INetworkService,
   NetworkService,
 } from '../network/network.service.interface';
-import { CacheService, ICacheService } from './cache.service.interface';
+import { Inject, Injectable } from '@nestjs/common';
+import * as winston from 'winston';
 import { CacheDir } from './entities/cache-dir.entity';
 
 /**

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -24,13 +24,6 @@ export class CacheRouter {
   private static readonly TOKENS_KEY = 'tokens';
   private static readonly TRANSFERS_KEY = 'transfers';
 
-  static balanceCacheKey(chainId: string, safeAddress: string): CacheDir {
-    return new CacheDir(
-      `${chainId}_${safeAddress}_${CacheRouter.BALANCES_KEY}`,
-      '',
-    );
-  }
-
   static getBalanceCacheDir(
     chainId: string,
     safeAddress: string,

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -1,0 +1,265 @@
+import { CacheDir } from './entities/cache-dir.entity';
+
+export class CacheRouter {
+  private static readonly ALL_TRANSACTIONS_KEY = 'all_transactions';
+  private static readonly BACKBONE_KEY = 'backbone';
+  private static readonly BALANCES_KEY = 'balances';
+  private static readonly CHAIN_KEY = 'chain';
+  private static readonly CHAINS_KEY = 'chains';
+  private static readonly COLLECTIBLES_KEY = 'collectibles';
+  private static readonly CONTRACT_KEY = 'contract';
+  private static readonly CREATION_TRANSACTION_KEY = 'creation_transaction';
+  private static readonly DELEGATES_KEY = 'delegates';
+  private static readonly INCOMING_TRANSFERS_KEY = 'incoming_transfers';
+  private static readonly MASTER_COPIES_KEY = 'master-copies';
+  private static readonly MESSAGE_KEY = 'message';
+  private static readonly MESSAGES_KEY = 'messages';
+  private static readonly MODULE_TRANSACTIONS_KEY = 'module_transactions';
+  private static readonly MULTISIG_TRANSACTION_KEY = 'multisig_transaction';
+  private static readonly MULTISIG_TRANSACTIONS_KEY = 'multisig_transactions';
+  private static readonly OWNERS_SAFE_KEY = 'owner_safes';
+  private static readonly SAFE_APPS_KEY = 'safe_apps';
+  private static readonly SAFE_KEY = 'safe';
+  private static readonly TOKEN_KEY = 'token';
+  private static readonly TOKENS_KEY = 'tokens';
+  private static readonly TRANSFERS_KEY = 'transfers';
+
+  static balanceCacheKey(chainId: string, safeAddress: string): CacheDir {
+    return new CacheDir(
+      `${chainId}_${safeAddress}_${CacheRouter.BALANCES_KEY}`,
+      '',
+    );
+  }
+
+  static getBalanceCacheDir(
+    chainId: string,
+    safeAddress: string,
+    trusted?: boolean,
+    excludeSpam?: boolean,
+  ): CacheDir {
+    return new CacheDir(
+      `${chainId}_${safeAddress}_${CacheRouter.BALANCES_KEY}`,
+      `${trusted}_${excludeSpam}`,
+    );
+  }
+
+  static getSafeCacheDir(chainId: string, safeAddress: string): CacheDir {
+    return new CacheDir(
+      `${chainId}_${safeAddress}_${CacheRouter.SAFE_KEY}`,
+      '',
+    );
+  }
+
+  static getContractCacheDir(
+    chainId: string,
+    contractAddress: string,
+  ): CacheDir {
+    return new CacheDir(
+      `${chainId}_${contractAddress}_${CacheRouter.CONTRACT_KEY}`,
+      '',
+    );
+  }
+
+  static getBackboneCacheDir(chainId: string): CacheDir {
+    return new CacheDir(`${chainId}_${CacheRouter.BACKBONE_KEY}`, '');
+  }
+
+  static getMasterCopiesCacheDir(chainId: string): CacheDir {
+    return new CacheDir(`${chainId}_${CacheRouter.MASTER_COPIES_KEY}`, '');
+  }
+
+  static getCollectiblesCacheDir(
+    chainId: string,
+    safeAddress: string,
+    limit?: number,
+    offset?: number,
+    trusted?: boolean,
+    excludeSpam?: boolean,
+  ): CacheDir {
+    return new CacheDir(
+      `${chainId}_${safeAddress}_${CacheRouter.COLLECTIBLES_KEY}`,
+      `${limit}_${offset}_${trusted}_${excludeSpam}`,
+    );
+  }
+
+  static getDelegatesCacheDir(
+    chainId: string,
+    safeAddress?: string,
+    delegate?: string,
+    delegator?: string,
+    label?: string,
+    limit?: number,
+    offset?: number,
+  ): CacheDir {
+    return new CacheDir(
+      `${chainId}_${CacheRouter.DELEGATES_KEY}`,
+      `${safeAddress}_${delegate}_${delegator}_${label}_${limit}_${offset}`,
+    );
+  }
+
+  static getTransfersCacheDir(
+    chainId: string,
+    safeAddress: string,
+    onlyErc20: boolean,
+    onlyErc721: boolean,
+    limit?: number,
+    offset?: number,
+  ): CacheDir {
+    return new CacheDir(
+      `${chainId}_${safeAddress}_${CacheRouter.TRANSFERS_KEY}`,
+      `${onlyErc20}_${onlyErc721}_${limit}_${offset}`,
+    );
+  }
+
+  static getModuleTransactionsCacheDir(
+    chainId: string,
+    safeAddress: string,
+    to?: string,
+    module?: string,
+    limit?: number,
+    offset?: number,
+  ): CacheDir {
+    return new CacheDir(
+      `${chainId}_${safeAddress}_${CacheRouter.MODULE_TRANSACTIONS_KEY}`,
+      `${to}_${module}_${limit}_${offset}`,
+    );
+  }
+
+  static getIncomingTransfersCacheDir(
+    chainId: string,
+    safeAddress: string,
+    executionDateGte?: string,
+    executionDateLte?: string,
+    to?: string,
+    value?: string,
+    tokenAddress?: string,
+    limit?: number,
+    offset?: number,
+  ): CacheDir {
+    return new CacheDir(
+      `${chainId}_${safeAddress}_${CacheRouter.INCOMING_TRANSFERS_KEY}`,
+      `${executionDateGte}_${executionDateLte}_${to}_${value}_${tokenAddress}_${limit}_${offset}`,
+    );
+  }
+
+  static getMultisigTransactionsCacheDir(
+    chainId: string,
+    safeAddress: string,
+    ordering?: string,
+    executed?: boolean,
+    trusted?: boolean,
+    executionDateGte?: string,
+    executionDateLte?: string,
+    to?: string,
+    value?: string,
+    nonce?: string,
+    limit?: number,
+    offset?: number,
+  ): CacheDir {
+    return new CacheDir(
+      `${chainId}_${safeAddress}_${CacheRouter.MULTISIG_TRANSACTIONS_KEY}`,
+      `${ordering}_${executed}_${trusted}_${executionDateGte}_${executionDateLte}_${to}_${value}_${nonce}_${limit}_${offset}`,
+    );
+  }
+
+  static getMultisigTransactionCacheDir(
+    chainId: string,
+    safeTransactionHash: string,
+  ): CacheDir {
+    return new CacheDir(
+      `${chainId}_${safeTransactionHash}_${CacheRouter.MULTISIG_TRANSACTION_KEY}`,
+      '',
+    );
+  }
+
+  static getCreationTransactionCacheDir(
+    chainId: string,
+    safeAddress: string,
+  ): CacheDir {
+    return new CacheDir(
+      `${chainId}_${safeAddress}_${CacheRouter.CREATION_TRANSACTION_KEY}`,
+      '',
+    );
+  }
+
+  static getAllTransactionsCacheDir(
+    chainId: string,
+    safeAddress: string,
+    ordering?: string,
+    executed?: boolean,
+    queued?: boolean,
+    limit?: number,
+    offset?: number,
+  ): CacheDir {
+    return new CacheDir(
+      `${chainId}_${safeAddress}_${CacheRouter.ALL_TRANSACTIONS_KEY}`,
+      `${ordering}_${executed}_${queued}_${limit}_${offset}`,
+    );
+  }
+
+  static getTokenCacheDir(chainId: string, address: string): CacheDir {
+    return new CacheDir(`${chainId}_${address}_${CacheRouter.TOKEN_KEY}`, '');
+  }
+
+  static getTokensCacheDir(
+    chainId: string,
+    limit?: number,
+    offset?: number,
+  ): CacheDir {
+    return new CacheDir(
+      `${chainId}_${CacheRouter.TOKENS_KEY}`,
+      `${limit}_${offset}`,
+    );
+  }
+
+  static getSafesByOwnerCacheDir(
+    chainId: string,
+    ownerAddress: string,
+  ): CacheDir {
+    return new CacheDir(
+      `${chainId}_${ownerAddress}_${CacheRouter.OWNERS_SAFE_KEY}`,
+      '',
+    );
+  }
+
+  static getMessageByHashCacheDir(
+    chainId: string,
+    messageHash: string,
+  ): CacheDir {
+    return new CacheDir(
+      `${chainId}_${messageHash}_${CacheRouter.MESSAGE_KEY}`,
+      '',
+    );
+  }
+
+  static getMessagesBySafeCacheDir(
+    chainId: string,
+    safeAddress: string,
+    limit?: number,
+    offset?: number,
+  ): CacheDir {
+    return new CacheDir(
+      `${chainId}_${safeAddress}_${CacheRouter.MESSAGES_KEY}`,
+      `${limit}_${offset}`,
+    );
+  }
+
+  static getChainsCacheDir(limit?: number, offset?: number): CacheDir {
+    return new CacheDir(CacheRouter.CHAINS_KEY, `${limit}_${offset}`);
+  }
+
+  static getChainCacheDir(chainId: string): CacheDir {
+    return new CacheDir(`${chainId}_${CacheRouter.CHAIN_KEY}`, '');
+  }
+
+  static getSafeAppsCacheDir(
+    chainId?: string,
+    clientUrl?: string,
+    url?: string,
+  ): CacheDir {
+    return new CacheDir(
+      CacheRouter.SAFE_APPS_KEY,
+      `${chainId}_${clientUrl}_${url}`,
+    );
+  }
+}

--- a/src/datasources/cache/cache.service.interface.ts
+++ b/src/datasources/cache/cache.service.interface.ts
@@ -1,14 +1,15 @@
+import { CacheDir } from './entities/cache-dir.entity';
+
 export const CacheService = Symbol('ICacheService');
 
 export interface ICacheService {
   set(
-    key: string,
-    field: string,
+    cacheDir: CacheDir,
     value: string,
     expireTimeSeconds?: number,
   ): Promise<void>;
 
-  get(key: string, field: string): Promise<string | undefined>;
+  get(cacheDir: CacheDir): Promise<string | undefined>;
 
   delete(key: string): Promise<number>;
 }

--- a/src/datasources/cache/cache.service.interface.ts
+++ b/src/datasources/cache/cache.service.interface.ts
@@ -11,5 +11,5 @@ export interface ICacheService {
 
   get(cacheDir: CacheDir): Promise<string | undefined>;
 
-  delete(key: string): Promise<number>;
+  delete(cacheDir: CacheDir): Promise<number>;
 }

--- a/src/datasources/cache/entities/cache-dir.entity.ts
+++ b/src/datasources/cache/entities/cache-dir.entity.ts
@@ -1,0 +1,9 @@
+export class CacheDir {
+  key: string;
+  field: string;
+
+  constructor(key: string, field: string) {
+    this.key = key;
+    this.field = field;
+  }
+}

--- a/src/datasources/cache/entities/cache-dir.entity.ts
+++ b/src/datasources/cache/entities/cache-dir.entity.ts
@@ -1,6 +1,6 @@
 export class CacheDir {
-  key: string;
-  field: string;
+  readonly key: string;
+  readonly field: string;
 
   constructor(key: string, field: string) {
     this.key = key;

--- a/src/datasources/cache/redis.cache.service.spec.ts
+++ b/src/datasources/cache/redis.cache.service.spec.ts
@@ -159,9 +159,12 @@ describe('RedisCacheService', () => {
   });
 
   it(`Deleting key calls delete`, async () => {
-    const key = faker.random.alphaNumeric();
+    const cacheDir = new CacheDir(
+      faker.random.alphaNumeric(),
+      faker.datatype.string(),
+    );
 
-    await redisCacheService.delete(key);
+    await redisCacheService.delete(cacheDir);
 
     expect(redisClientTypeMock.unlink).toBeCalledTimes(1);
     expect(redisClientTypeMock.hGet).toBeCalledTimes(0);

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -1,8 +1,9 @@
 import { Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
-import { ICacheService } from './cache.service.interface';
-import { RedisClientType } from './cache.module';
-import { IConfigurationService } from '../../config/configuration.service.interface';
 import * as winston from 'winston';
+import { IConfigurationService } from '../../config/configuration.service.interface';
+import { RedisClientType } from './cache.module';
+import { ICacheService } from './cache.service.interface';
+import { CacheDir } from './entities/cache-dir.entity';
 
 @Injectable()
 export class RedisCacheService implements ICacheService, OnModuleDestroy {
@@ -20,25 +21,24 @@ export class RedisCacheService implements ICacheService, OnModuleDestroy {
   }
 
   async set(
-    key: string,
-    field: string,
+    cacheDir: CacheDir,
     value: string,
     expireTimeSeconds?: number,
   ): Promise<void> {
     try {
-      await this.client.hSet(key, field, value);
+      await this.client.hSet(cacheDir.key, cacheDir.field, value);
       await this.client.expire(
-        key,
+        cacheDir.key,
         expireTimeSeconds ?? this.defaultExpirationTimeInSeconds,
       );
     } catch (error) {
-      await this.client.hDel(key, field);
+      await this.client.hDel(cacheDir.key, cacheDir.field);
       throw error;
     }
   }
 
-  async get(key: string, field: string): Promise<string | undefined> {
-    return await this.client.hGet(key, field);
+  async get(cacheDir: CacheDir): Promise<string | undefined> {
+    return await this.client.hGet(cacheDir.key, cacheDir.field);
   }
 
   async delete(key: string): Promise<number> {

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -41,9 +41,9 @@ export class RedisCacheService implements ICacheService, OnModuleDestroy {
     return await this.client.hGet(cacheDir.key, cacheDir.field);
   }
 
-  async delete(key: string): Promise<number> {
+  async delete(cacheDir: CacheDir): Promise<number> {
     // see https://redis.io/commands/unlink/
-    return await this.client.unlink(key);
+    return await this.client.unlink(cacheDir.key);
   }
 
   /**

--- a/src/datasources/config-api/config-api.service.spec.ts
+++ b/src/datasources/config-api/config-api.service.spec.ts
@@ -6,6 +6,7 @@ import { DataSourceError } from '../../domain/errors/data-source.error';
 import { faker } from '@faker-js/faker';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { safeAppBuilder } from '../../domain/safe-apps/entities/__tests__/safe-app.builder';
+import { CacheDir } from '../cache/entities/cache-dir.entity';
 
 const dataSource = {
   get: jest.fn(),
@@ -58,8 +59,7 @@ describe('ConfigApi', () => {
     expect(actual).toBe(data);
     expect(mockDataSource.get).toBeCalledTimes(1);
     expect(mockDataSource.get).toBeCalledWith(
-      'chains',
-      'undefined_undefined',
+      new CacheDir('chains', 'undefined_undefined'),
       `${baseUri}/api/v1/chains`,
       { params: { limit: undefined, offset: undefined } },
     );
@@ -75,8 +75,7 @@ describe('ConfigApi', () => {
     expect(actual).toBe(data);
     expect(mockDataSource.get).toBeCalledTimes(1);
     expect(mockDataSource.get).toBeCalledWith(
-      `${data.chainId}_chain`,
-      '',
+      new CacheDir(`${data.chainId}_chain`, ''),
       `${baseUri}/api/v1/chains/${data.chainId}`,
     );
     expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
@@ -92,8 +91,7 @@ describe('ConfigApi', () => {
     expect(actual).toBe(data);
     expect(mockDataSource.get).toBeCalledTimes(1);
     expect(mockDataSource.get).toBeCalledWith(
-      `safe_apps`,
-      `${chainId}_undefined_undefined`,
+      new CacheDir(`safe_apps`, `${chainId}_undefined_undefined`),
       `${baseUri}/api/v1/safe-apps/`,
       { params: { chainId, clientUrl: undefined, url: undefined } },
     );
@@ -111,8 +109,7 @@ describe('ConfigApi', () => {
     expect(actual).toBe(data);
     expect(mockDataSource.get).toBeCalledTimes(1);
     expect(mockDataSource.get).toBeCalledWith(
-      `safe_apps`,
-      `${chainId}_undefined_${url}`,
+      new CacheDir(`safe_apps`, `${chainId}_undefined_${url}`),
       `${baseUri}/api/v1/safe-apps/`,
       { params: { chainId, clientUrl: undefined, url } },
     );
@@ -130,8 +127,7 @@ describe('ConfigApi', () => {
     expect(actual).toBe(data);
     expect(mockDataSource.get).toBeCalledTimes(1);
     expect(mockDataSource.get).toBeCalledWith(
-      `safe_apps`,
-      `${chainId}_${clientUrl}_undefined`,
+      new CacheDir(`safe_apps`, `${chainId}_${clientUrl}_undefined`),
       `${baseUri}/api/v1/safe-apps/`,
       { params: { chainId, clientUrl, url: undefined } },
     );

--- a/src/datasources/config-api/config-api.service.ts
+++ b/src/datasources/config-api/config-api.service.ts
@@ -25,16 +25,9 @@ export class ConfigApi implements IConfigApi {
   async getChains(limit?: number, offset?: number): Promise<Page<Chain>> {
     try {
       const url = `${this.baseUri}/api/v1/chains`;
-      return await this.dataSource.get(
-        CacheRouter.getChainsCacheDir(limit, offset),
-        url,
-        {
-          params: {
-            limit,
-            offset,
-          },
-        },
-      );
+      const params = { limit, offset };
+      const cacheDir = CacheRouter.getChainsCacheDir(limit, offset);
+      return await this.dataSource.get(cacheDir, url, { params });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -43,10 +36,8 @@ export class ConfigApi implements IConfigApi {
   async getChain(chainId: string): Promise<Chain> {
     try {
       const url = `${this.baseUri}/api/v1/chains/${chainId}`;
-      return await this.dataSource.get(
-        CacheRouter.getChainCacheDir(chainId),
-        url,
-      );
+      const cacheDir = CacheRouter.getChainCacheDir(chainId);
+      return await this.dataSource.get(cacheDir, url);
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -58,11 +49,10 @@ export class ConfigApi implements IConfigApi {
     url?: string,
   ): Promise<SafeApp[]> {
     try {
-      return await this.dataSource.get(
-        CacheRouter.getSafeAppsCacheDir(chainId, clientUrl, url),
-        `${this.baseUri}/api/v1/safe-apps/`,
-        { params: { chainId, clientUrl, url } },
-      );
+      const providerUrl = `${this.baseUri}/api/v1/safe-apps/`;
+      const params = { chainId, clientUrl, url };
+      const cacheDir = CacheRouter.getSafeAppsCacheDir(chainId, clientUrl, url);
+      return await this.dataSource.get(cacheDir, providerUrl, { params });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -9,6 +9,7 @@ import { safeBuilder } from '../../domain/safe/entities/__tests__/safe.builder';
 import { backboneBuilder } from '../../domain/backbone/entities/__tests__/backbone.builder';
 import { balanceBuilder } from '../../domain/balances/entities/__tests__/balance.builder';
 import { CacheDir } from '../cache/entities/cache-dir.entity';
+import { CacheRouter } from '../cache/cache.router';
 
 const dataSource = {
   get: jest.fn(),
@@ -104,7 +105,7 @@ describe('TransactionApi', () => {
 
       expect(mockCacheService.delete).toBeCalledTimes(1);
       expect(mockCacheService.delete).toBeCalledWith(
-        `${chainId}_${safeAddress}_balances`,
+        CacheRouter.balanceCacheKey(chainId, safeAddress),
       );
       expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
     });

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -8,6 +8,7 @@ import { AxiosNetworkService } from '../network/axios.network.service';
 import { safeBuilder } from '../../domain/safe/entities/__tests__/safe.builder';
 import { backboneBuilder } from '../../domain/backbone/entities/__tests__/backbone.builder';
 import { balanceBuilder } from '../../domain/balances/entities/__tests__/balance.builder';
+import { CacheDir } from '../cache/entities/cache-dir.entity';
 
 const dataSource = {
   get: jest.fn(),
@@ -118,8 +119,7 @@ describe('TransactionApi', () => {
 
       expect(actual).toBe(safe);
       expect(mockDataSource.get).toBeCalledWith(
-        `${chainId}_${safe.address}_safe`,
-        '',
+        new CacheDir(`${chainId}_${safe.address}_safe`, ''),
         `${baseUrl}/api/v1/safes/${safe.address}`,
       );
       expect(httpErrorFactory.from).toHaveBeenCalledTimes(0);

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -105,7 +105,7 @@ describe('TransactionApi', () => {
 
       expect(mockCacheService.delete).toBeCalledTimes(1);
       expect(mockCacheService.delete).toBeCalledWith(
-        CacheRouter.balanceCacheKey(chainId, safeAddress),
+        CacheRouter.getBalanceCacheDir(chainId, safeAddress),
       );
       expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
     });

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -61,7 +61,7 @@ export class TransactionApi implements ITransactionApi {
 
   async clearLocalBalances(safeAddress: string): Promise<void> {
     const cacheDir = CacheRouter.balanceCacheKey(this.chainId, safeAddress);
-    await this.cacheService.delete(cacheDir.key);
+    await this.cacheService.delete(cacheDir);
   }
 
   async getDataDecoded(data: string, to: string): Promise<DataDecoded> {

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -60,7 +60,7 @@ export class TransactionApi implements ITransactionApi {
   }
 
   async clearLocalBalances(safeAddress: string): Promise<void> {
-    const cacheDir = CacheRouter.balanceCacheKey(this.chainId, safeAddress);
+    const cacheDir = CacheRouter.getBalanceCacheDir(this.chainId, safeAddress);
     await this.cacheService.delete(cacheDir);
   }
 

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -1,40 +1,29 @@
-import { CacheFirstDataSource } from '../cache/cache.first.data.source';
-import { ITransactionApi } from '../../domain/interfaces/transaction-api.interface';
-import { Balance } from '../../domain/balances/entities/balance.entity';
 import { Backbone } from '../../domain/backbone/entities/backbone.entity';
-import { ICacheService } from '../cache/cache.service.interface';
-import { HttpErrorFactory } from '../errors/http-error-factory';
-import { Collectible } from '../../domain/collectibles/entities/collectible.entity';
-import { Page } from '../../domain/entities/page.entity';
+import { Balance } from '../../domain/balances/entities/balance.entity';
 import { MasterCopy } from '../../domain/chains/entities/master-copies.entity';
-import { Safe } from '../../domain/safe/entities/safe.entity';
-import { SafeList } from '../../domain/safe/entities/safe-list.entity';
+import { Collectible } from '../../domain/collectibles/entities/collectible.entity';
 import { Contract } from '../../domain/contracts/entities/contract.entity';
 import { DataDecoded } from '../../domain/data-decoder/entities/data-decoded.entity';
 import { Delegate } from '../../domain/delegate/entities/delegate.entity';
-import { INetworkService } from '../network/network.service.interface';
-import { Transfer } from '../../domain/safe/entities/transfer.entity';
-import { MultisigTransaction } from '../../domain/safe/entities/multisig-transaction.entity';
-import { Transaction } from '../../domain/safe/entities/transaction.entity';
-import { Token } from '../../domain/tokens/entities/token.entity';
-import { ModuleTransaction } from '../../domain/safe/entities/module-transaction.entity';
-import { CreationTransaction } from '../../domain/safe/entities/creation-transaction.entity';
-import { Device } from '../../domain/notifications/entities/device.entity';
-import { GetEstimationDto } from '../../domain/estimations/entities/get-estimation.dto.entity';
+import { Page } from '../../domain/entities/page.entity';
 import { Estimation } from '../../domain/estimations/entities/estimation.entity';
+import { GetEstimationDto } from '../../domain/estimations/entities/get-estimation.dto.entity';
+import { ITransactionApi } from '../../domain/interfaces/transaction-api.interface';
 import { Message } from '../../domain/messages/entities/message.entity';
-
-function balanceCacheKey(chainId: string, safeAddress: string): string {
-  return `${chainId}_${safeAddress}_balances`;
-}
-
-function safeCacheKey(chainId: string, safeAddress: string): string {
-  return `${chainId}_${safeAddress}_safe`;
-}
-
-function contractCacheKey(chainId: string, contractAddress: string): string {
-  return `${chainId}_${contractAddress}_contract`;
-}
+import { Device } from '../../domain/notifications/entities/device.entity';
+import { CreationTransaction } from '../../domain/safe/entities/creation-transaction.entity';
+import { ModuleTransaction } from '../../domain/safe/entities/module-transaction.entity';
+import { MultisigTransaction } from '../../domain/safe/entities/multisig-transaction.entity';
+import { SafeList } from '../../domain/safe/entities/safe-list.entity';
+import { Safe } from '../../domain/safe/entities/safe.entity';
+import { Transaction } from '../../domain/safe/entities/transaction.entity';
+import { Transfer } from '../../domain/safe/entities/transfer.entity';
+import { Token } from '../../domain/tokens/entities/token.entity';
+import { CacheFirstDataSource } from '../cache/cache.first.data.source';
+import { CacheRouter } from '../cache/cache.router';
+import { ICacheService } from '../cache/cache.service.interface';
+import { HttpErrorFactory } from '../errors/http-error-factory';
+import { INetworkService } from '../network/network.service.interface';
 
 export class TransactionApi implements ITransactionApi {
   constructor(
@@ -52,10 +41,14 @@ export class TransactionApi implements ITransactionApi {
     excludeSpam?: boolean,
   ): Promise<Balance[]> {
     try {
-      const cacheKey = balanceCacheKey(this.chainId, safeAddress);
-      const cacheKeyField = `${trusted}_${excludeSpam}`;
+      const cacheDir = CacheRouter.getBalanceCacheDir(
+        this.chainId,
+        safeAddress,
+        trusted,
+        excludeSpam,
+      );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/balances/usd/`;
-      return await this.dataSource.get(cacheKey, cacheKeyField, url, {
+      return await this.dataSource.get(cacheDir, url, {
         params: {
           trusted: trusted,
           exclude_spam: excludeSpam,
@@ -67,8 +60,8 @@ export class TransactionApi implements ITransactionApi {
   }
 
   async clearLocalBalances(safeAddress: string): Promise<void> {
-    const cacheKey = balanceCacheKey(this.chainId, safeAddress);
-    await this.cacheService.delete(cacheKey);
+    const cacheDir = CacheRouter.balanceCacheKey(this.chainId, safeAddress);
+    await this.cacheService.delete(cacheDir.key);
   }
 
   async getDataDecoded(data: string, to: string): Promise<DataDecoded> {
@@ -92,10 +85,16 @@ export class TransactionApi implements ITransactionApi {
     excludeSpam?: boolean,
   ): Promise<Page<Collectible>> {
     try {
-      const cacheKey = `${this.chainId}_${safeAddress}_collectibles`;
-      const cacheKeyField = `${limit}_${offset}_${trusted}_${excludeSpam}`;
+      const cacheDir = CacheRouter.getCollectiblesCacheDir(
+        this.chainId,
+        safeAddress,
+        limit,
+        offset,
+        trusted,
+        excludeSpam,
+      );
       const url = `${this.baseUrl}/api/v2/safes/${safeAddress}/collectibles/`;
-      return await this.dataSource.get(cacheKey, cacheKeyField, url, {
+      return await this.dataSource.get(cacheDir, url, {
         params: {
           limit: limit,
           offset: offset,
@@ -110,10 +109,9 @@ export class TransactionApi implements ITransactionApi {
 
   async getBackbone(): Promise<Backbone> {
     try {
-      const cacheKey = `${this.chainId}_backbone`;
-      const field = '';
+      const cacheDir = CacheRouter.getBackboneCacheDir(this.chainId);
       const url = `${this.baseUrl}/api/v1/about`;
-      return await this.dataSource.get(cacheKey, field, url);
+      return await this.dataSource.get(cacheDir, url);
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -121,10 +119,9 @@ export class TransactionApi implements ITransactionApi {
 
   async getMasterCopies(): Promise<MasterCopy[]> {
     try {
-      const cacheKey = `${this.chainId}_master-copies`;
-      const field = '';
+      const cacheDir = CacheRouter.getMasterCopiesCacheDir(this.chainId);
       const url = `${this.baseUrl}/api/v1/about/master-copies/`;
-      return await this.dataSource.get(cacheKey, field, url);
+      return await this.dataSource.get(cacheDir, url);
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -132,9 +129,9 @@ export class TransactionApi implements ITransactionApi {
 
   async getSafe(safeAddress: string): Promise<Safe> {
     try {
-      const cacheKey = safeCacheKey(this.chainId, safeAddress);
+      const cacheDir = CacheRouter.getSafeCacheDir(this.chainId, safeAddress);
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}`;
-      return await this.dataSource.get(cacheKey, '', url);
+      return await this.dataSource.get(cacheDir, url);
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -142,9 +139,12 @@ export class TransactionApi implements ITransactionApi {
 
   async getContract(contractAddress: string): Promise<Contract> {
     try {
-      const cacheKey = contractCacheKey(this.chainId, contractAddress);
+      const cacheDir = CacheRouter.getContractCacheDir(
+        this.chainId,
+        contractAddress,
+      );
       const url = `${this.baseUrl}/api/v1/contracts/${contractAddress}`;
-      return await this.dataSource.get(cacheKey, '', url);
+      return await this.dataSource.get(cacheDir, url);
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -159,10 +159,17 @@ export class TransactionApi implements ITransactionApi {
     offset?: number,
   ): Promise<Page<Delegate>> {
     try {
-      const cacheKey = `${this.chainId}_delegates`;
-      const cacheKeyField = `${safeAddress}_${delegate}_${delegator}_${label}_${limit}_${offset}`;
+      const cacheDir = CacheRouter.getDelegatesCacheDir(
+        this.chainId,
+        safeAddress,
+        delegate,
+        delegator,
+        label,
+        limit,
+        offset,
+      );
       const url = `${this.baseUrl}/api/v1/delegates/`;
-      return await this.dataSource.get(cacheKey, cacheKeyField, url, {
+      return await this.dataSource.get(cacheDir, url, {
         params: {
           safe: safeAddress,
           delegate: delegate,
@@ -240,10 +247,16 @@ export class TransactionApi implements ITransactionApi {
     offset?: number,
   ): Promise<Page<Transfer>> {
     try {
-      const cacheKey = `${this.chainId}_${safeAddress}_transfers`;
-      const cacheKeyField = `${onlyErc20}_${onlyErc721}_${limit}_${offset}`;
+      const cacheDir = CacheRouter.getTransfersCacheDir(
+        this.chainId,
+        safeAddress,
+        onlyErc20,
+        onlyErc721,
+        limit,
+        offset,
+      );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/transfers/`;
-      return await this.dataSource.get(cacheKey, cacheKeyField, url, {
+      return await this.dataSource.get(cacheDir, url, {
         params: {
           erc20: onlyErc20,
           erc721: onlyErc721,
@@ -267,10 +280,19 @@ export class TransactionApi implements ITransactionApi {
     offset?: number,
   ): Promise<Page<Transfer>> {
     try {
-      const cacheKey = `${this.chainId}_${safeAddress}_incoming_transfers`;
-      const cacheKeyField = `${executionDateGte}_${executionDateLte}_${to}_${value}_${tokenAddress}_${limit}_${offset}`;
+      const cacheDir = CacheRouter.getIncomingTransfersCacheDir(
+        this.chainId,
+        safeAddress,
+        executionDateGte,
+        executionDateLte,
+        to,
+        value,
+        tokenAddress,
+        limit,
+        offset,
+      );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/incoming-transfers/`;
-      return await this.dataSource.get(cacheKey, cacheKeyField, url, {
+      return await this.dataSource.get(cacheDir, url, {
         params: {
           execution_date__gte: executionDateGte,
           execution_date__lte: executionDateLte,
@@ -294,10 +316,16 @@ export class TransactionApi implements ITransactionApi {
     offset?: number,
   ): Promise<Page<ModuleTransaction>> {
     try {
-      const cacheKey = `${this.chainId}_${safeAddress}_module_transactions`;
-      const cacheKeyField = `${to}_${module}_${limit}_${offset}`;
+      const cacheDir = CacheRouter.getModuleTransactionsCacheDir(
+        this.chainId,
+        safeAddress,
+        to,
+        module,
+        limit,
+        offset,
+      );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/module-transactions/`;
-      return await this.dataSource.get(cacheKey, cacheKeyField, url, {
+      return await this.dataSource.get(cacheDir, url, {
         params: {
           to,
           module,
@@ -324,10 +352,22 @@ export class TransactionApi implements ITransactionApi {
     offset?: number,
   ): Promise<Page<MultisigTransaction>> {
     try {
-      const cacheKey = `${this.chainId}_${safeAddress}_multisig_transactions`;
-      const cacheKeyField = `${ordering}_${executed}_${trusted}_${executionDateGte}_${executionDateLte}_${to}_${value}_${nonce}_${limit}_${offset}`;
+      const cacheDir = CacheRouter.getMultisigTransactionsCacheDir(
+        this.chainId,
+        safeAddress,
+        ordering,
+        executed,
+        trusted,
+        executionDateGte,
+        executionDateLte,
+        to,
+        value,
+        nonce,
+        limit,
+        offset,
+      );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/multisig-transactions/`;
-      return await this.dataSource.get(cacheKey, cacheKeyField, url, {
+      return await this.dataSource.get(cacheDir, url, {
         params: {
           safe: safeAddress,
           ordering,
@@ -351,9 +391,12 @@ export class TransactionApi implements ITransactionApi {
     safeTransactionHash: string,
   ): Promise<MultisigTransaction> {
     try {
-      const cacheKey = `${this.chainId}_${safeTransactionHash}_multisig_transaction`;
+      const cacheDir = CacheRouter.getMultisigTransactionsCacheDir(
+        this.chainId,
+        safeTransactionHash,
+      );
       const url = `${this.baseUrl}/api/v1/multisig-transactions/${safeTransactionHash}/`;
-      return await this.dataSource.get(cacheKey, '', url);
+      return await this.dataSource.get(cacheDir, url);
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -363,9 +406,12 @@ export class TransactionApi implements ITransactionApi {
     safeAddress: string,
   ): Promise<CreationTransaction> {
     try {
-      const cacheKey = `${this.chainId}_${safeAddress}_creation_transaction`;
+      const cacheDir = CacheRouter.getCreationTransactionCacheDir(
+        this.chainId,
+        safeAddress,
+      );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/creation/`;
-      return await this.dataSource.get(cacheKey, '', url);
+      return await this.dataSource.get(cacheDir, url);
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -380,10 +426,17 @@ export class TransactionApi implements ITransactionApi {
     offset?: number,
   ): Promise<Page<Transaction>> {
     try {
-      const cacheKey = `${this.chainId}_${safeAddress}_all_transactions`;
-      const cacheKeyField = `${ordering}_${executed}_${queued}_${limit}_${offset}`;
+      const cacheDir = CacheRouter.getAllTransactionsCacheDir(
+        this.chainId,
+        safeAddress,
+        ordering,
+        executed,
+        queued,
+        limit,
+        offset,
+      );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/all-transactions/`;
-      return await this.dataSource.get(cacheKey, cacheKeyField, url, {
+      return await this.dataSource.get(cacheDir, url, {
         params: {
           safe: safeAddress,
           ordering: ordering,
@@ -400,9 +453,9 @@ export class TransactionApi implements ITransactionApi {
 
   async getToken(address: string): Promise<Token> {
     try {
-      const cacheKey = `${this.chainId}_${address}_token`;
+      const cacheDir = CacheRouter.getTokenCacheDir(this.chainId, address);
       const url = `${this.baseUrl}/api/v1/tokens/${address}`;
-      return await this.dataSource.get(cacheKey, '', url);
+      return await this.dataSource.get(cacheDir, url);
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -410,10 +463,13 @@ export class TransactionApi implements ITransactionApi {
 
   async getTokens(limit?: number, offset?: number): Promise<Page<Token>> {
     try {
-      const cacheKey = `${this.chainId}_tokens`;
-      const cacheKeyField = `${limit}_${offset}`;
+      const cacheDir = CacheRouter.getTokensCacheDir(
+        this.chainId,
+        limit,
+        offset,
+      );
       const url = `${this.baseUrl}/api/v1/tokens/`;
-      return await this.dataSource.get(cacheKey, cacheKeyField, url, {
+      return await this.dataSource.get(cacheDir, url, {
         params: {
           limit: limit,
           offset: offset,
@@ -426,9 +482,12 @@ export class TransactionApi implements ITransactionApi {
 
   async getSafesByOwner(ownerAddress: string): Promise<SafeList> {
     try {
-      const cacheKey = `${this.chainId}_${ownerAddress}_owner_safes`;
+      const cacheDir = CacheRouter.getSafesByOwnerCacheDir(
+        this.chainId,
+        ownerAddress,
+      );
       const url = `${this.baseUrl}/api/v1/owners/${ownerAddress}/safes/`;
-      return await this.dataSource.get(cacheKey, '', url);
+      return await this.dataSource.get(cacheDir, url);
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -489,9 +548,12 @@ export class TransactionApi implements ITransactionApi {
 
   async getMessageByHash(messageHash: string): Promise<Message> {
     try {
-      const cacheKey = `${this.chainId}_${messageHash}_message`;
       const url = `${this.baseUrl}/api/v1/messages/${messageHash}`;
-      return await this.dataSource.get(cacheKey, '', url);
+      const cacheDir = CacheRouter.getMessageByHashCacheDir(
+        this.chainId,
+        messageHash,
+      );
+      return await this.dataSource.get(cacheDir, url);
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -503,10 +565,14 @@ export class TransactionApi implements ITransactionApi {
     offset?: number | undefined,
   ): Promise<Page<Message>> {
     try {
-      const cacheKey = `${this.chainId}_${safeAddress}_messages`;
-      const cacheKeyField = `${limit}_${offset}`;
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/messages/`;
-      return await this.dataSource.get(cacheKey, cacheKeyField, url, {
+      const cacheDir = CacheRouter.getMessagesBySafeCacheDir(
+        this.chainId,
+        safeAddress,
+        limit,
+        offset,
+      );
+      return await this.dataSource.get(cacheDir, url, {
         params: {
           limit: limit,
           offset: offset,

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -1,23 +1,24 @@
+import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
 import {
   fakeConfigurationService,
   TestConfigurationModule,
 } from '../../config/__tests__/test.configuration.module';
+import { CacheDir } from '../../datasources/cache/entities/cache-dir.entity';
 import {
   fakeCacheService,
   TestCacheModule,
 } from '../../datasources/cache/__tests__/test.cache.module';
-import { Test, TestingModule } from '@nestjs/testing';
-import { DomainModule } from '../../domain.module';
 import {
   mockNetworkService,
   TestNetworkModule,
 } from '../../datasources/network/__tests__/test.network.module';
-import { CacheHooksModule } from './cache-hooks.module';
-import * as request from 'supertest';
-import { faker } from '@faker-js/faker';
+import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { ValidationModule } from '../../validation/validation.module';
+import { CacheHooksModule } from './cache-hooks.module';
 
 describe('Post Hook Events (Unit)', () => {
   let app: INestApplication;
@@ -162,9 +163,11 @@ describe('Post Hook Events (Unit)', () => {
     it('clears local balances', async () => {
       const safeAddress = faker.finance.ethereumAddress();
       const chainId = '1';
-      const cacheKey = `${chainId}_${safeAddress}_balances`;
-      const cacheField = faker.random.alpha();
-      await fakeCacheService.set(cacheKey, cacheField, faker.random.alpha());
+      const cacheDir = new CacheDir(
+        `${chainId}_${safeAddress}_balances`,
+        faker.random.alpha(),
+      );
+      await fakeCacheService.set(cacheDir, faker.random.alpha());
       const data = {
         address: safeAddress,
         chainId: chainId,
@@ -188,9 +191,7 @@ describe('Post Hook Events (Unit)', () => {
         .send(data)
         .expect(200);
 
-      await expect(
-        fakeCacheService.get(cacheKey, cacheField),
-      ).resolves.toBeUndefined();
+      await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
**(Please review https://github.com/5afe/safe-client-gateway-nest/pull/284 before)**

This PR is preliminary work for #255. The `/v2/flush` endpoint needs to invalidate cache keys on demand, but the calculation of a concrete key/field is currently bonded to the client API functions (`transaction-api.service`, `config-api.service` classes), so this PR:

- Extracts the cache key/field calculation from the API client class.
- Centralises this calculation in a utility class with static functions (since state is not needed and the calculation is deterministic): `CacheRouter`.
- Adds the `CacheDir` interface which encapsulates the key/field for a given cache address.