### PR TITLE
Change default SAFE_CONFIG_BASE_URI in documentation

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,8 +5,8 @@
 #EXCHANGE_API_KEY=
 
 # The base url for the Safe Config Service
-# Default if none is set: https://safe-config.gnosis.io
-#SAFE_CONFIG_BASE_URI=https://safe-config.gnosis.io
+# Default if none is set: https://safe-config.safe.global
+#SAFE_CONFIG_BASE_URI=https://safe-config.safe.global
 
 
 # Redis


### PR DESCRIPTION
This PR:

- Modifies the `.env.sample` file to adapt the default Config Service URL to the new Safe domain.