### PR TITLE
Fix random e2e test error caused by chain ids duplication

### DIFF
--- a/src/domain/chains/entities/__tests__/chain.builder.ts
+++ b/src/domain/chains/entities/__tests__/chain.builder.ts
@@ -10,7 +10,7 @@ import { rpcUriBuilder } from './rpc-uri.builder';
 
 export function chainBuilder(): IBuilder<Chain> {
   return Builder.new<Chain>()
-    .with('chainId', faker.random.numeric())
+    .with('chainId', faker.random.numeric(6))
     .with('chainName', faker.company.name())
     .with('description', faker.random.words())
     .with('l2', faker.datatype.boolean())

--- a/src/domain/chains/entities/__tests__/chain.builder.ts
+++ b/src/domain/chains/entities/__tests__/chain.builder.ts
@@ -10,7 +10,7 @@ import { rpcUriBuilder } from './rpc-uri.builder';
 
 export function chainBuilder(): IBuilder<Chain> {
   return Builder.new<Chain>()
-    .with('chainId', faker.random.numeric(6))
+    .with('chainId', faker.random.numeric())
     .with('chainName', faker.company.name())
     .with('description', faker.random.words())
     .with('l2', faker.datatype.boolean())

--- a/src/routes/flush/flush.controller.spec.ts
+++ b/src/routes/flush/flush.controller.spec.ts
@@ -92,7 +92,10 @@ describe('Flush Controller (Unit)', () => {
     });
 
     it('should invalidate chains', async () => {
-      const chains = [chainBuilder().build(), chainBuilder().build()];
+      const chains = [
+        chainBuilder().with('chainId', '1').build(),
+        chainBuilder().with('chainId', '2').build(),
+      ];
       mockNetworkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigApiUrl}/api/v1/chains`:


### PR DESCRIPTION
**Motivation**
We were getting random test errors (flaky tests) due to the cached `Chains` being different from the expected ones. This was caused because `faker.random.numeric` only produces a _one-digit string_ by default, so sometimes sequential calls to `chainBuilder()` produce `Chains` the same `chainId`, and the cache direction gets repeated. So only one `Chain` was being cached ( since the same cache identifier was produced twice).

To avoid this situation, ~~the simplest fix is increasing the entropy and making `faker.random.numeric` to produce more digits. Collisions are very rare that way, but we could also think about producing an uuid here, even if this would make our chainBuilder differ from the production behavior, where `chainIds` are strings containing integers~~ I've just manually set the `chainIds` of the failing test instead of relying on a random value.