### PR TITLE
Avoid mocks reuse on test cases

### DIFF
--- a/src/routes/transactions/mappers/common/custom-transaction.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/custom-transaction.mapper.spec.ts
@@ -15,11 +15,16 @@ const addressInfoHelper = jest.mocked({
 } as unknown as AddressInfoHelper);
 
 describe('Multisig Custom Transaction mapper (Unit)', () => {
-  const mapper = new CustomTransactionMapper(addressInfoHelper);
+  let mapper: CustomTransactionMapper;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mapper = new CustomTransactionMapper(addressInfoHelper);
+  });
 
   it('should build a CustomTransactionInfo with null actionCount', async () => {
     const toAddress = new AddressInfo(faker.finance.ethereumAddress());
-    addressInfoHelper.getOrDefault.mockResolvedValueOnce(toAddress);
+    addressInfoHelper.getOrDefault.mockResolvedValue(toAddress);
     const value = faker.datatype.number();
     const dataSize = faker.datatype.number();
     const chainId = faker.random.numeric();
@@ -47,7 +52,7 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
 
   it('should build a multiSend CustomTransactionInfo with null actionCount', async () => {
     const toAddress = new AddressInfo(faker.finance.ethereumAddress());
-    addressInfoHelper.getOrDefault.mockResolvedValueOnce(toAddress);
+    addressInfoHelper.getOrDefault.mockResolvedValue(toAddress);
     const method = 'multiSend';
     const value = faker.datatype.number();
     const dataSize = faker.datatype.number();
@@ -76,7 +81,7 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
 
   it('should build a multiSend CustomTransactionInfo with actionCount', async () => {
     const toAddress = new AddressInfo(faker.finance.ethereumAddress());
-    addressInfoHelper.getOrDefault.mockResolvedValueOnce(toAddress);
+    addressInfoHelper.getOrDefault.mockResolvedValue(toAddress);
     const method = 'multiSend';
     const value = faker.datatype.number();
     const dataSize = faker.datatype.number();
@@ -116,7 +121,7 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
 
   it('should build a cancellation CustomTransactionInfo', async () => {
     const toAddress = new AddressInfo(faker.finance.ethereumAddress());
-    addressInfoHelper.getOrDefault.mockResolvedValueOnce(toAddress);
+    addressInfoHelper.getOrDefault.mockResolvedValue(toAddress);
     const method = faker.random.word();
     const value = faker.datatype.number();
     const dataSize = 0;

--- a/src/routes/transactions/mappers/common/settings-change.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/settings-change.mapper.spec.ts
@@ -24,14 +24,18 @@ const addressInfoHelper = jest.mocked({
 } as unknown as AddressInfoHelper);
 
 describe('Multisig Settings Change Transaction mapper (Unit)', () => {
-  const mapper = new SettingsChangeMapper(
-    addressInfoHelper,
-    new DataDecodedParamHelper(),
-  );
+  let mapper: SettingsChangeMapper;
+
+  beforeEach(() => {
+    mapper = new SettingsChangeMapper(
+      addressInfoHelper,
+      new DataDecodedParamHelper(),
+    );
+  });
 
   it('should build a SetFallbackHandler setting', async () => {
     const handlerValue = faker.finance.ethereumAddress();
-    addressInfoHelper.getOrDefault.mockResolvedValueOnce(
+    addressInfoHelper.getOrDefault.mockResolvedValue(
       new AddressInfo(handlerValue),
     );
     const transaction = multisigTransactionBuilder()
@@ -166,7 +170,7 @@ describe('Multisig Settings Change Transaction mapper (Unit)', () => {
 
   it('should build a ChangeMasterCopy setting', async () => {
     const newMasterCopy = faker.finance.ethereumAddress();
-    addressInfoHelper.getOrDefault.mockResolvedValueOnce(
+    addressInfoHelper.getOrDefault.mockResolvedValue(
       new AddressInfo(newMasterCopy),
     );
     const transaction = multisigTransactionBuilder()
@@ -192,7 +196,7 @@ describe('Multisig Settings Change Transaction mapper (Unit)', () => {
 
   it('should build a EnableModule setting', async () => {
     const moduleAddress = faker.finance.ethereumAddress();
-    addressInfoHelper.getOrDefault.mockResolvedValueOnce(
+    addressInfoHelper.getOrDefault.mockResolvedValue(
       new AddressInfo(moduleAddress),
     );
     const transaction = multisigTransactionBuilder()
@@ -220,7 +224,7 @@ describe('Multisig Settings Change Transaction mapper (Unit)', () => {
 
   it('should build a DisableModule setting', async () => {
     const moduleAddress = faker.finance.ethereumAddress();
-    addressInfoHelper.getOrDefault.mockResolvedValueOnce(
+    addressInfoHelper.getOrDefault.mockResolvedValue(
       new AddressInfo(moduleAddress),
     );
     const transaction = multisigTransactionBuilder()
@@ -273,7 +277,7 @@ describe('Multisig Settings Change Transaction mapper (Unit)', () => {
   it('should build a SetGuard setting', async () => {
     const guardAddress = faker.finance.ethereumAddress();
     const guardAddressInfo = new AddressInfo(guardAddress);
-    addressInfoHelper.getOrDefault.mockResolvedValueOnce(guardAddressInfo);
+    addressInfoHelper.getOrDefault.mockResolvedValue(guardAddressInfo);
     const transaction = multisigTransactionBuilder()
       .with(
         'dataDecoded',

--- a/src/routes/transactions/mappers/common/transaction-data.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/transaction-data.mapper.spec.ts
@@ -28,7 +28,7 @@ describe('Transaction Data Mapper (Unit)', () => {
   let mapper: TransactionDataMapper;
 
   beforeEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
     mapper = new TransactionDataMapper(
       addressInfoHelper,
       contractsRepository,

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.spec.ts
@@ -8,7 +8,11 @@ import { TransactionStatus } from '../../entities/transaction-status.entity';
 import { MultisigTransactionExecutionInfoMapper } from './multisig-transaction-execution-info.mapper';
 
 describe('Multisig Transaction execution info mapper (Unit)', () => {
-  const mapper = new MultisigTransactionExecutionInfoMapper();
+  let mapper: MultisigTransactionExecutionInfoMapper;
+
+  beforeEach(() => {
+    mapper = new MultisigTransactionExecutionInfoMapper();
+  });
 
   it('should return a MultiSigExecutionInfo with no missing signers', () => {
     const safe = safeBuilder().build();

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-status.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-status.mapper.spec.ts
@@ -5,7 +5,11 @@ import { confirmationBuilder } from '../../../../domain/safe/entities/__tests__/
 import { safeBuilder } from '../../../../domain/safe/entities/__tests__/safe.builder';
 
 describe('Multisig Transaction status mapper (Unit)', () => {
-  const mapper = new MultisigTransactionStatusMapper();
+  let mapper: MultisigTransactionStatusMapper;
+
+  beforeEach(() => {
+    mapper = new MultisigTransactionStatusMapper();
+  });
 
   it('should return a SUCCESS status', () => {
     const transaction = multisigTransactionBuilder()

--- a/src/routes/transactions/mappers/transfers/transfer-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-info.mapper.spec.ts
@@ -25,10 +25,11 @@ const tokenRepository = jest.mocked({
 } as unknown as TokenRepository);
 
 describe('Transfer Info mapper (Unit)', () => {
-  const mapper = new TransferInfoMapper(tokenRepository, addressInfoHelper);
+  let mapper: TransferInfoMapper;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mapper = new TransferInfoMapper(tokenRepository, addressInfoHelper);
   });
 
   it('should build an ERC20 TransferTransactionInfo', async () => {


### PR DESCRIPTION
More context on https://github.com/5afe/safe-client-gateway-nest/pull/291#discussion_r1169745379

This PR:
- Moves the mappers' initialization to `beforeEach` functions on each test suite, so the potential risk of sharing state between tests gets removed.
- Changes the related usages of `mockResolvedValueOnce` by `mockResolvedValue` so we assure we're not depending on the execution order and we're always clearing the state between tests.
- Changes one `resetAllMocks` call by `clearAllMocks`, since it's not needed to reset the mocked functions implementations (the mocked instance itself gets recreated).