### PR TITLE
Unify cache keys

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -11,7 +11,7 @@ export class CacheRouter {
   private static readonly CREATION_TRANSACTION_KEY = 'creation_transaction';
   private static readonly DELEGATES_KEY = 'delegates';
   private static readonly INCOMING_TRANSFERS_KEY = 'incoming_transfers';
-  private static readonly MASTER_COPIES_KEY = 'master-copies';
+  private static readonly MASTER_COPIES_KEY = 'master_copies';
   private static readonly MESSAGE_KEY = 'message';
   private static readonly MESSAGES_KEY = 'messages';
   private static readonly MODULE_TRANSACTIONS_KEY = 'module_transactions';


### PR DESCRIPTION
This PR contains just a simple change in a cache name, but the intention is to discuss the keys we want to use for the different features of the service.

I have some doubts about whether `all_transactions` and `owner_safes` are descriptive names, what do you think @fmrsabino? 