### PR TITLE
Add CreationTransactionInfo to Transaction Swagger 

### DIFF
--- a/src/routes/transactions/entities/creation-transaction-info.entity.ts
+++ b/src/routes/transactions/entities/creation-transaction-info.entity.ts
@@ -7,9 +7,9 @@ export class CreationTransactionInfo extends TransactionInfo {
   creator: AddressInfo;
   @ApiProperty()
   transactionHash: string;
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ type: AddressInfo, nullable: true })
   implementation: AddressInfo | null;
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ type: AddressInfo, nullable: true })
   factory: AddressInfo | null;
 
   constructor(

--- a/src/routes/transactions/entities/transaction.entity.ts
+++ b/src/routes/transactions/entities/transaction.entity.ts
@@ -4,6 +4,7 @@ import {
   ApiPropertyOptional,
   getSchemaPath,
 } from '@nestjs/swagger';
+import { CreationTransactionInfo } from './creation-transaction-info.entity';
 import { CustomTransactionInfo } from './custom-transaction.entity';
 import { ExecutionInfo } from './execution-info.entity';
 import { ModuleExecutionInfo } from './module-execution-info.entity';
@@ -14,6 +15,7 @@ import { TransactionInfo } from './transaction-info.entity';
 import { TransferTransactionInfo } from './transfer-transaction-info.entity';
 
 @ApiExtraModels(
+  CreationTransactionInfo,
   CustomTransactionInfo,
   SettingsChangeTransaction,
   TransferTransactionInfo,
@@ -29,6 +31,7 @@ export class Transaction {
   txStatus: string;
   @ApiProperty({
     oneOf: [
+      { $ref: getSchemaPath(CreationTransactionInfo) },
       { $ref: getSchemaPath(CustomTransactionInfo) },
       { $ref: getSchemaPath(SettingsChangeTransaction) },
       { $ref: getSchemaPath(TransferTransactionInfo) },


### PR DESCRIPTION
More context in: https://github.com/5afe/safe-client-gateway-nest/pull/291#discussion_r1168840520

This PR:
- Adds the missing type `CreationTransactionInfo` to the `txInfo` possible values on the Swagger model for `Transaction`.
- Fixes OpenAPI specification for optional fields in `CreationTransactionInfo`.