### PR TITLE
Fix start of day calculation on TransactionsHistoryMapper

### DIFF
--- a/src/routes/transactions/mappers/transactions-history.mapper.ts
+++ b/src/routes/transactions/mappers/transactions-history.mapper.ts
@@ -151,9 +151,9 @@ export class TransactionsHistoryMapper {
     }
     return new Date(
       Date.UTC(
-        timestamp.getFullYear(),
-        timestamp.getMonth(),
-        timestamp.getDate(),
+        timestamp.getUTCFullYear(),
+        timestamp.getUTCMonth(),
+        timestamp.getUTCDate(),
       ),
     );
   }

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -177,7 +177,7 @@ describe('Transactions History Controller (Unit)', () => {
         .with('dataDecoded', null)
         .with(
           'executionDate',
-          faker.date.between('2022-12-06T00:00:00Z', '2022-12-06T23:59:59Z'),
+          faker.date.between('2022-12-06T23:00:00Z', '2022-12-06T23:59:59Z'),
         )
         .build(),
     );
@@ -187,7 +187,7 @@ describe('Transactions History Controller (Unit)', () => {
         .with('origin', null)
         .with(
           'executionDate',
-          faker.date.between('2022-12-25T00:00:00Z', '2022-12-25T23:59:59Z'),
+          faker.date.between('2022-12-25T00:00:00Z', '2022-12-25T00:59:59Z'),
         )
         .build(),
     );


### PR DESCRIPTION
**Motivation**
This change is motivated because of some unpredictable testing behavior (flaky tests) in `transactions-history-controller.spec.ts`. The tests failed because for non-UTC time zones, dates at the edge of the day (near the day start or near the day end) get shifted because of the usage of non-UTC date functions.

For example, in `UTC +2 / Central European Summer Time (CEST)`, this happens:
```javascript
new Date('2022-12-06T23:00:00Z').getDate()
7
```

So this was causing tests to fail only when `faker.date.between('2022-12-06T00:00:00Z', '2022-12-06T23:59:59Z')` got evaluated to `'2022-12-06T23:00:00Z'` or later, causing tests to fail sometimes.