### PR TITLE
Replace the usage of non-UTC date functions

### DIFF
--- a/src/routes/messages/messages.controller.spec.ts
+++ b/src/routes/messages/messages.controller.spec.ts
@@ -479,9 +479,9 @@ describe('Messages controller', () => {
                   type: 'DATE_LABEL',
                   timestamp: new Date(
                     Date.UTC(
-                      message.created.getFullYear(),
-                      message.created.getMonth(),
-                      message.created.getDate(),
+                      message.created.getUTCFullYear(),
+                      message.created.getUTCMonth(),
+                      message.created.getUTCDate(),
                     ),
                   ).getTime(),
                 },
@@ -563,9 +563,9 @@ describe('Messages controller', () => {
                   type: 'DATE_LABEL',
                   timestamp: new Date(
                     Date.UTC(
-                      messageCreationDate.getFullYear(),
-                      messageCreationDate.getMonth(),
-                      messageCreationDate.getDate(),
+                      messageCreationDate.getUTCFullYear(),
+                      messageCreationDate.getUTCMonth(),
+                      messageCreationDate.getUTCDate(),
                     ),
                   ).getTime(),
                 },

--- a/src/routes/messages/messages.service.ts
+++ b/src/routes/messages/messages.service.ts
@@ -92,13 +92,11 @@ export class MessagesService {
     messages: DomainMessage[],
   ): [number, DomainMessage[]][] {
     const groups = groupBy(messages, (m) =>
-      new Date(
-        Date.UTC(
-          m.created.getFullYear(),
-          m.created.getMonth(),
-          m.created.getDate(),
-        ),
-      ).getTime(),
+      Date.UTC(
+        m.created.getUTCFullYear(),
+        m.created.getUTCMonth(),
+        m.created.getUTCDate(),
+      ),
     );
 
     return sortBy(Object.entries(groups), ([timestamp]) => timestamp).map(


### PR DESCRIPTION
Similar to https://github.com/5afe/safe-client-gateway-nest/pull/296

**Motivation**
This PR changes the usage of non-UTC date functions which were causing date shifts on non-UTC timezones.